### PR TITLE
Adding `.pbp` rom entries for Sony - PlayStation games

### DIFF
--- a/Nintendo - Nintendo 64 update tool.py
+++ b/Nintendo - Nintendo 64 update tool.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Module Docstring
+"""
+
+__author__ = "Stephen Ancona"
+__version__ = "0.1.0"
+__license__ = "MIT"
+
+
+import xml.etree.ElementTree as ET
+
+header = '<?xml version="1.0"?>\n<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">\n'
+
+
+def main():
+    """ Main entry point of the app """
+    try:
+        tree = ET.parse("Nintendo - Nintendo 64.dat")
+    except:
+        print("Error opening Nintendo - Nintendo 64.dat")
+        exit(1)
+    root = tree.getroot()
+    for child in root:
+        if child.tag == "header":
+            for sub in child:
+                if sub.tag == "version":
+                    sub.text = sub.text + " Ludo Custom"
+                if sub.tag == "author":
+                    sub.text = "Ludo Nintendo 64 Customizer"
+        if child.tag == "game":
+            children = []
+            for tag in child:
+                if tag.tag == "rom":
+                    children.append(tag.attrib["name"])
+            combo = "\t".join(children)
+            if ".n64" not in combo:
+                original_name = children[0]
+                updated_name = original_name.split(".")
+                updated_name.pop()
+                updated_name.append("n64")
+                updated_name = ".".join(updated_name)
+                new_element = ET.Element("rom")
+                new_element.set("name", updated_name)
+                child.insert(1,new_element)
+            if ".z64" not in combo:
+                original_name = children[0]
+                updated_name = original_name.split(".")
+                updated_name.pop()
+                updated_name.append("z64")
+                updated_name = ".".join(updated_name)
+                new_element = ET.Element("rom")
+                new_element.set("name", updated_name)
+                child.insert(1,new_element)
+    ET.indent(tree, "\t")
+    tree.write("Nintendo - Nintendo 64.dat")
+    with open("Nintendo - Nintendo 64.dat") as file_raw:
+        file_dat = file_raw.read()
+    file_dat = header + file_dat
+    with open("Nintendo - Nintendo 64.dat", "w") as file_raw:
+        file_raw.write(file_dat)
+
+
+def main2():
+    """ Main entry point of the app """
+    try:
+        tree = ET.parse("Nintendo - Nintendo 64.dat")
+    except:
+        print("Error opening Nintendo - Nintendo 64.dat")
+        exit(1)
+    root = tree.getroot()
+    for child in root:
+        if child.tag == "header":
+            for sub in child:
+                if sub.tag == "version":
+                    sub.text = sub.text + " Ludo Custom"
+                if sub.tag == "author":
+                    sub.text = "Ludo Nintendo 64 Customizer"
+        if child.tag == "game":
+            if ".n64" not in child[2].attrib["name"]:
+                original_name = child[2].attrib["name"]
+                updated_name = original_name.split(".")
+                updated_name.pop()
+                updated_name.append("n64")
+                updated_name = ".".join(updated_name)
+                new_element = ET.Element("rom")
+                new_element.set("name", updated_name)
+                child.insert(2,new_element)
+    ET.indent(tree, "\t")
+    tree.write("Nintendo - Nintendo 64.dat")
+    with open("Nintendo - Nintendo 64.dat") as file_raw:
+        file_dat = file_raw.read()
+    file_dat = header + file_dat
+    with open("Nintendo - Nintendo 64.dat", "w") as file_raw:
+        file_raw.write(file_dat)
+
+
+if __name__ == "__main__":
+    """ This is executed when run from the command line """
+    main()

--- a/Nintendo - Nintendo 64.dat
+++ b/Nintendo - Nintendo 64.dat
@@ -1,6140 +1,5621 @@
 <?xml version="1.0"?>
 <!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">
-<datafile>
+<datafile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://datomatic.no-intro.org/stuff https://datomatic.no-intro.org/stuff/schema_nointro_datfile_v3.xsd">
 	<header>
-		<name>Nintendo - Nintendo 64 (BigEndian) (Parent-Clone)</name>
-		<description>Nintendo - Nintendo 64 (BigEndian) (Parent-Clone)</description>
-		<version>20210430-080604 Ludo Custom</version>
-		<date>20210430-080604</date>
+		<id>24</id>
+		<name>Nintendo - Nintendo 64 (BigEndian)</name>
+		<description>Nintendo - Nintendo 64 (BigEndian, Non-Merged, Licensed, Machine life span)</description>
+		<version>20240210-044612 Ludo Custom</version>
 		<author>Ludo Nintendo 64 Customizer</author>
-		<url>www.no-intro.org</url>
+		<homepage>No-Intro</homepage>
+		<url>https://www.no-intro.org</url>
+		<clrmamepro forcenodump="required" />
 	</header>
-	<game name="007 - The World Is Not Enough (Europe) (En,Fr,De)">
+	<game name="007 - The World Is Not Enough (Europe) (En,Fr,De)" id="0004">
 		<description>007 - The World Is Not Enough (Europe) (En,Fr,De)</description>
 		<rom name="007 - The World Is Not Enough (Europe) (En,Fr,De).n64" />
-		<release name="007 - The World Is Not Enough (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="007 - The World Is Not Enough (Europe) (En,Fr,De).z64" size="33554432" crc="002c3b2a" md5="34ab1dea3111a233a8b5c5679de22e83" sha1="7fde668850a7e1a8402ab94bb09538a537a7e38b" status="verified" />
+		<rom name="007 - The World Is Not Enough (Europe) (En,Fr,De).z64" size="33554432" crc="002c3b2a" md5="34ab1dea3111a233a8b5c5679de22e83" sha1="7fde668850a7e1a8402ab94bb09538a537a7e38b" sha256="06c65f4f35c869468502f33bf7edd2d4995c9cccada6bff30fe4e8da0209c2ac" status="verified" serial="NO7P" />
 	</game>
-	<game name="007 - The World Is Not Enough (USA)" cloneof="007 - The World Is Not Enough (Europe) (En,Fr,De)">
+	<game name="007 - The World Is Not Enough (USA)" id="0005" cloneofid="0004">
 		<description>007 - The World Is Not Enough (USA)</description>
 		<rom name="007 - The World Is Not Enough (USA).n64" />
-		<release name="007 - The World Is Not Enough (USA)" region="USA" />
-		<rom name="007 - The World Is Not Enough (USA).z64" size="33554432" crc="26360987" md5="9d58996a8aa91263b5cd45c385f45fe4" sha1="d347159808f0374a93cf44cfb6135d8f56279f7b" />
+		<rom name="007 - The World Is Not Enough (USA).z64" size="33554432" crc="26360987" md5="9d58996a8aa91263b5cd45c385f45fe4" sha1="d347159808f0374a93cf44cfb6135d8f56279f7b" sha256="72e3e7b4ff1615bc17336d3d10e18aa9342898db063ace68922a47f5e46c48b1" serial="NO7E" />
 	</game>
-	<game name="007 - The World Is Not Enough (USA) (v21) (Beta)" cloneof="007 - The World Is Not Enough (Europe) (En,Fr,De)">
+	<game name="007 - The World Is Not Enough (USA) (v21) (Beta)" id="0952" cloneofid="0004">
 		<description>007 - The World Is Not Enough (USA) (v21) (Beta)</description>
 		<rom name="007 - The World Is Not Enough (USA) (v21) (Beta).n64" />
-		<rom name="007 - The World Is Not Enough (USA) (v21) (Beta).z64" size="33554432" crc="f0b6bf59" md5="12bd3fafb4e064b6b0c07b7ee156243b" sha1="53c6de60383517f38d27e449d47bced319f8e87a" />
+		<rom name="007 - The World Is Not Enough (USA) (v21) (Beta).z64" size="33554432" crc="f0b6bf59" md5="12bd3fafb4e064b6b0c07b7ee156243b" sha1="53c6de60383517f38d27e449d47bced319f8e87a" sha256="1cd43fbe6ff06d7b326297824d3458c46014517096ba0c08e9edfab75639bbfa" serial="NO7E" />
 	</game>
-	<game name="007 - The World Is Not Enough (USA) (v2) (Beta)" cloneof="007 - The World Is Not Enough (Europe) (En,Fr,De)">
+	<game name="007 - The World Is Not Enough (USA) (v2) (Beta)" id="1043" cloneofid="0004">
 		<description>007 - The World Is Not Enough (USA) (v2) (Beta)</description>
 		<rom name="007 - The World Is Not Enough (USA) (v2) (Beta).n64" />
-		<rom name="007 - The World Is Not Enough (USA) (v2) (Beta).z64" size="16777216" crc="6c180fef" md5="39abe0c383a44c464b408be3e1d6766e" sha1="376042ddedfd4f738786500531d67d5c299577be" />
+		<rom name="007 - The World Is Not Enough (USA) (v2) (Beta).z64" size="16777216" crc="6c180fef" md5="39abe0c383a44c464b408be3e1d6766e" sha1="376042ddedfd4f738786500531d67d5c299577be" sha256="5ab4affb162e2b4172ed0bbc766641b3f17417fd3619d2a048d8720d726edb87" serial="NM4E" />
 	</game>
-	<game name="1080 Snowboarding (Europe) (En,Ja,Fr,De)">
+	<game name="1080 Snowboarding (Europe) (En,Ja,Fr,De)" id="0006">
 		<description>1080 Snowboarding (Europe) (En,Ja,Fr,De)</description>
 		<rom name="1080 Snowboarding (Europe) (En,Ja,Fr,De).n64" />
-		<release name="1080 Snowboarding (Europe) (En,Ja,Fr,De)" region="EUR" />
-		<rom name="1080 Snowboarding (Europe) (En,Ja,Fr,De).z64" size="16777216" crc="75a21679" md5="632c98cf281cda776e66685b278a4fa6" sha1="637d92b08dbfe7c2f9d5e338835b1fce5f4a87d0" status="verified" />
+		<rom name="1080 Snowboarding (Europe) (En,Ja,Fr,De).z64" size="16777216" crc="75a21679" md5="632c98cf281cda776e66685b278a4fa6" sha1="637d92b08dbfe7c2f9d5e338835b1fce5f4a87d0" sha256="a5d47b9b21bc2c234a0e5c8a1f7eb0e893a914e17a0755318b48c5ad15b7d13c" status="verified" serial="NTEP" />
 	</game>
-	<game name="1080 Snowboarding (Japan, USA) (En,Ja)" cloneof="1080 Snowboarding (Europe) (En,Ja,Fr,De)">
+	<game name="1080 Snowboarding (Japan, USA) (En,Ja)" id="0007" cloneofid="0006">
 		<description>1080 Snowboarding (Japan, USA) (En,Ja)</description>
 		<rom name="1080 Snowboarding (Japan, USA) (En,Ja).n64" />
-		<release name="1080 Snowboarding (Japan, USA) (En,Ja)" region="JPN" />
-		<release name="1080 Snowboarding (Japan, USA) (En,Ja)" region="USA" />
-		<rom name="1080 Snowboarding (Japan, USA) (En,Ja).z64" size="16777216" crc="08fe81c7" md5="fa27089c425dbab99f19245c5c997613" sha1="79cd1166c365e5809dec9b62e6d40d6032d5db3a" status="verified" />
+		<rom name="1080 Snowboarding (Japan, USA) (En,Ja).z64" size="16777216" crc="08fe81c7" md5="fa27089c425dbab99f19245c5c997613" sha1="79cd1166c365e5809dec9b62e6d40d6032d5db3a" sha256="5e9d7168e5786ba1bd4b643431ba7100ff3d7a09e558acae15438d426c0f34df" status="verified" serial="NTEA" />
 	</game>
-	<game name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07)">
+	<game name="1080 Snowboarding (USA) (En,Ja) (LodgeNet)" id="1136" cloneofid="0006">
+		<category>Games</category>
+		<rom name="1080 Snowboarding (USA) (En,Ja) (LodgeNet).n64" />
+		<description>1080 Snowboarding (USA) (En,Ja) (LodgeNet)</description>
+		<rom name="1080 Snowboarding (USA) (En,Ja) (LodgeNet).i64" size="64" crc="57c7bfe2" md5="e0c4c9a32a35616014624c3f01c355ba" sha1="23e06350c61dccf3ffaade55873163adabf747f7" />
+		<rom name="1080 Snowboarding (USA) (En,Ja) (LodgeNet).z64" size="16777216" crc="67e010d2" md5="c6061ad1b4446c4db57cdf094da7c534" sha1="7266eef53af8f2c21f3e3288258121f97eddfa7e" />
+	</game>
+	<game name="3D Model RGB Test Program (USA) (Test Program)" id="1071">
+		<description>3D Model RGB Test Program (USA) (Test Program)</description>
+		<rom name="3D Model RGB Test Program (USA) (Test Program).n64" />
+		<rom name="3D Model RGB Test Program (USA) (Test Program).z64" size="16777216" crc="3504dbd5" md5="5901624099bbb8f73c6f9229260d18c7" sha1="c9522561b622d2eb22e57aadbb43da6cf71d458d" sha256="c907f2d572a623e5458fa5b474849e0d66b9e86eefe6a72e302ed7a0506d6eb1" serial="N4WE" />
+	</game>
+	<game name="40 Winks (USA) (Proto) (2000-01-10)" id="1076" cloneofid="0008">
+		<description>40 Winks (USA) (Proto) (2000-01-10)</description>
+		<rom name="40 Winks (USA) (Proto) (2000-01-10).n64" />
+		<rom name="40 Winks (USA) (Proto) (2000-01-10).z64" size="33554432" crc="3a674026" md5="8c3e4fe5f6b2d37c66a71097e8b1c72a" sha1="e671412580800013703be666e56e1b7e512aa55c" sha256="9316ffbe863051a7464e33b9837d6deff11845389a6b275ce6541eded4caa7b0" serial="N4WZ" />
+	</game>
+	<game name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07)" id="0008">
 		<description>40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07)</description>
 		<rom name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07).n64" />
-		<release name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07)" region="EUR" />
-		<rom name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07).z64" size="33554432" crc="7e718143" md5="0a5acfea0c7cf68ae25202040d5ad1eb" sha1="3774e87aa383220060d330314f2c5bbb872f72ce" />
+		<rom name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07).z64" size="33554432" crc="7e718143" md5="0a5acfea0c7cf68ae25202040d5ad1eb" sha1="3774e87aa383220060d330314f2c5bbb872f72ce" sha256="899b866a45dfbebc8152a3122f28aa0ba906fb448dc6b2dc7c7442e7622b5442" status="verified" serial="N4WX" />
 	</game>
-	<game name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)">
+	<game name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)" id="0009">
 		<description>64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)</description>
 		<rom name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan).n64" />
-		<release name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)" region="JPN" />
-		<rom name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan).z64" size="12582912" crc="67a789e5" md5="ea6a92de5a221a00814f7448bf6f1b31" sha1="35f7e37c62ae36eb29aad0d9da0ae83d57f6d8bd" />
+		<rom name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan).z64" size="12582912" crc="67a789e5" md5="ea6a92de5a221a00814f7448bf6f1b31" sha1="35f7e37c62ae36eb29aad0d9da0ae83d57f6d8bd" sha256="77f656a9e71c286d41a1e84c26bcdf126fd7598807c98b62e96491c76da403d6" status="verified" serial="NTWJ" />
 	</game>
-	<game name="64 Hanafuda - Tenshi no Yakusoku (Japan)">
+	<game name="64 Hanafuda - Tenshi no Yakusoku (Japan)" id="0010">
 		<description>64 Hanafuda - Tenshi no Yakusoku (Japan)</description>
 		<rom name="64 Hanafuda - Tenshi no Yakusoku (Japan).n64" />
-		<release name="64 Hanafuda - Tenshi no Yakusoku (Japan)" region="JPN" />
-		<rom name="64 Hanafuda - Tenshi no Yakusoku (Japan).z64" size="8388608" crc="60a680e7" md5="66335f4dc6ab27034398bc26f263b897" sha1="36d1b4ef15cda8139face7e118cb34727c30bf29" />
+		<rom name="64 Hanafuda - Tenshi no Yakusoku (Japan).z64" size="8388608" crc="60a680e7" md5="66335f4dc6ab27034398bc26f263b897" sha1="36d1b4ef15cda8139face7e118cb34727c30bf29" sha256="08e68047b4eed07de7a05bf50c2011b44a8de553440b99b3f4ef2c15ac94d518" serial="NHFJ" />
 	</game>
-	<game name="64 Oozumou (Japan)">
+	<game name="64 Oozumou (Japan)" id="0011">
 		<description>64 Oozumou (Japan)</description>
 		<rom name="64 Oozumou (Japan).n64" />
-		<release name="64 Oozumou (Japan)" region="JPN" />
-		<rom name="64 Oozumou (Japan).z64" size="16777216" crc="742e31fb" md5="2cf9edb51ada9de2ae7ad9fd5acc5580" sha1="e77fe9f2c32870eb7acbcf6a13d26dd022bafe5d" />
+		<rom name="64 Oozumou (Japan).z64" size="16777216" crc="742e31fb" md5="2cf9edb51ada9de2ae7ad9fd5acc5580" sha1="e77fe9f2c32870eb7acbcf6a13d26dd022bafe5d" sha256="661420aa5a7b5c0f86aad0dad813a0c876b99267d9d92fed0f4507e8e2a37240" status="verified" serial="NOSJ" />
 	</game>
-	<game name="64 Oozumou 2 (Japan)">
+	<game name="64 Oozumou 2 (Japan)" id="0012">
 		<description>64 Oozumou 2 (Japan)</description>
 		<rom name="64 Oozumou 2 (Japan).n64" />
-		<release name="64 Oozumou 2 (Japan)" region="JPN" />
-		<rom name="64 Oozumou 2 (Japan).z64" size="16777216" crc="c1bc6fd8" md5="f7c796371e77e0a6fbd02eb866341952" sha1="6d524e0d0dd610dfb0c3bccaa88ef1e7aeceab98" />
+		<rom name="64 Oozumou 2 (Japan).z64" size="16777216" crc="c1bc6fd8" md5="f7c796371e77e0a6fbd02eb866341952" sha1="6d524e0d0dd610dfb0c3bccaa88ef1e7aeceab98" sha256="3ff701b4735c84b17f8d80a996db59801caa766ee7da4d3e5a3b88eb34d99a17" serial="NO2J" />
 	</game>
-	<game name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan)">
+	<game name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan)" id="0013">
 		<description>64 Trump Collection - Alice no Wakuwaku Trump World (Japan)</description>
 		<rom name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan).n64" />
-		<release name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan)" region="JPN" />
-		<rom name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan).z64" size="12582912" crc="dca7f4eb" md5="6b947f654775cf5dacd1e5d53d577da7" sha1="b5cf2c98d60ad8e6fad450681f9cefd63f4e5939" />
+		<rom name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan).z64" size="12582912" crc="dca7f4eb" md5="6b947f654775cf5dacd1e5d53d577da7" sha1="b5cf2c98d60ad8e6fad450681f9cefd63f4e5939" sha256="afc2eedcd4e7cfe6fd0e56259a45d58ed5647f7ce64fad6d2199312ea564de6f" serial="NTCJ" />
 	</game>
-	<game name="Action Replay Pro 64 (Europe) (v3.3) (Unl)">
-		<description>Action Replay Pro 64 (Europe) (v3.3) (Unl)</description>
-		<rom name="Action Replay Pro 64 (Europe) (v3.3) (Unl).z64" />
-		<rom name="Action Replay Pro 64 (Europe) (v3.3) (Unl).n64" />
-		<release name="Action Replay Pro 64 (Europe) (v3.3) (Unl)" region="EUR" />
-		<rom name="Action Replay Pro 64 (Europe) (v3.3) (Unl).bin" size="262144" crc="9fbabfda" md5="67afa5df80a5cfc91fce1dc918ea0a4f" sha1="c3426114f5da1fb7abde15a766d362698ad07166" />
-	</game>
-	<game name="Action Replay Pro 64 (Europe) (v3.0) (Unl)" cloneof="Action Replay Pro 64 (Europe) (v3.3) (Unl)">
-		<description>Action Replay Pro 64 (Europe) (v3.0) (Unl)</description>
-		<rom name="Action Replay Pro 64 (Europe) (v3.0) (Unl).z64" />
-		<rom name="Action Replay Pro 64 (Europe) (v3.0) (Unl).n64" />
-		<rom name="Action Replay Pro 64 (Europe) (v3.0) (Unl).bin" size="262144" crc="c992dfb4" md5="35ba407ea9e4ef7c0ace8b4f58beec41" sha1="d5e4e8c875d6bda0afafb1b2513b16b1cb88dfc1" />
-	</game>
-	<game name="GameShark Pro (USA) (v2.0) (Unl)" cloneof="Action Replay Pro 64 (Europe) (v3.3) (Unl)">
-		<description>GameShark Pro (USA) (v2.0) (Unl)</description>
-		<rom name="GameShark Pro (USA) (v2.0) (Unl).z64" />
-		<rom name="GameShark Pro (USA) (v2.0) (Unl).n64" />
-		<rom name="GameShark Pro (USA) (v2.0) (Unl).bin" size="262144" crc="ef9edf87" md5="437efd7fd7f84f4c0f802d3bf1f8464e" sha1="19148a009ef8e1013ab35c8141781184b141699f" />
-	</game>
-	<game name="GameShark Pro (USA) (v3.3) (Unl)" cloneof="Action Replay Pro 64 (Europe) (v3.3) (Unl)">
-		<description>GameShark Pro (USA) (v3.3) (Unl)</description>
-		<rom name="GameShark Pro (USA) (v3.3) (Unl).z64" />
-		<rom name="GameShark Pro (USA) (v3.3) (Unl).n64" />
-		<release name="GameShark Pro (USA) (v3.3) (Unl)" region="USA" />
-		<rom name="GameShark Pro (USA) (v3.3) (Unl).bin" size="262144" crc="7cc07bbc" md5="9f556d184d945369ddd11b5f815814a8" sha1="3b5046ae8129fd226eb7b02bc2c26cc7548fe6f2" />
-	</game>
-	<game name="AeroFighters Assault (Europe) (En,Fr,De)">
+	<game name="AeroFighters Assault (Europe) (En,Fr,De)" id="0021">
 		<description>AeroFighters Assault (Europe) (En,Fr,De)</description>
 		<rom name="AeroFighters Assault (Europe) (En,Fr,De).n64" />
-		<release name="AeroFighters Assault (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="AeroFighters Assault (Europe) (En,Fr,De).z64" size="12582912" crc="6a2b08da" md5="7558e3da7225712936d3ba3dce210c36" sha1="f1057a278a06dcfbc7eb8b6b7679ab879255f977" />
+		<rom name="AeroFighters Assault (Europe) (En,Fr,De).z64" size="12582912" crc="6a2b08da" md5="7558e3da7225712936d3ba3dce210c36" sha1="f1057a278a06dcfbc7eb8b6b7679ab879255f977" sha256="be4a5d9c32e79334ddbe1611136b6a7c31c1e41a2a1024bbc32eec6632855c4d" status="verified" serial="NSAP" />
 	</game>
-	<game name="AeroFighters Assault (USA)" cloneof="AeroFighters Assault (Europe) (En,Fr,De)">
+	<game name="AeroFighters Assault (USA)" id="0022" cloneofid="0021">
 		<description>AeroFighters Assault (USA)</description>
 		<rom name="AeroFighters Assault (USA).n64" />
-		<release name="AeroFighters Assault (USA)" region="USA" />
-		<rom name="AeroFighters Assault (USA).z64" size="8388608" crc="4370d7e3" md5="79fb6e2452af077c5ef1dde5fc810f04" sha1="6742f67d7d2639072e186d240237be1c662cb25a" />
+		<rom name="AeroFighters Assault (USA).z64" size="8388608" crc="4370d7e3" md5="79fb6e2452af077c5ef1dde5fc810f04" sha1="6742f67d7d2639072e186d240237be1c662cb25a" sha256="5abd27f2be286d6814d64c76a521a80b2b07d03802a71bc03e61e80a16b27931" serial="NERE" />
 	</game>
-	<game name="Sonic Wings Assault (Japan)" cloneof="AeroFighters Assault (Europe) (En,Fr,De)">
-		<description>Sonic Wings Assault (Japan)</description>
-		<rom name="Sonic Wings Assault (Japan).n64" />
-		<release name="Sonic Wings Assault (Japan)" region="JPN" />
-		<rom name="Sonic Wings Assault (Japan).z64" size="8388608" crc="fc73fb79" md5="7d47911b5c3d91a303ef19e764f3c02b" sha1="978936613096d1ebe49fec3ef50e3c870ce165b6" />
-	</game>
-	<game name="AeroGauge (Europe) (En,Fr,De)">
+	<game name="AeroGauge (Europe) (En,Fr,De)" id="0023">
 		<description>AeroGauge (Europe) (En,Fr,De)</description>
 		<rom name="AeroGauge (Europe) (En,Fr,De).n64" />
-		<release name="AeroGauge (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="AeroGauge (Europe) (En,Fr,De).z64" size="8388608" crc="040b0046" md5="05056045447bf1fba8f9878a7f6009f3" sha1="38aadd684ad7662b02bbc29edddade9c9e16a3c0" status="verified" />
+		<rom name="AeroGauge (Europe) (En,Fr,De).z64" size="8388608" crc="040b0046" md5="05056045447bf1fba8f9878a7f6009f3" sha1="38aadd684ad7662b02bbc29edddade9c9e16a3c0" sha256="acae3faba2f0f3e55d6fc0746b392275cbaf51a27e82cf4f88adcc32080d481a" status="verified" serial="NAGP" />
 	</game>
-	<game name="AeroGauge (Japan) (Demo) (Kiosk)" cloneof="AeroGauge (Europe) (En,Fr,De)">
+	<game name="AeroGauge (Japan) (Demo) (Kiosk)" id="0024" cloneofid="0023">
 		<description>AeroGauge (Japan) (Demo) (Kiosk)</description>
 		<rom name="AeroGauge (Japan) (Demo) (Kiosk).n64" />
-		<rom name="AeroGauge (Japan) (Demo) (Kiosk).z64" size="8388608" crc="6ee3b932" md5="e970af3de25bb5ae1154010e26af776f" sha1="0253c33355986ddda18a7a72b81b91ddc1bed978" />
+		<rom name="AeroGauge (Japan) (Demo) (Kiosk).z64" size="8388608" crc="6ee3b932" md5="e970af3de25bb5ae1154010e26af776f" sha1="0253c33355986ddda18a7a72b81b91ddc1bed978" sha256="1ae451dbfbc4b9206356f765f18b7d2db4722e63cd39e656a5405a175d29eba2" serial="NAGJ" />
 	</game>
-	<game name="AeroGauge (Japan) (Rev 1)" cloneof="AeroGauge (Europe) (En,Fr,De)">
+	<game name="AeroGauge (Japan) (Rev 1)" id="0025" cloneofid="0023">
 		<description>AeroGauge (Japan) (Rev 1)</description>
 		<rom name="AeroGauge (Japan) (Rev 1).n64" />
-		<release name="AeroGauge (Japan) (Rev 1)" region="JPN" />
-		<rom name="AeroGauge (Japan) (Rev 1).z64" size="8388608" crc="f322b641" md5="0620c2d134a0430f4afa208ffeda67b8" sha1="f7c2d4b0e77cc02deafe2e5fd95152b7e8bf86cf" />
+		<rom name="AeroGauge (Japan) (Rev 1).z64" size="8388608" crc="f322b641" md5="0620c2d134a0430f4afa208ffeda67b8" sha1="f7c2d4b0e77cc02deafe2e5fd95152b7e8bf86cf" sha256="1abff752862450bbfd3cfbb75b1c217daa57f524bee65f14ae436519a615368a" serial="NAGJ" />
 	</game>
-	<game name="AeroGauge (USA)" cloneof="AeroGauge (Europe) (En,Fr,De)">
+	<game name="AeroGauge (USA)" id="0026" cloneofid="0023">
 		<description>AeroGauge (USA)</description>
 		<rom name="AeroGauge (USA).n64" />
-		<release name="AeroGauge (USA)" region="USA" />
-		<rom name="AeroGauge (USA).z64" size="8388608" crc="198b9e0e" md5="72c7ffcea6c1430616867616f5e9d51a" sha1="77626171c35fb1a4dfebb0927280897f362225ed" />
+		<rom name="AeroGauge (USA).z64" size="8388608" crc="198b9e0e" md5="72c7ffcea6c1430616867616f5e9d51a" sha1="77626171c35fb1a4dfebb0927280897f362225ed" sha256="2cc529109b11b00289d87f693a40591ef260d1dc7c1129113966ba6ddb1be4a5" serial="NAGE" />
 	</game>
-	<game name="AI Shougi 3 (Japan)">
+	<game name="AI Shougi 3 (Japan)" id="0027">
 		<description>AI Shougi 3 (Japan)</description>
 		<rom name="AI Shougi 3 (Japan).n64" />
-		<release name="AI Shougi 3 (Japan)" region="JPN" />
-		<rom name="AI Shougi 3 (Japan).z64" size="8388608" crc="86df90e6" md5="4a5c509a20db7a429dc1dd4e219ad4a2" sha1="8d87d888e8916c4c148dad32ee0519dd297d1fa6" />
+		<rom name="AI Shougi 3 (Japan).z64" size="8388608" crc="86df90e6" md5="4a5c509a20db7a429dc1dd4e219ad4a2" sha1="8d87d888e8916c4c148dad32ee0519dd297d1fa6" sha256="05265ab26612612b5573971c217709a073b44640182333ea87269975c324c9b9" serial="NS3J" />
 	</game>
-	<game name="Aidyn Chronicles - The First Mage (Europe)">
+	<game name="Aidyn Chronicles - The First Mage (Europe)" id="0028">
 		<description>Aidyn Chronicles - The First Mage (Europe)</description>
 		<rom name="Aidyn Chronicles - The First Mage (Europe).n64" />
-		<release name="Aidyn Chronicles - The First Mage (Europe)" region="EUR" />
-		<rom name="Aidyn Chronicles - The First Mage (Europe).z64" size="33554432" crc="be7e230d" md5="54d0a39123c15f74aabb1ecc24d4d6a0" sha1="e3a1e26f4c10a6767612d1a8462689e86d09dc0b" />
+		<rom name="Aidyn Chronicles - The First Mage (Europe).z64" size="33554432" crc="be7e230d" md5="54d0a39123c15f74aabb1ecc24d4d6a0" sha1="e3a1e26f4c10a6767612d1a8462689e86d09dc0b" sha256="19a7739f1a3c8db931eaffc0cbcaebc4f4a93da7d550a257258bcde6eab1a1a7" status="verified" serial="NAYP" />
 	</game>
-	<game name="Aidyn Chronicles - The First Mage (USA)" cloneof="Aidyn Chronicles - The First Mage (Europe)">
+	<game name="Aidyn Chronicles - The First Mage (USA)" id="0029" cloneofid="0028">
 		<description>Aidyn Chronicles - The First Mage (USA)</description>
 		<rom name="Aidyn Chronicles - The First Mage (USA).n64" />
-		<rom name="Aidyn Chronicles - The First Mage (USA).z64" size="33554432" crc="b1f18186" md5="af149336b3ddb899598e7be8740d7dc6" sha1="47ae795a2b12783a13e2b8d03439ce9a39fc826c" />
+		<rom name="Aidyn Chronicles - The First Mage (USA).z64" size="33554432" crc="b1f18186" md5="af149336b3ddb899598e7be8740d7dc6" sha1="47ae795a2b12783a13e2b8d03439ce9a39fc826c" sha256="64e80de903faa4ddd40f3f0f077ca814f82b6cb46c1de14b7b968bbd380bf41c" serial="NAYE" />
 	</game>
-	<game name="Aidyn Chronicles - The First Mage (USA) (Rev 1)" cloneof="Aidyn Chronicles - The First Mage (Europe)">
+	<game name="Aidyn Chronicles - The First Mage (USA) (Rev 1)" id="0924" cloneofid="0028">
 		<description>Aidyn Chronicles - The First Mage (USA) (Rev 1)</description>
 		<rom name="Aidyn Chronicles - The First Mage (USA) (Rev 1).n64" />
-		<release name="Aidyn Chronicles - The First Mage (USA) (Rev 1)" region="USA" />
-		<rom name="Aidyn Chronicles - The First Mage (USA) (Rev 1).z64" size="33554432" crc="d5051096" md5="e8cddf0c52b72453d52da385322dfe15" sha1="f80e135e7e962308f51bb9f7600b25213549c688" />
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Rev 1).z64" size="33554432" crc="d5051096" md5="e8cddf0c52b72453d52da385322dfe15" sha1="f80e135e7e962308f51bb9f7600b25213549c688" sha256="c1ceed1e7fe15263bd915062e2eedddc4f4f32991e4dbf2acd6ee7d0703f14ec" serial="NAYE" />
 	</game>
-	<game name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10)" cloneof="Aidyn Chronicles - The First Mage (Europe)">
+	<game name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10)" id="1032" cloneofid="0028">
 		<description>Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10)</description>
 		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10).n64" />
-		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10).z64" size="33554432" crc="c46d84a0" md5="cd24763becfa1d0053e5438b0ef5e75e" sha1="6e8e1d2a40076b8503a433947658456ef5b833b9" />
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10).z64" size="33554432" crc="c46d84a0" md5="cd24763becfa1d0053e5438b0ef5e75e" sha1="6e8e1d2a40076b8503a433947658456ef5b833b9" sha256="0069edab529c75ea72e028b05b0f580152dd86b3896e7579f399ccc35e1ec939" />
 	</game>
-	<game name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09)" cloneof="Aidyn Chronicles - The First Mage (Europe)">
+	<game name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09)" id="1033" cloneofid="0028">
 		<description>Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09)</description>
 		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09).n64" />
-		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09).z64" size="33554432" crc="abd43f3f" md5="cc6eae9ed582044cc27945684fd396cd" sha1="d741ceac3cf6b14ab16a1f8d4f1bf9858bbf6c3d" />
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09).z64" size="33554432" crc="abd43f3f" md5="cc6eae9ed582044cc27945684fd396cd" sha1="d741ceac3cf6b14ab16a1f8d4f1bf9858bbf6c3d" sha256="c975fb203ce3ceec6276e5c88c5172c6c353f8e1f03693c81e49df997ab29cd8" />
 	</game>
-	<game name="Airboarder 64 (Europe)">
-		<description>Airboarder 64 (Europe)</description>
-		<rom name="Airboarder 64 (Europe).n64" />
-		<release name="Airboarder 64 (Europe)" region="EUR" />
-		<rom name="Airboarder 64 (Europe).z64" size="8388608" crc="c14d45ac" md5="e8891f8f498a615a6cbaf75b7ddc9fa6" sha1="2171fe2c0a9253cba56828f24a5e6153726c1516" />
+	<game name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-12-05)" id="1100" cloneofid="0028">
+		<category>Games</category>
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-12-05).n64" />
+		<description>Aidyn Chronicles - The First Mage (USA) (Beta) (2000-12-05)</description>
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-12-05).z64" size="33554432" crc="2b39f8e3" md5="1ac9dec95ad700412a7295da39237155" sha1="330cc37425909022baea9aae58ab49cdd903eed5" sha256="468efe1af342f60b93461c50cbcc471f41f48f4e54c81ef622b69820a9d00c32" serial="!none" />
 	</game>
-	<game name="Air Boarder 64 (Japan)" cloneof="Airboarder 64 (Europe)">
+	<game name="Aidyn Chronicles - The First Mage (Europe) (Beta) (2001-03-02)" id="1101" cloneofid="0028">
+		<category>Games</category>
+		<rom name="Aidyn Chronicles - The First Mage (Europe) (Beta) (2001-03-02).n64" />
+		<description>Aidyn Chronicles - The First Mage (Europe) (Beta) (2001-03-02)</description>
+		<rom name="Aidyn Chronicles - The First Mage (Europe) (Beta) (2001-03-02).z64" size="33554432" crc="7e1f78b8" md5="86fef7da7cb95d52d5980cd59eab31a5" sha1="dc49455068b1cca2acc2e0d24306dd70978b559e" sha256="954843718bd0ba6d19d214aead72895df8c47fe96505fa9c2caa57f2ff89a261" serial="NAYP" />
+	</game>
+	<game name="Aidyn Chronicles - The First Mage (Europe) (Beta) (2001-04-10)" id="1102" cloneofid="0028">
+		<category>Games</category>
+		<rom name="Aidyn Chronicles - The First Mage (Europe) (Beta) (2001-04-10).n64" />
+		<description>Aidyn Chronicles - The First Mage (Europe) (Beta) (2001-04-10)</description>
+		<rom name="Aidyn Chronicles - The First Mage (Europe) (Beta) (2001-04-10).z64" size="33554432" crc="60c73748" md5="76ae4afb0fdddb8f28856179a3f2cd59" sha1="7b6df16479d926b042b4fc6971bc89f9d1f46dfe" sha256="d6bfc15751cfcfb668cca0d2038cb0919873bc39c15f77dfa3d32f8f72dd0c90" serial="NAYP" />
+	</game>
+	<game name="Air Boarder 64 (Japan)" id="0031" cloneofid="0030">
 		<description>Air Boarder 64 (Japan)</description>
 		<rom name="Air Boarder 64 (Japan).n64" />
-		<release name="Air Boarder 64 (Japan)" region="JPN" />
-		<rom name="Air Boarder 64 (Japan).z64" size="8388608" crc="58fcb771" md5="ccee2fcf38dc2200128d75d15db53283" sha1="4a70c9ca027ecc8d05337993204e1ef76f5f0ac9" />
+		<rom name="Air Boarder 64 (Japan).z64" size="8388608" crc="58fcb771" md5="ccee2fcf38dc2200128d75d15db53283" sha1="4a70c9ca027ecc8d05337993204e1ef76f5f0ac9" sha256="e3fa6d6f13671237e703f32d01f48aff62071114a7a92086c9e3229d1b943ecc" serial="NABJ" />
 	</game>
-	<game name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It)">
-		<description>All Star Tennis '99 (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="996e845f" md5="e3f4c868917a12bd5e84d94d1c260c7d" sha1="09ddbd45f4962735def65399b5792e3bb5bd7d3c" />
+	<game name="Airboarder 64 (Europe)" id="0030">
+		<description>Airboarder 64 (Europe)</description>
+		<rom name="Airboarder 64 (Europe).n64" />
+		<rom name="Airboarder 64 (Europe).z64" size="8388608" crc="c14d45ac" md5="e8891f8f498a615a6cbaf75b7ddc9fa6" sha1="2171fe2c0a9253cba56828f24a5e6153726c1516" sha256="adc68241f2472aa5b4cd71f189f0b04f44d99e4d29776e831feb0ef86e6ceb79" status="verified" serial="NABP" />
 	</game>
-	<game name="All Star Tennis 99 (USA)" cloneof="All Star Tennis '99 (Europe) (En,Fr,De,Es,It)">
-		<description>All Star Tennis 99 (USA)</description>
-		<rom name="All Star Tennis 99 (USA).n64" />
-		<release name="All Star Tennis 99 (USA)" region="USA" />
-		<rom name="All Star Tennis 99 (USA).z64" size="8388608" crc="a7dcf638" md5="afc3dc9bb737d81903f6ce4875b63ae9" sha1="3a6446409d63dcac0d5c860a3e2888a378474887" />
-	</game>
-	<game name="All-Star Baseball 2000 (Europe)">
-		<description>All-Star Baseball 2000 (Europe)</description>
-		<rom name="All-Star Baseball 2000 (Europe).n64" />
-		<release name="All-Star Baseball 2000 (Europe)" region="EUR" />
-		<rom name="All-Star Baseball 2000 (Europe).z64" size="16777216" crc="d3c29aa4" md5="90448c4175ee9d0247674474dcabdfed" sha1="c8f41a27b9509da422b7ecf32f64df3e213194ea" />
-	</game>
-	<game name="All-Star Baseball 2000 (USA)" cloneof="All-Star Baseball 2000 (Europe)">
-		<description>All-Star Baseball 2000 (USA)</description>
-		<rom name="All-Star Baseball 2000 (USA).n64" />
-		<release name="All-Star Baseball 2000 (USA)" region="USA" />
-		<rom name="All-Star Baseball 2000 (USA).z64" size="16777216" crc="69e88471" md5="aada358ce97f06c4df5bf55987268844" sha1="4256a23902e22e6e8291f1931f8de4b2716fe480" />
-	</game>
-	<game name="All-Star Baseball 2001 (USA)">
-		<description>All-Star Baseball 2001 (USA)</description>
-		<rom name="All-Star Baseball 2001 (USA).n64" />
-		<release name="All-Star Baseball 2001 (USA)" region="USA" />
-		<rom name="All-Star Baseball 2001 (USA).z64" size="16777216" crc="4d659e85" md5="6e01b8d425ae74ef5a0f875c700a3b18" sha1="4f1b8635322190bb3d0c6fc7d3ba844941f05574" />
-	</game>
-	<game name="All-Star Baseball 99 (Europe)">
-		<description>All-Star Baseball 99 (Europe)</description>
-		<rom name="All-Star Baseball 99 (Europe).n64" />
-		<release name="All-Star Baseball 99 (Europe)" region="EUR" />
-		<rom name="All-Star Baseball 99 (Europe).z64" size="12582912" crc="d0de3584" md5="ed5f1e12da36dbec8a0a24ed98d4aed5" sha1="3ac0d13f2260797dabf99cfedabf7e3676c5b2e2" />
-	</game>
-	<game name="All-Star Baseball 99 (USA)" cloneof="All-Star Baseball 99 (Europe)">
-		<description>All-Star Baseball 99 (USA)</description>
-		<rom name="All-Star Baseball 99 (USA).n64" />
-		<release name="All-Star Baseball 99 (USA)" region="USA" />
-		<rom name="All-Star Baseball 99 (USA).z64" size="12582912" crc="6d25b36f" md5="78551d23f230b58b9f449cdb4a285761" sha1="aa576624f2a66034cb0d6e621ba16a0d3beaca3a" />
-	</game>
-	<game name="Armorines - Project S.W.A.R.M. (Europe)">
-		<description>Armorines - Project S.W.A.R.M. (Europe)</description>
-		<rom name="Armorines - Project S.W.A.R.M. (Europe).n64" />
-		<release name="Armorines - Project S.W.A.R.M. (Europe)" region="EUR" />
-		<rom name="Armorines - Project S.W.A.R.M. (Europe).z64" size="16777216" crc="600bc49e" md5="0c2cbafec6f184ad39ef29b2b5e0f44a" sha1="66f2b431d2275b2563692bfd053d4c0118e0e0c2" />
-	</game>
-	<game name="Armorines - Project S.W.A.R.M. (Germany)" cloneof="Armorines - Project S.W.A.R.M. (Europe)">
-		<description>Armorines - Project S.W.A.R.M. (Germany)</description>
-		<rom name="Armorines - Project S.W.A.R.M. (Germany).n64" />
-		<release name="Armorines - Project S.W.A.R.M. (Germany)" region="GER" />
-		<rom name="Armorines - Project S.W.A.R.M. (Germany).z64" size="16777216" crc="5bab9100" md5="2bc48b3e6f61896b9bc7bef5205cc49c" sha1="68f9dda2863f7625a36f115419956dd9f249afe6" />
-	</game>
-	<game name="Armorines - Project S.W.A.R.M. (USA)" cloneof="Armorines - Project S.W.A.R.M. (Europe)">
-		<description>Armorines - Project S.W.A.R.M. (USA)</description>
-		<rom name="Armorines - Project S.W.A.R.M. (USA).n64" />
-		<release name="Armorines - Project S.W.A.R.M. (USA)" region="USA" />
-		<rom name="Armorines - Project S.W.A.R.M. (USA).z64" size="16777216" crc="630a19e2" md5="6e6e7a703c131adaddf4175e9037a2eb" sha1="d9f55acf77a54eeb7f62577aa5711769ebeadde3" />
-	</game>
-	<game name="Army Men - Air Combat (USA)">
-		<description>Army Men - Air Combat (USA)</description>
-		<rom name="Army Men - Air Combat (USA).n64" />
-		<release name="Army Men - Air Combat (USA)" region="USA" />
-		<rom name="Army Men - Air Combat (USA).z64" size="8388608" crc="1952cc87" md5="755df7f57edf87706d4c80ff15883312" sha1="eb9bacb12eb6665be9936a3e1dfd6d57b2eaabdb" />
-	</game>
-	<game name="Army Men - Sarge's Heroes (Europe) (En,Fr,De)">
-		<description>Army Men - Sarge's Heroes (Europe) (En,Fr,De)</description>
-		<rom name="Army Men - Sarge's Heroes (Europe) (En,Fr,De).n64" />
-		<release name="Army Men - Sarge's Heroes (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Army Men - Sarge's Heroes (Europe) (En,Fr,De).z64" size="8388608" crc="e79048e2" md5="53e2872612760133ab7b2cc2e22b847c" sha1="00e594fa64da61c2ad3138a31a22b9854bb3fafa" />
-	</game>
-	<game name="Army Men - Sarge's Heroes (USA)" cloneof="Army Men - Sarge's Heroes (Europe) (En,Fr,De)">
-		<description>Army Men - Sarge's Heroes (USA)</description>
-		<rom name="Army Men - Sarge's Heroes (USA).n64" />
-		<release name="Army Men - Sarge's Heroes (USA)" region="USA" />
-		<rom name="Army Men - Sarge's Heroes (USA).z64" size="8388608" crc="2fe786f6" md5="b8085c2edb1c6d23e52ed8c06d92b4f8" sha1="1824380911579424e50042d45aef4851f7ab25a7" />
-	</game>
-	<game name="Army Men - Sarge's Heroes 2 (USA)">
-		<description>Army Men - Sarge's Heroes 2 (USA)</description>
-		<rom name="Army Men - Sarge's Heroes 2 (USA).n64" />
-		<release name="Army Men - Sarge's Heroes 2 (USA)" region="USA" />
-		<rom name="Army Men - Sarge's Heroes 2 (USA).z64" size="8388608" crc="79a71608" md5="6eea5c4a6256092ed8f9ba8861c689c6" sha1="f32b6de2f87928378f26ca17b68b27d87fdefce1" />
-	</game>
-	<game name="Asteroids Hyper 64 (USA)">
-		<description>Asteroids Hyper 64 (USA)</description>
-		<rom name="Asteroids Hyper 64 (USA).n64" />
-		<release name="Asteroids Hyper 64 (USA)" region="USA" />
-		<rom name="Asteroids Hyper 64 (USA).z64" size="4194304" crc="f5ce3d91" md5="874c7b7b365d2c20aaa1a0c90c93f9b8" sha1="329f4d560b0ba7da622edd9b84523e86e265fffe" />
-	</game>
-	<game name="Automobili Lamborghini (Europe)">
-		<description>Automobili Lamborghini (Europe)</description>
-		<rom name="Automobili Lamborghini (Europe).n64" />
-		<release name="Automobili Lamborghini (Europe)" region="EUR" />
-		<rom name="Automobili Lamborghini (Europe).z64" size="4194304" crc="3baf58d5" md5="7853f02dc66a35bc8c2bc33d03b8f0ca" sha1="513c9511539bf2361ff20ee1f19dc03f618b5214" status="verified" />
-	</game>
-	<game name="Automobili Lamborghini (USA)" cloneof="Automobili Lamborghini (Europe)">
-		<description>Automobili Lamborghini (USA)</description>
-		<rom name="Automobili Lamborghini (USA).n64" />
-		<release name="Automobili Lamborghini (USA)" region="USA" />
-		<rom name="Automobili Lamborghini (USA).z64" size="4194304" crc="a4374eac" md5="ec39579f066a9714ff030d07dec3c9d3" sha1="78b36b48040426478011caef5e11884af2e80375" />
-	</game>
-	<game name="Super Speed Race 64 (Japan)" cloneof="Automobili Lamborghini (Europe)">
-		<description>Super Speed Race 64 (Japan)</description>
-		<rom name="Super Speed Race 64 (Japan).n64" />
-		<release name="Super Speed Race 64 (Japan)" region="JPN" />
-		<rom name="Super Speed Race 64 (Japan).z64" size="4194304" crc="0f879a70" md5="6b5d93b3566e96147009d1ac4fb15c97" sha1="e0a49ff953b882f9f135b583ef9e09a664d24288" />
-	</game>
-	<game name="Bakuretsu Muteki Bangaioh (Japan)">
-		<description>Bakuretsu Muteki Bangaioh (Japan)</description>
-		<rom name="Bakuretsu Muteki Bangaioh (Japan).n64" />
-		<release name="Bakuretsu Muteki Bangaioh (Japan)" region="JPN" />
-		<rom name="Bakuretsu Muteki Bangaioh (Japan).z64" size="12582912" crc="6ab7fec6" md5="8107825ac2a522057422463ed81e276b" sha1="2dbfe78f97b8d6e1a33b73d244be831d18b0491e" />
-	</game>
-	<game name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)">
-		<description>Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)</description>
-		<rom name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).n64" />
-		<release name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)" region="JPN" />
-		<rom name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).z64" size="12582912" crc="ef8c2f34" md5="09fd63afa1156405e618752fc583df93" sha1="28e6d11f6f48c86a9b7c112c672109e1c2d7e5d0" />
-	</game>
-	<game name="Banjo-Kazooie (Europe) (En,Fr,De)">
-		<description>Banjo-Kazooie (Europe) (En,Fr,De)</description>
-		<rom name="Banjo-Kazooie (Europe) (En,Fr,De).n64" />
-		<release name="Banjo-Kazooie (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Banjo-Kazooie (Europe) (En,Fr,De).z64" size="16777216" crc="525899c9" md5="06a43bacf5c0687f596df9b018ca6d7f" sha1="bb359a75941df74bf7290212c89fbc6e2c5601fe" status="verified" />
-	</game>
-	<game name="Banjo to Kazooie no Daibouken (Japan)" cloneof="Banjo-Kazooie (Europe) (En,Fr,De)">
-		<description>Banjo to Kazooie no Daibouken (Japan)</description>
-		<rom name="Banjo to Kazooie no Daibouken (Japan).n64" />
-		<release name="Banjo to Kazooie no Daibouken (Japan)" region="JPN" />
-		<rom name="Banjo to Kazooie no Daibouken (Japan).z64" size="16777216" crc="8f7c9324" md5="3d3855a86fd5a1b4d30beb0f5a4a85af" sha1="90726d7e7cd5bf6cdfd38f45c9acbf4d45bd9fd8" status="verified" />
-	</game>
-	<game name="Banjo-Kazooie (USA)" cloneof="Banjo-Kazooie (Europe) (En,Fr,De)">
-		<description>Banjo-Kazooie (USA)</description>
-		<rom name="Banjo-Kazooie (USA).n64" />
-		<rom name="Banjo-Kazooie (USA).z64" size="16777216" crc="ad429961" md5="b29599651a13f681c9923d69354bf4a3" sha1="1fe1632098865f639e22c11b9a81ee8f29c75d7a" status="verified" />
-	</game>
-	<game name="Banjo-Kazooie (USA) (Rev 1)" cloneof="Banjo-Kazooie (Europe) (En,Fr,De)">
-		<description>Banjo-Kazooie (USA) (Rev 1)</description>
-		<rom name="Banjo-Kazooie (USA) (Rev 1).n64" />
-		<release name="Banjo-Kazooie (USA) (Rev 1)" region="USA" />
-		<rom name="Banjo-Kazooie (USA) (Rev 1).z64" size="16777216" crc="fb7ffb10" md5="b11f476d4bc8e039355241e871dc08cf" sha1="ded6ee166e740ad1bc810fd678a84b48e245ab80" />
-	</game>
-	<game name="Banjo-Tooie (Europe) (En,Fr,De,Es)">
-		<description>Banjo-Tooie (Europe) (En,Fr,De,Es)</description>
-		<rom name="Banjo-Tooie (Europe) (En,Fr,De,Es).n64" />
-		<release name="Banjo-Tooie (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Banjo-Tooie (Europe) (En,Fr,De,Es).z64" size="33554432" crc="1ec12f5a" md5="8b2e56f18421a67bca861427453a1e19" sha1="93bf2fac1387320ad07251cb4b64fd36bac1d7a6" status="verified" />
-	</game>
-	<game name="Banjo to Kazooie no Daibouken 2 (Japan)" cloneof="Banjo-Tooie (Europe) (En,Fr,De,Es)">
-		<description>Banjo to Kazooie no Daibouken 2 (Japan)</description>
-		<rom name="Banjo to Kazooie no Daibouken 2 (Japan).n64" />
-		<release name="Banjo to Kazooie no Daibouken 2 (Japan)" region="JPN" />
-		<rom name="Banjo to Kazooie no Daibouken 2 (Japan).z64" size="33554432" crc="258c58d0" md5="715a8816f30fa24b8d174dc5cb6f25a9" sha1="5a5172383037d171f121790959962703be1f373c" />
-	</game>
-	<game name="Banjo-Tooie (Australia)" cloneof="Banjo-Tooie (Europe) (En,Fr,De,Es)">
-		<description>Banjo-Tooie (Australia)</description>
-		<rom name="Banjo-Tooie (Australia).n64" />
-		<release name="Banjo-Tooie (Australia)" region="AUS" />
-		<rom name="Banjo-Tooie (Australia).z64" size="33554432" crc="2736266a" md5="61b5c5c3e5e1a81e5d37072c01b39b76" sha1="4ca2d332f6e6b018777afc6a8b7880b38b6dfb79" />
-	</game>
-	<game name="Banjo-Tooie (USA)" cloneof="Banjo-Tooie (Europe) (En,Fr,De,Es)">
-		<description>Banjo-Tooie (USA)</description>
-		<rom name="Banjo-Tooie (USA).n64" />
-		<release name="Banjo-Tooie (USA)" region="USA" />
-		<rom name="Banjo-Tooie (USA).z64" size="33554432" crc="bab803ef" md5="40e98faa24ac3ebe1d25cb5e5ddf49e4" sha1="af1a89e12b638b8d82cc4c085c8e01d4cba03fb3" />
-	</game>
-	<game name="Bass Rush - ECOGEAR PowerWorm Championship (Japan)">
-		<description>Bass Rush - ECOGEAR PowerWorm Championship (Japan)</description>
-		<rom name="Bass Rush - ECOGEAR PowerWorm Championship (Japan).n64" />
-		<release name="Bass Rush - ECOGEAR PowerWorm Championship (Japan)" region="JPN" />
-		<rom name="Bass Rush - ECOGEAR PowerWorm Championship (Japan).z64" size="33554432" crc="383b86ef" md5="2c618f6c69c3b4803f08762a03835139" sha1="1718c9048cb7849a59d48138a058b20bf191ebf6" />
-	</game>
-	<game name="Bassmasters 2000 (USA)">
-		<description>Bassmasters 2000 (USA)</description>
-		<rom name="Bassmasters 2000 (USA).n64" />
-		<release name="Bassmasters 2000 (USA)" region="USA" />
-		<rom name="Bassmasters 2000 (USA).z64" size="12582912" crc="6b09092e" md5="930c7f6e5863471dde1816d28a10eb88" sha1="946b3e08a1a4de4f917ad547bb24f533b737f712" />
-	</game>
-	<game name="Bassmasters 2000 (USA) (Beta)" cloneof="Bassmasters 2000 (USA)">
-		<description>Bassmasters 2000 (USA) (Beta)</description>
-		<rom name="Bassmasters 2000 (USA) (Beta).n64" />
-		<rom name="Bassmasters 2000 (USA) (Beta).z64" size="33554432" crc="86f8e439" md5="684f4f7cefcc0863710799c8a43dd882" sha1="aa5e9d5eccd278bc59d995e31431715d67e93fe2" />
-	</game>
-	<game name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De)">
-		<description>Batman of the Future - Return of the Joker (Europe) (En,Fr,De)</description>
-		<rom name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De).n64" />
-		<release name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De).z64" size="4194304" crc="82a4bb8a" md5="a5ee8a6c34863e3d0eb8c06ae8668b30" sha1="3954131395f98e605072bea11cc85842da58f754" />
-	</game>
-	<game name="Batman Beyond - Return of the Joker (USA)" cloneof="Batman of the Future - Return of the Joker (Europe) (En,Fr,De)">
-		<description>Batman Beyond - Return of the Joker (USA)</description>
-		<rom name="Batman Beyond - Return of the Joker (USA).n64" />
-		<release name="Batman Beyond - Return of the Joker (USA)" region="USA" />
-		<rom name="Batman Beyond - Return of the Joker (USA).z64" size="4194304" crc="35299f9c" md5="a08676124b326b1035b202c83a97468f" sha1="f7382358250965e9757ba9a89fe42d033dbe7fe8" />
-	</game>
-	<game name="BattleTanx (USA)">
-		<description>BattleTanx (USA)</description>
-		<rom name="BattleTanx (USA).n64" />
-		<release name="BattleTanx (USA)" region="USA" />
-		<rom name="BattleTanx (USA).z64" size="8388608" crc="6c230765" md5="3406a505c22bac2f40d9bfc6ff08cf86" sha1="535860d941738ac1210c20a9b80114fea0e0ff17" />
-	</game>
-	<game name="BattleTanx - Global Assault (Europe) (En,Fr,De)">
-		<description>BattleTanx - Global Assault (Europe) (En,Fr,De)</description>
-		<rom name="BattleTanx - Global Assault (Europe) (En,Fr,De).n64" />
-		<release name="BattleTanx - Global Assault (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="BattleTanx - Global Assault (Europe) (En,Fr,De).z64" size="8388608" crc="c99c6030" md5="d6e667fe10afe8f7116888efde98ae0e" sha1="aefade7a37a4716ddc82a6b67ba085cbf7c27259" />
-	</game>
-	<game name="BattleTanx - Global Assault (USA)" cloneof="BattleTanx - Global Assault (Europe) (En,Fr,De)">
-		<description>BattleTanx - Global Assault (USA)</description>
-		<rom name="BattleTanx - Global Assault (USA).n64" />
-		<release name="BattleTanx - Global Assault (USA)" region="USA" />
-		<rom name="BattleTanx - Global Assault (USA).z64" size="8388608" crc="31beb053" md5="654557c316f901a2ca6f7f4b43343147" sha1="805248fb0a0ee694cad8d7dc927b631d860dd8cf" />
-	</game>
-	<game name="Battlezone - Rise of the Black Dogs (USA)">
-		<description>Battlezone - Rise of the Black Dogs (USA)</description>
-		<rom name="Battlezone - Rise of the Black Dogs (USA).n64" />
-		<release name="Battlezone - Rise of the Black Dogs (USA)" region="USA" />
-		<rom name="Battlezone - Rise of the Black Dogs (USA).z64" size="16777216" crc="736f9d5c" md5="266c0989ed0929df499389954779ea97" sha1="85b4febbe6fbd1ecfc883905e43e68e7188c44f9" />
-	</game>
-	<game name="Beetle Adventure Racing! (Europe) (En,Fr,De)">
-		<description>Beetle Adventure Racing! (Europe) (En,Fr,De)</description>
-		<rom name="Beetle Adventure Racing! (Europe) (En,Fr,De).n64" />
-		<release name="Beetle Adventure Racing! (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Beetle Adventure Racing! (Europe) (En,Fr,De).z64" size="16777216" crc="5b6c6e4c" md5="a94135d163e6091c960adc918c1fb8a7" sha1="85b3b95d587d2646f781b04cf5239804d105685a" />
-	</game>
-	<game name="Beetle Adventure Racing! (Japan)" cloneof="Beetle Adventure Racing! (Europe) (En,Fr,De)">
-		<description>Beetle Adventure Racing! (Japan)</description>
-		<rom name="Beetle Adventure Racing! (Japan).n64" />
-		<release name="Beetle Adventure Racing! (Japan)" region="JPN" />
-		<rom name="Beetle Adventure Racing! (Japan).z64" size="16777216" crc="49e75825" md5="5ffd43089b7334072b2b74421618d973" sha1="d6e943a8733d3c09795f4be24b75c7fb0c30a27d" />
-	</game>
-	<game name="Beetle Adventure Racing! (USA) (En,Fr,De)" cloneof="Beetle Adventure Racing! (Europe) (En,Fr,De)">
-		<description>Beetle Adventure Racing! (USA) (En,Fr,De)</description>
-		<rom name="Beetle Adventure Racing! (USA) (En,Fr,De).n64" />
-		<release name="Beetle Adventure Racing! (USA) (En,Fr,De)" region="USA" />
-		<rom name="Beetle Adventure Racing! (USA) (En,Fr,De).z64" size="16777216" crc="f4a97c73" md5="cf97c336479ddbf1217e4dde89d9d2d3" sha1="e5ab4d226c08d22f68a2edcc48870203e67454b8" />
-	</game>
-	<game name="HSV Adventure Racing! (Australia)" cloneof="Beetle Adventure Racing! (Europe) (En,Fr,De)">
-		<description>HSV Adventure Racing! (Australia)</description>
-		<rom name="HSV Adventure Racing! (Australia).n64" />
-		<release name="HSV Adventure Racing! (Australia)" region="AUS" />
-		<rom name="HSV Adventure Racing! (Australia).z64" size="16777216" crc="c0ba9440" md5="26f7d8f4640ebdfa823f84e5f89d62bf" sha1="8a9cdc2a7d98c354ba4b31cea644dbd5153880ae" status="verified" />
-	</game>
-	<game name="Big Mountain 2000 (USA)">
-		<description>Big Mountain 2000 (USA)</description>
-		<rom name="Big Mountain 2000 (USA).n64" />
-		<release name="Big Mountain 2000 (USA)" region="USA" />
-		<rom name="Big Mountain 2000 (USA).z64" size="12582912" crc="3ac924bc" md5="bf6780e2982c16d4a4fdb553be8f9226" sha1="e28f3ebfb7bc706cce639fc1874243e1d4995d1d" />
-	</game>
-	<game name="Snow Speeder (Japan)" cloneof="Big Mountain 2000 (USA)">
-		<description>Snow Speeder (Japan)</description>
-		<rom name="Snow Speeder (Japan).n64" />
-		<release name="Snow Speeder (Japan)" region="JPN" />
-		<rom name="Snow Speeder (Japan).z64" size="12582912" crc="30ea3fd7" md5="f7e66da23c8bb8e59f641a636a9cae82" sha1="0e7df6a6f053f37a168ec33af8ce5240cb18f0ee" />
-	</game>
-	<game name="Bio F.R.E.A.K.S. (Europe)">
-		<description>Bio F.R.E.A.K.S. (Europe)</description>
-		<rom name="Bio F.R.E.A.K.S. (Europe).n64" />
-		<release name="Bio F.R.E.A.K.S. (Europe)" region="EUR" />
-		<rom name="Bio F.R.E.A.K.S. (Europe).z64" size="16777216" crc="2c4eb906" md5="42672ba5e98cd21d7f3e3745e69038dd" sha1="8a85ec7d68954a36569f28f6a26981d6f283fd6d" />
-	</game>
-	<game name="Bio F.R.E.A.K.S. (USA)" cloneof="Bio F.R.E.A.K.S. (Europe)">
-		<description>Bio F.R.E.A.K.S. (USA)</description>
-		<rom name="Bio F.R.E.A.K.S. (USA).n64" />
-		<release name="Bio F.R.E.A.K.S. (USA)" region="USA" />
-		<rom name="Bio F.R.E.A.K.S. (USA).z64" size="16777216" crc="dfbf448c" md5="b90ab8f7605d971cc7a6d9ba5e67d1af" sha1="e20e9124480b559aa7148412c8993804501e180d" />
-	</game>
-	<game name="Blast Corps (Europe) (En,De)">
-		<description>Blast Corps (Europe) (En,De)</description>
-		<rom name="Blast Corps (Europe) (En,De).n64" />
-		<release name="Blast Corps (Europe) (En,De)" region="EUR" />
-		<rom name="Blast Corps (Europe) (En,De).z64" size="8388608" crc="4c820695" md5="889d4d337ad11ce94357511c725eab6a" sha1="460212600f8b9f0da95219c4c7330f2e626d9a7e" status="verified" />
-	</game>
-	<game name="Blast Corps (USA)" cloneof="Blast Corps (Europe) (En,De)">
-		<description>Blast Corps (USA)</description>
-		<rom name="Blast Corps (USA).n64" />
-		<rom name="Blast Corps (USA).z64" size="8388608" crc="767a95e7" md5="a8dfdff49144627492da9b0b65b91845" sha1="185a6ef7ba1adb243278062c81a7d4e119bda58c" />
-	</game>
-	<game name="Blast Corps (USA) (Rev 1)" cloneof="Blast Corps (Europe) (En,De)">
-		<description>Blast Corps (USA) (Rev 1)</description>
-		<rom name="Blast Corps (USA) (Rev 1).n64" />
-		<release name="Blast Corps (USA) (Rev 1)" region="USA" />
-		<rom name="Blast Corps (USA) (Rev 1).z64" size="8388608" crc="9cbbccf1" md5="5875fc73069077c93e214233b60f0bdc" sha1="483f7161aea39de8b45c9fbc70a2c3883c4dea8c" />
-	</game>
-	<game name="Blastdozer (Japan)" cloneof="Blast Corps (Europe) (En,De)">
-		<description>Blastdozer (Japan)</description>
-		<rom name="Blastdozer (Japan).n64" />
-		<release name="Blastdozer (Japan)" region="JPN" />
-		<rom name="Blastdozer (Japan).z64" size="8388608" crc="081a3641" md5="16b82d53d7f038a8fe67a78027720516" sha1="b147fdbeb661c89107c440b00dc4810508f58636" />
-	</game>
-	<game name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="8fb41658" md5="31b4a8ed52b48e756b344c9f22736e50" sha1="d641afca71a7d83587f9d7105d5e6dffdeaa8016" />
-	</game>
-	<game name="Blues Brothers 2000 (USA)" cloneof="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Blues Brothers 2000 (USA)</description>
-		<rom name="Blues Brothers 2000 (USA).n64" />
-		<release name="Blues Brothers 2000 (USA)" region="USA" />
-		<rom name="Blues Brothers 2000 (USA).z64" size="16777216" crc="c6f49764" md5="997fd8f79cd6f3cd1c1c1fd21e358717" sha1="ed0fe7c9a2e8015bdf8262d35065f53c6fcea60f" />
-	</game>
-	<game name="Blues Brothers 2000 (USA) (Beta) (2000-01-15)" cloneof="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Blues Brothers 2000 (USA) (Beta) (2000-01-15)</description>
-		<rom name="Blues Brothers 2000 (USA) (Beta) (2000-01-15).n64" />
-		<rom name="Blues Brothers 2000 (USA) (Beta) (2000-01-15).z64" size="33554432" crc="bb1ca04d" md5="410bf50920c28ce6d2c36174f659b0d7" sha1="b0f2546c0dbc4d8cc095337a288736e785219d02" />
-	</game>
-	<game name="Body Harvest (Europe) (En,Fr,De)">
-		<description>Body Harvest (Europe) (En,Fr,De)</description>
-		<rom name="Body Harvest (Europe) (En,Fr,De).n64" />
-		<release name="Body Harvest (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Body Harvest (Europe) (En,Fr,De).z64" size="12582912" crc="6a04cdae" md5="b27fa5e9ad0cb47bb3a74ffac7bc8edf" sha1="67750e2e7ab46fedf65a271ab7f4c7aad92ae355" status="verified" />
-	</game>
-	<game name="Body Harvest (USA)" cloneof="Body Harvest (Europe) (En,Fr,De)">
-		<description>Body Harvest (USA)</description>
-		<rom name="Body Harvest (USA).n64" />
-		<release name="Body Harvest (USA)" region="USA" />
-		<rom name="Body Harvest (USA).z64" size="12582912" crc="fabbdf02" md5="3b8585ed03e8ddb89d7de456317545e7" sha1="bbb6666f5014a473747ee4145f036d9fb25d7348" />
-	</game>
-	<game name="Bomberman 64 (Europe)">
-		<description>Bomberman 64 (Europe)</description>
-		<rom name="Bomberman 64 (Europe).n64" />
-		<release name="Bomberman 64 (Europe)" region="EUR" />
-		<rom name="Bomberman 64 (Europe).z64" size="8388608" crc="525339c5" md5="b68f49aa8f6f7499184ac6b7b8570f2b" sha1="01e50f41733994bf229bee3b3d8aa9fd46441175" status="verified" />
-	</game>
-	<game name="Baku Bomberman (Japan)" cloneof="Bomberman 64 (Europe)">
-		<description>Baku Bomberman (Japan)</description>
-		<rom name="Baku Bomberman (Japan).n64" />
-		<release name="Baku Bomberman (Japan)" region="JPN" />
-		<rom name="Baku Bomberman (Japan).z64" size="8388608" crc="22f54a52" md5="8183688a4b7d0a390496b5655bcd252e" sha1="4813b147d552f72fdb0b306469bf9aa0f820fd5b" />
-	</game>
-	<game name="Bomberman 64 (USA)" cloneof="Bomberman 64 (Europe)">
-		<description>Bomberman 64 (USA)</description>
-		<rom name="Bomberman 64 (USA).n64" />
-		<release name="Bomberman 64 (USA)" region="USA" />
-		<rom name="Bomberman 64 (USA).z64" size="8388608" crc="3ed0e0dc" md5="093058ece14c8cc1a887b2087eb5cfe9" sha1="8a7648d8105ac4fc1ad942291b2ef89aeca921c9" />
-	</game>
-	<game name="Bomberman 64 (Japan)">
-		<description>Bomberman 64 (Japan)</description>
-		<rom name="Bomberman 64 (Japan).n64" />
-		<release name="Bomberman 64 (Japan)" region="JPN" />
-		<rom name="Bomberman 64 (Japan).z64" size="12582912" crc="7e74eedc" md5="08e491f87445c6e5c168d982fc665d5f" sha1="1f2e0598730a2f7ea1987603e505af45879e194a" />
-	</game>
-	<game name="Bomberman 64 - The Second Attack! (USA)">
-		<description>Bomberman 64 - The Second Attack! (USA)</description>
-		<rom name="Bomberman 64 - The Second Attack! (USA).n64" />
-		<release name="Bomberman 64 - The Second Attack! (USA)" region="USA" />
-		<rom name="Bomberman 64 - The Second Attack! (USA).z64" size="16777216" crc="57550007" md5="aec1fdb0f1caad86c9f457989a4ce482" sha1="66b1fd763793ecc6e03aa6c5d023df8de5351b9e" />
-	</game>
-	<game name="Baku Bomberman 2 (Japan)" cloneof="Bomberman 64 - The Second Attack! (USA)">
-		<description>Baku Bomberman 2 (Japan)</description>
-		<rom name="Baku Bomberman 2 (Japan).n64" />
-		<release name="Baku Bomberman 2 (Japan)" region="JPN" />
-		<rom name="Baku Bomberman 2 (Japan).z64" size="16777216" crc="86bbc278" md5="ca956015b6820dcff1c814f3532e18b1" sha1="179cab7426755f14bd3f4999f3789eb6d7af64c4" />
-	</game>
-	<game name="Bomberman Hero (Europe)">
-		<description>Bomberman Hero (Europe)</description>
-		<rom name="Bomberman Hero (Europe).n64" />
-		<release name="Bomberman Hero (Europe)" region="EUR" />
-		<rom name="Bomberman Hero (Europe).z64" size="12582912" crc="59e39947" md5="f79ef0813157880ffbad6199e07579be" sha1="ba1e6a4cc323a83d7c14573c9128ab9f9b60e5f2" status="verified" />
-	</game>
-	<game name="Bomberman Hero (USA)" cloneof="Bomberman Hero (Europe)">
-		<description>Bomberman Hero (USA)</description>
-		<rom name="Bomberman Hero (USA).n64" />
-		<release name="Bomberman Hero (USA)" region="USA" />
-		<rom name="Bomberman Hero (USA).z64" size="12582912" crc="2cc2e634" md5="ef2453bff7ad0c4bfa9ab0bd6324ebf3" sha1="a36364b7e59351f7551ab351cb3b41ebc4be285b" status="verified" />
-	</game>
-	<game name="Bomberman Hero - Mirian Oujo o Sukue! (Japan)" cloneof="Bomberman Hero (Europe)">
-		<description>Bomberman Hero - Mirian Oujo o Sukue! (Japan)</description>
-		<rom name="Bomberman Hero - Mirian Oujo o Sukue! (Japan).n64" />
-		<release name="Bomberman Hero - Mirian Oujo o Sukue! (Japan)" region="JPN" />
-		<rom name="Bomberman Hero - Mirian Oujo o Sukue! (Japan).z64" size="12582912" crc="69ceabcc" md5="ee273763c7391458865ff26c7ea0c3f1" sha1="ae3f4f7c31ddbd14843d9beb932fc5aa21746211" status="verified" />
-	</game>
-	<game name="Bottom of the 9th (USA)">
-		<description>Bottom of the 9th (USA)</description>
-		<rom name="Bottom of the 9th (USA).n64" />
-		<release name="Bottom of the 9th (USA)" region="USA" />
-		<rom name="Bottom of the 9th (USA).z64" size="16777216" crc="1844c8ca" md5="fb19afd5e8c49978e6e6ae3622e0498a" sha1="4ee0e3768b9f23112e4e5ef0c81a2b29ae22eab2" />
-	</game>
-	<game name="Brunswick Circuit Pro Bowling (USA)">
-		<description>Brunswick Circuit Pro Bowling (USA)</description>
-		<rom name="Brunswick Circuit Pro Bowling (USA).n64" />
-		<release name="Brunswick Circuit Pro Bowling (USA)" region="USA" />
-		<rom name="Brunswick Circuit Pro Bowling (USA).z64" size="8388608" crc="80d70173" md5="62e92102d6fd1701a6e904da6ab58ae8" sha1="91f6f7843a7413126a7b4026104526615f979134" />
-	</game>
-	<game name="Buck Bumble (Europe) (En,Fr,De,Es,It)">
-		<description>Buck Bumble (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="Buck Bumble (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Buck Bumble (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Buck Bumble (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="e26192ab" md5="a2e4be02876cb0f0d1e925ff95090c96" sha1="1123bfac4ec3730a54900ca83e196065cbb4b6e2" status="verified" />
-	</game>
-	<game name="Buck Bumble (Japan)" cloneof="Buck Bumble (Europe) (En,Fr,De,Es,It)">
-		<description>Buck Bumble (Japan)</description>
-		<rom name="Buck Bumble (Japan).n64" />
-		<release name="Buck Bumble (Japan)" region="JPN" />
-		<rom name="Buck Bumble (Japan).z64" size="12582912" crc="2ed81a65" md5="aee981977d8f069003574cd10a268d47" sha1="38007f846a454ad09d2090f0ef86e9762a46ccf7" />
-	</game>
-	<game name="Buck Bumble (USA)" cloneof="Buck Bumble (Europe) (En,Fr,De,Es,It)">
-		<description>Buck Bumble (USA)</description>
-		<rom name="Buck Bumble (USA).n64" />
-		<release name="Buck Bumble (USA)" region="USA" />
-		<rom name="Buck Bumble (USA).z64" size="12582912" crc="8ec937db" md5="41417fce2b37eaae787c5a845a0015c4" sha1="01d9497ea0e1f68ae285b8c7a57439b42b7d9a56" />
-	</game>
-	<game name="Bug's Life, A (Europe)">
-		<description>Bug's Life, A (Europe)</description>
-		<rom name="Bug's Life, A (Europe).n64" />
-		<release name="Bug's Life, A (Europe)" region="EUR" />
-		<rom name="Bug's Life, A (Europe).z64" size="12582912" crc="791881d4" md5="ed3e962653a1cd56aab175deee6ee52a" sha1="2922c2281faa4106295830c617289292df4c377a" />
-	</game>
-	<game name="Bug's Life, A (France)" cloneof="Bug's Life, A (Europe)">
-		<description>Bug's Life, A (France)</description>
-		<rom name="Bug's Life, A (France).n64" />
-		<release name="Bug's Life, A (France)" region="FRA" />
-		<rom name="Bug's Life, A (France).z64" size="12582912" crc="e5429094" md5="d2860d4fbd0ec4b2711a6ef8d78f9866" sha1="4970ecc65e8de25990a241b0d2ffbe274cb1619a" />
-	</game>
-	<game name="Bug's Life, A (Germany)" cloneof="Bug's Life, A (Europe)">
-		<description>Bug's Life, A (Germany)</description>
-		<rom name="Bug's Life, A (Germany).n64" />
-		<release name="Bug's Life, A (Germany)" region="GER" />
-		<rom name="Bug's Life, A (Germany).z64" size="12582912" crc="15a32836" md5="cbef54768670f4b5602ccbc90150007a" sha1="daa7114a8d16c3e636b2808d4f256e07954f05dd" />
-	</game>
-	<game name="Bug's Life, A (Italy)" cloneof="Bug's Life, A (Europe)">
-		<description>Bug's Life, A (Italy)</description>
-		<rom name="Bug's Life, A (Italy).n64" />
-		<release name="Bug's Life, A (Italy)" region="ITA" />
-		<rom name="Bug's Life, A (Italy).z64" size="12582912" crc="2d118764" md5="e3609fd12369c464e832c6d2a4d20790" sha1="46f9c5d7eb822b19be6910b992949def27e46887" />
-	</game>
-	<game name="Bug's Life, A (USA)" cloneof="Bug's Life, A (Europe)">
-		<description>Bug's Life, A (USA)</description>
-		<rom name="Bug's Life, A (USA).n64" />
-		<release name="Bug's Life, A (USA)" region="USA" />
-		<rom name="Bug's Life, A (USA).z64" size="12582912" crc="cf2ea0b6" md5="7fd6bffb80f920e01ef869829d485ea3" sha1="697c1e895fc840826fcb6a6f37411a2af6d6f47c" />
-	</game>
-	<game name="Bust-A-Move 2 - Arcade Edition (Europe)">
-		<description>Bust-A-Move 2 - Arcade Edition (Europe)</description>
-		<rom name="Bust-A-Move 2 - Arcade Edition (Europe).n64" />
-		<release name="Bust-A-Move 2 - Arcade Edition (Europe)" region="EUR" />
-		<rom name="Bust-A-Move 2 - Arcade Edition (Europe).z64" size="8388608" crc="04731bab" md5="094f639a9ba63b2136d2887c8d72bca0" sha1="f92a1b19c522ba6cf20a9d7883321e6e283da32f" />
-	</game>
-	<game name="Bust-A-Move 2 - Arcade Edition (USA)" cloneof="Bust-A-Move 2 - Arcade Edition (Europe)">
-		<description>Bust-A-Move 2 - Arcade Edition (USA)</description>
-		<rom name="Bust-A-Move 2 - Arcade Edition (USA).n64" />
-		<release name="Bust-A-Move 2 - Arcade Edition (USA)" region="USA" />
-		<rom name="Bust-A-Move 2 - Arcade Edition (USA).z64" size="8388608" crc="9f54cd2d" md5="8897a39e34aee4d3f807af255c6617d6" sha1="8f1aad51e733958d1a9a7a0cb7516fc7a293ca7b" />
-	</game>
-	<game name="Bust-A-Move 3 DX (Europe)">
-		<description>Bust-A-Move 3 DX (Europe)</description>
-		<rom name="Bust-A-Move 3 DX (Europe).n64" />
-		<release name="Bust-A-Move 3 DX (Europe)" region="EUR" />
-		<rom name="Bust-A-Move 3 DX (Europe).z64" size="8388608" crc="95595889" md5="3ea21256ddc4157c3231ae5cc9c4652a" sha1="2bd376c3db3080d0a2328ef4052e59c3df71797e" />
-	</game>
-	<game name="Bust-A-Move '99 (USA)" cloneof="Bust-A-Move 3 DX (Europe)">
-		<description>Bust-A-Move '99 (USA)</description>
-		<rom name="Bust-A-Move '99 (USA).n64" />
-		<release name="Bust-A-Move '99 (USA)" region="USA" />
-		<rom name="Bust-A-Move '99 (USA).z64" size="8388608" crc="c285fc69" md5="8567382d3cd5bc0406b7b4c780f621dc" sha1="8d874677cfbfa88c5e52bc13327d518be3b756ba" />
-	</game>
-	<game name="Puzzle Bobble 64 (Japan)" cloneof="Bust-A-Move 3 DX (Europe)">
-		<description>Puzzle Bobble 64 (Japan)</description>
-		<rom name="Puzzle Bobble 64 (Japan).n64" />
-		<release name="Puzzle Bobble 64 (Japan)" region="JPN" />
-		<rom name="Puzzle Bobble 64 (Japan).z64" size="8388608" crc="ea837423" md5="b478d4af60d43c38ba81de9faea6e057" sha1="9a4cdde04e6c42cf7957bf578a0b15ca90203280" />
-	</game>
-	<game name="California Speed (USA)">
-		<description>California Speed (USA)</description>
-		<rom name="California Speed (USA).n64" />
-		<release name="California Speed (USA)" region="USA" />
-		<rom name="California Speed (USA).z64" size="16777216" crc="6f6262cb" md5="965ad2fa317f0644e49a89a3219719cb" sha1="bd4c070a71ef58499587cb811fb7490b88dd7c0b" />
-	</game>
-	<game name="California Speed (Europe) (Proto)" cloneof="California Speed (USA)">
-		<description>California Speed (Europe) (Proto)</description>
-		<rom name="California Speed (Europe) (Proto).n64" />
-		<rom name="California Speed (Europe) (Proto).z64" size="16777216" crc="d913b95f" md5="29b79bf5812e5f9e5ecef073d59f8915" sha1="b0ca8a5c8cbf2d18a91ac1b9df82907613bef479" />
-	</game>
-	<game name="Carmageddon 64 (Europe) (En,Fr,Es,It)">
-		<description>Carmageddon 64 (Europe) (En,Fr,Es,It)</description>
-		<rom name="Carmageddon 64 (Europe) (En,Fr,Es,It).n64" />
-		<release name="Carmageddon 64 (Europe) (En,Fr,Es,It)" region="EUR" />
-		<rom name="Carmageddon 64 (Europe) (En,Fr,Es,It).z64" size="16777216" crc="8036f999" md5="59eb5646fa079bcbd7a340d7a10196dd" sha1="a26831c07ecc57dbf5846db847a30d9f735297c2" />
-	</game>
-	<game name="Carmageddon 64 (Europe) (En,Fr,De,Es)" cloneof="Carmageddon 64 (Europe) (En,Fr,Es,It)">
-		<description>Carmageddon 64 (Europe) (En,Fr,De,Es)</description>
-		<rom name="Carmageddon 64 (Europe) (En,Fr,De,Es).n64" />
-		<release name="Carmageddon 64 (Europe) (En,Fr,De,Es)" region="GER" />
-		<rom name="Carmageddon 64 (Europe) (En,Fr,De,Es).z64" size="16777216" crc="8569f1a0" md5="ca21467bde6b355e7a15b8f1ada7b24d" sha1="2ab7ea2a9bc05ecf3cac026e2aff7acc9d3202e5" />
-	</game>
-	<game name="Carmageddon 64 (USA)" cloneof="Carmageddon 64 (Europe) (En,Fr,Es,It)">
-		<description>Carmageddon 64 (USA)</description>
-		<rom name="Carmageddon 64 (USA).n64" />
-		<release name="Carmageddon 64 (USA)" region="USA" />
-		<rom name="Carmageddon 64 (USA).z64" size="16777216" crc="10c6a0a1" md5="31bb57c1fad0d47dc2353c1950b11886" sha1="dc7495093fb9a668b0c851b87c037a4cdf2ddc65" />
-	</game>
-	<game name="Castlevania (Europe) (En,Fr,De)">
-		<description>Castlevania (Europe) (En,Fr,De)</description>
-		<rom name="Castlevania (Europe) (En,Fr,De).n64" />
-		<release name="Castlevania (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Castlevania (Europe) (En,Fr,De).z64" size="12582912" crc="d9d76235" md5="57146b6cd8ee7d96b01a811f98a1ac61" sha1="e0da571cddcb8d069b36c2df254334f7c532133e" />
-	</game>
-	<game name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)" cloneof="Castlevania (Europe) (En,Fr,De)">
+	<game name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)" id="0032" cloneofid="0112">
 		<description>Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)</description>
 		<rom name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan).n64" />
-		<release name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)" region="JPN" />
-		<rom name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan).z64" size="12582912" crc="e349cfec" md5="256a1cb23f9e1a2762a7a171417b5d68" sha1="aa70348968589e6ba6e7091ca115fb505099cd97" status="verified" />
+		<rom name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan).z64" size="12582912" crc="e349cfec" md5="256a1cb23f9e1a2762a7a171417b5d68" sha1="aa70348968589e6ba6e7091ca115fb505099cd97" sha256="f5b8a1bd8dd4d03b5fe291428b284ca30d9afd300fe25f60317aa1e4590db638" status="verified" serial="ND3J" />
 	</game>
-	<game name="Castlevania (USA)" cloneof="Castlevania (Europe) (En,Fr,De)">
-		<description>Castlevania (USA)</description>
-		<rom name="Castlevania (USA).n64" />
-		<rom name="Castlevania (USA).z64" size="12582912" crc="8b0d3c00" md5="1cc5cf3b4d29d8c3ade957648b529dc1" sha1="989a28782ed6b0bc489a1bbbd7bec355d8f2707e" />
-	</game>
-	<game name="Castlevania (USA) (Rev 2)" cloneof="Castlevania (Europe) (En,Fr,De)">
-		<description>Castlevania (USA) (Rev 2)</description>
-		<rom name="Castlevania (USA) (Rev 2).n64" />
-		<release name="Castlevania (USA) (Rev 2)" region="USA" />
-		<rom name="Castlevania (USA) (Rev 2).z64" size="12582912" crc="83032d97" md5="06b58673f7d31c56f8fe8186e86f6bd6" sha1="ba23d0fb480b9885f0d847f7f3d67b249177c8c4" />
-	</game>
-	<game name="Castlevania (USA) (Rev 1)" cloneof="Castlevania (Europe) (En,Fr,De)">
-		<description>Castlevania (USA) (Rev 1)</description>
-		<rom name="Castlevania (USA) (Rev 1).n64" />
-		<rom name="Castlevania (USA) (Rev 1).z64" size="12582912" crc="274d3493" md5="ce71d1ce0a2b6d597f72cb4fc08f5844" sha1="349a031320c1fe16a99801c1bab48a7aa8deac8e" />
-	</game>
-	<game name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)">
-		<description>Castlevania - Legacy of Darkness (Europe) (En,Fr,De)</description>
-		<rom name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De).n64" />
-		<release name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De).z64" size="16777216" crc="12ab9b45" md5="78d5f8a98a5ed21d0817856bcd2ad750" sha1="0c6817082dd322477c63f3c91a99c1f34af0065c" />
-	</game>
-	<game name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)" cloneof="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)">
+	<game name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)" id="0033" cloneofid="0115">
 		<description>Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)</description>
 		<rom name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan).n64" />
-		<release name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)" region="JPN" />
-		<rom name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan).z64" size="16777216" crc="ff009c21" md5="47ea239717c4d225c9d0e9fd37b9fcb3" sha1="50439acb5784bea3a4bbba5188c2aeaa1442099d" />
-	</game>
-	<game name="Castlevania - Legacy of Darkness (USA)" cloneof="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)">
-		<description>Castlevania - Legacy of Darkness (USA)</description>
-		<rom name="Castlevania - Legacy of Darkness (USA).n64" />
-		<release name="Castlevania - Legacy of Darkness (USA)" region="USA" />
-		<rom name="Castlevania - Legacy of Darkness (USA).z64" size="16777216" crc="ab13028c" md5="25258460f98f567497b24844abe3a05b" sha1="879ead98f197fd05edda867655da5b1ce25aa5b8" />
-	</game>
-	<game name="Centre Court Tennis (Europe)">
-		<description>Centre Court Tennis (Europe)</description>
-		<rom name="Centre Court Tennis (Europe).n64" />
-		<release name="Centre Court Tennis (Europe)" region="EUR" />
-		<rom name="Centre Court Tennis (Europe).z64" size="12582912" crc="b1d26f39" md5="31fb88048076ace4bd4205c5f40414ab" sha1="c6f1251b4b7841220f670d8a0af844b34c5cfada" />
-	</game>
-	<game name="Let's Smash (Japan)" cloneof="Centre Court Tennis (Europe)">
-		<description>Let's Smash (Japan)</description>
-		<rom name="Let's Smash (Japan).n64" />
-		<release name="Let's Smash (Japan)" region="JPN" />
-		<rom name="Let's Smash (Japan).z64" size="12582912" crc="455a1770" md5="aee5016e6d60d12ad768e9f6d10adde8" sha1="6fda28a79cec30b6c52c3dbc96b513da16bfa4d0" />
-	</game>
-	<game name="Chameleon Twist (Europe)">
-		<description>Chameleon Twist (Europe)</description>
-		<rom name="Chameleon Twist (Europe).n64" />
-		<release name="Chameleon Twist (Europe)" region="EUR" />
-		<rom name="Chameleon Twist (Europe).z64" size="12582912" crc="587dd983" md5="1cd90b13b7fd6afdcb838f801d807826" sha1="197556f41756c82edb6ba7767f0d181290c1b2c2" />
-	</game>
-	<game name="Chameleon Twist (Japan)" cloneof="Chameleon Twist (Europe)">
-		<description>Chameleon Twist (Japan)</description>
-		<rom name="Chameleon Twist (Japan).n64" />
-		<release name="Chameleon Twist (Japan)" region="JPN" />
-		<rom name="Chameleon Twist (Japan).z64" size="12582912" crc="6395c475" md5="c0eb519122d63a944a122437ec1b98ee" sha1="a1faf5c4ca961ab2c029c84ecfa556755e7f70c8" />
-	</game>
-	<game name="Chameleon Twist (USA)" cloneof="Chameleon Twist (Europe)">
-		<description>Chameleon Twist (USA)</description>
-		<rom name="Chameleon Twist (USA).n64" />
-		<rom name="Chameleon Twist (USA).z64" size="12582912" crc="7fe024c9" md5="397be52d4fb7df1e26c6275e05425571" sha1="173875d2a98161228efb56841484e12446a43156" />
-	</game>
-	<game name="Chameleon Twist (USA) (Rev 1)" cloneof="Chameleon Twist (Europe)">
-		<description>Chameleon Twist (USA) (Rev 1)</description>
-		<rom name="Chameleon Twist (USA) (Rev 1).n64" />
-		<release name="Chameleon Twist (USA) (Rev 1)" region="USA" />
-		<rom name="Chameleon Twist (USA) (Rev 1).z64" size="12582912" crc="7ff42fd0" md5="d8a88acfcd89df7a59d9a1b050fda740" sha1="4ca6d563131b4809fe1748335182816a024999d4" />
-	</game>
-	<game name="Chameleon Twist 2 (Europe)">
-		<description>Chameleon Twist 2 (Europe)</description>
-		<rom name="Chameleon Twist 2 (Europe).n64" />
-		<release name="Chameleon Twist 2 (Europe)" region="EUR" />
-		<rom name="Chameleon Twist 2 (Europe).z64" size="8388608" crc="3b53519f" md5="45d1d039ab7926adc748de640afd986a" sha1="bbca485ee38e07da78f44e5de653311b8edc18f2" />
-	</game>
-	<game name="Chameleon Twist 2 (Japan)" cloneof="Chameleon Twist 2 (Europe)">
-		<description>Chameleon Twist 2 (Japan)</description>
-		<rom name="Chameleon Twist 2 (Japan).n64" />
-		<release name="Chameleon Twist 2 (Japan)" region="JPN" />
-		<rom name="Chameleon Twist 2 (Japan).z64" size="12582912" crc="08287cc8" md5="740ad4db03952bbe997db09947a41e62" sha1="b60d0347e7b765195fb27c3ee50a806ea9977dca" />
-	</game>
-	<game name="Chameleon Twist 2 (USA)" cloneof="Chameleon Twist 2 (Europe)">
-		<description>Chameleon Twist 2 (USA)</description>
-		<rom name="Chameleon Twist 2 (USA).n64" />
-		<release name="Chameleon Twist 2 (USA)" region="USA" />
-		<rom name="Chameleon Twist 2 (USA).z64" size="8388608" crc="cdf26d67" md5="00327e0b5df6dce6decc31353f33a3d3" sha1="9fa379d66b218228da3cbf386c91d857c677f489" />
-	</game>
-	<game name="Charlie Blast's Territory (Europe)">
-		<description>Charlie Blast's Territory (Europe)</description>
-		<rom name="Charlie Blast's Territory (Europe).n64" />
-		<release name="Charlie Blast's Territory (Europe)" region="EUR" />
-		<rom name="Charlie Blast's Territory (Europe).z64" size="4194304" crc="82c1d9e1" md5="dd53e1f83e8789d23df6af942ffef236" sha1="9a0eb87ba72c1ef4dcb8b80029f29cdeea91fe49" />
-	</game>
-	<game name="Charlie Blast's Territory (USA)" cloneof="Charlie Blast's Territory (Europe)">
-		<description>Charlie Blast's Territory (USA)</description>
-		<rom name="Charlie Blast's Territory (USA).n64" />
-		<release name="Charlie Blast's Territory (USA)" region="USA" />
-		<rom name="Charlie Blast's Territory (USA).z64" size="4194304" crc="ba4e65a8" md5="59fa8c6d533d36c0ffc2aafab7166e6f" sha1="e11619c7a8e1c2a280ea3ac069cf11153d4951a6" />
-	</game>
-	<game name="Chopper Attack (Europe)">
-		<description>Chopper Attack (Europe)</description>
-		<rom name="Chopper Attack (Europe).n64" />
-		<release name="Chopper Attack (Europe)" region="EUR" />
-		<rom name="Chopper Attack (Europe).z64" size="8388608" crc="c1dcd7ab" md5="8f6bed633be214cf039dbdac356231ce" sha1="9688c388384edea0141fc66b20d6d0e5fe2d668f" />
-	</game>
-	<game name="Chopper Attack (USA)" cloneof="Chopper Attack (Europe)">
-		<description>Chopper Attack (USA)</description>
-		<rom name="Chopper Attack (USA).n64" />
-		<release name="Chopper Attack (USA)" region="USA" />
-		<rom name="Chopper Attack (USA).z64" size="8388608" crc="aa5d76a9" md5="c37e8afb4f3ecc86d01ce7388ca59347" sha1="1e3f1c94c806b2699c4e0e941190d468435b9f60" />
-	</game>
-	<game name="Wild Choppers (Japan)" cloneof="Chopper Attack (Europe)">
-		<description>Wild Choppers (Japan)</description>
-		<rom name="Wild Choppers (Japan).n64" />
-		<release name="Wild Choppers (Japan)" region="JPN" />
-		<rom name="Wild Choppers (Japan).z64" size="8388608" crc="d6136dc5" md5="f85f2a2b6ca64898f0add2a78ccdccf3" sha1="9ed151fce580f875f09cb250d2bb9c18c8d549c0" />
-	</game>
-	<game name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)">
-		<description>Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)</description>
-		<rom name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan).n64" />
-		<release name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)" region="JPN" />
-		<rom name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan).z64" size="12582912" crc="5c565ad6" md5="9081370141079031ebbdbca56fc8c7d8" sha1="4532621d98b25d07e2f19aa106ff4db547104160" />
-	</game>
-	<game name="Chou Kuukan Nighter Pro Yakyuu King (Japan)">
-		<description>Chou Kuukan Nighter Pro Yakyuu King (Japan)</description>
-		<rom name="Chou Kuukan Nighter Pro Yakyuu King (Japan).n64" />
-		<release name="Chou Kuukan Nighter Pro Yakyuu King (Japan)" region="JPN" />
-		<rom name="Chou Kuukan Nighter Pro Yakyuu King (Japan).z64" size="8388608" crc="5f75634e" md5="78838c202c4ff5a460586451ee9182aa" sha1="a08dd769f3b885dc27f4cd14022613d1baa52b84" />
-	</game>
-	<game name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)">
-		<description>Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)</description>
-		<rom name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).n64" />
-		<release name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)" region="JPN" />
-		<rom name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).z64" size="16777216" crc="479643e2" md5="97eab4dc83da0ad2890de2aaaa5d109a" sha1="b8c62befe0a2bd7bcd6efb5f78b34b923b325aac" />
-	</game>
-	<game name="Clay Fighter - Sculptor's Cut (USA)">
-		<description>Clay Fighter - Sculptor's Cut (USA)</description>
-		<rom name="Clay Fighter - Sculptor's Cut (USA).n64" />
-		<release name="Clay Fighter - Sculptor's Cut (USA)" region="USA" />
-		<rom name="Clay Fighter - Sculptor's Cut (USA).z64" size="16777216" crc="434de656" md5="30e7e083b978408d5b7760d0ce4dc61d" sha1="28697fba130ded056bf7c497deaa3e154cce8022" />
-	</game>
-	<game name="Clay Fighter 63 1-3 (Europe)">
-		<description>Clay Fighter 63 1-3 (Europe)</description>
-		<rom name="Clay Fighter 63 1-3 (Europe).n64" />
-		<release name="Clay Fighter 63 1-3 (Europe)" region="EUR" />
-		<rom name="Clay Fighter 63 1-3 (Europe).z64" size="12582912" crc="82263e5d" md5="41965b533f3dd95663361d9df68b0c1f" sha1="fec40ef7d8b973c5937ade10423d0cf1b5a18e3c" />
-	</game>
-	<game name="Clay Fighter 63 1-3 (USA)" cloneof="Clay Fighter 63 1-3 (Europe)">
-		<description>Clay Fighter 63 1-3 (USA)</description>
-		<rom name="Clay Fighter 63 1-3 (USA).n64" />
-		<release name="Clay Fighter 63 1-3 (USA)" region="USA" />
-		<rom name="Clay Fighter 63 1-3 (USA).z64" size="12582912" crc="3fa647dd" md5="3207bf22e305c488109b09a03706f36f" sha1="036873ab0d3107b2d9b3225a180f67daf0899365" status="verified" />
-	</game>
-	<game name="Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21)" cloneof="Clay Fighter 63 1-3 (Europe)">
-		<description>Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21)</description>
-		<rom name="Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21).n64" />
-		<rom name="Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21).z64" size="12582912" crc="18f4166a" md5="cbbeaff5a9074d1a5507cf46cd683d36" sha1="3307f73b8bd0795d3c7036d77fc4a78efebc4ef0" />
-	</game>
-	<game name="Command &amp; Conquer (Europe) (En,Fr)">
-		<description>Command &amp; Conquer (Europe) (En,Fr)</description>
-		<rom name="Command &amp; Conquer (Europe) (En,Fr).n64" />
-		<release name="Command &amp; Conquer (Europe) (En,Fr)" region="EUR" />
-		<rom name="Command &amp; Conquer (Europe) (En,Fr).z64" size="33554432" crc="f3da8a26" md5="42da4c7d040f9e7cd046a42ec3e68027" sha1="0d5211e211e7fc063c63c3e8235b62bc288ce305" status="verified" />
-	</game>
-	<game name="Command &amp; Conquer (Germany)" cloneof="Command &amp; Conquer (Europe) (En,Fr)">
-		<description>Command &amp; Conquer (Germany)</description>
-		<rom name="Command &amp; Conquer (Germany).n64" />
-		<release name="Command &amp; Conquer (Germany)" region="GER" />
-		<rom name="Command &amp; Conquer (Germany).z64" size="33554432" crc="6cd0fc99" md5="1a9195662c89dcbea88bcfa99b096cde" sha1="725083ece68d5deb9724d3fa3f2a65f0291b2d5d" />
-	</game>
-	<game name="Command &amp; Conquer (USA)" cloneof="Command &amp; Conquer (Europe) (En,Fr)">
-		<description>Command &amp; Conquer (USA)</description>
-		<rom name="Command &amp; Conquer (USA).n64" />
-		<release name="Command &amp; Conquer (USA)" region="USA" />
-		<rom name="Command &amp; Conquer (USA).z64" size="33554432" crc="3e9069ef" md5="b436f4717ac585b0d847756468fd6393" sha1="b559e86d98de598b1d25583ca082faa4b7c62641" />
-	</game>
-	<game name="Conker's Bad Fur Day (Europe)">
-		<description>Conker's Bad Fur Day (Europe)</description>
-		<rom name="Conker's Bad Fur Day (Europe).n64" />
-		<release name="Conker's Bad Fur Day (Europe)" region="EUR" />
-		<rom name="Conker's Bad Fur Day (Europe).z64" size="67108864" crc="4667cfe9" md5="05194d49c14e52055df72a54d40791e1" sha1="ee7bc6656fd1e1d9ffb3d19add759f28b88df710" />
-	</game>
-	<game name="Conker's Bad Fur Day (USA)" cloneof="Conker's Bad Fur Day (Europe)">
-		<description>Conker's Bad Fur Day (USA)</description>
-		<rom name="Conker's Bad Fur Day (USA).n64" />
-		<release name="Conker's Bad Fur Day (USA)" region="USA" />
-		<rom name="Conker's Bad Fur Day (USA).z64" size="67108864" crc="ce8cc172" md5="00e2920665f2329b95797a7eaabc2390" sha1="4cbadd3c4e0729dec46af64ad018050eada4f47a" status="verified" />
-	</game>
-	<game name="Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26)" cloneof="Conker's Bad Fur Day (Europe)">
-		<description>Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26)</description>
-		<rom name="Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26).n64" />
-		<rom name="Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26).z64" size="67108864" crc="e1cda95a" md5="13ecbaeef7111d5343d73a80e03e353a" sha1="06597dc935651f8995bfacc30fde6e621d44c3e1" />
-	</game>
-	<game name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25)" cloneof="Conker's Bad Fur Day (Europe)">
-		<description>Conker's Bad Fur Day (USA) (Beta) (2000-10-25)</description>
-		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25).n64" />
-		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25).z64" size="67108864" crc="4f73408c" md5="70e9eb9bf2f7bc76ca38ce450ba01c2e" sha1="3b99222ee76f6277a963142cd807b3df25d5174f" />
-	</game>
-	<game name="Cruis'n Exotica (USA)">
-		<description>Cruis'n Exotica (USA)</description>
-		<rom name="Cruis'n Exotica (USA).n64" />
-		<release name="Cruis'n Exotica (USA)" region="USA" />
-		<rom name="Cruis'n Exotica (USA).z64" size="16777216" crc="867a2ced" md5="db7a03b77d44db81b8a3fcdfc4b72d8c" sha1="428f53a060103fd88ebfbdcc032a99caea901e17" />
-	</game>
-	<game name="Cruis'n USA (Europe)">
-		<description>Cruis'n USA (Europe)</description>
-		<rom name="Cruis'n USA (Europe).n64" />
-		<release name="Cruis'n USA (Europe)" region="EUR" />
-		<rom name="Cruis'n USA (Europe).z64" size="8388608" crc="8935a8d9" md5="69cd5ba6bc9310b9e37ccb1bc6bd16ad" sha1="404ab549cd148ea07f40d66c0b896a343741bbf6" status="verified" />
-	</game>
-	<game name="Cruis'n USA (USA)" cloneof="Cruis'n USA (Europe)">
-		<description>Cruis'n USA (USA)</description>
-		<rom name="Cruis'n USA (USA).n64" />
-		<rom name="Cruis'n USA (USA).z64" size="8388608" crc="5238b727" md5="00a3e885f8d899646228a21d946b2102" sha1="aefe77a5518fe74519908b6cbc97cb81b8570897" />
-	</game>
-	<game name="Cruis'n USA (USA) (Rev 1)" cloneof="Cruis'n USA (Europe)">
-		<description>Cruis'n USA (USA) (Rev 1)</description>
-		<rom name="Cruis'n USA (USA) (Rev 1).n64" />
-		<rom name="Cruis'n USA (USA) (Rev 1).z64" size="8388608" crc="4655ba2d" md5="45fc88e2ba6711f25f0de988e719df29" sha1="71bb3d8850b6a4a294aeca2abad1f936e4f85f0f" />
-	</game>
-	<game name="Cruis'n USA (USA) (Rev 2)" cloneof="Cruis'n USA (Europe)">
-		<description>Cruis'n USA (USA) (Rev 2)</description>
-		<rom name="Cruis'n USA (USA) (Rev 2).n64" />
-		<release name="Cruis'n USA (USA) (Rev 2)" region="USA" />
-		<rom name="Cruis'n USA (USA) (Rev 2).z64" size="8388608" crc="c3b52701" md5="2838a9018ad2bcb8b7f6161c746a1b71" sha1="54a875ee0b482036fa401a6bc2b242699f0259f7" status="verified" />
-	</game>
-	<game name="Cruis'n USA (USA) (Wii Virtual Console)" cloneof="Cruis'n USA (Europe)">
-		<description>Cruis'n USA (USA) (Wii Virtual Console)</description>
-		<rom name="Cruis'n USA (USA) (Wii Virtual Console).n64" />
-		<rom name="Cruis'n USA (USA) (Wii Virtual Console).z64" size="8388608" crc="8fc564f9" md5="41ca21bd737e16ba81168982b74276f1" sha1="273f1d6ddd48f92af49f37e88405f318a340c2cd" />
-	</game>
-	<game name="Cruis'n World (Europe) (Rev 1)">
-		<description>Cruis'n World (Europe) (Rev 1)</description>
-		<rom name="Cruis'n World (Europe) (Rev 1).n64" />
-		<release name="Cruis'n World (Europe) (Rev 1)" region="EUR" />
-		<rom name="Cruis'n World (Europe) (Rev 1).z64" size="12582912" crc="ebaed1f9" md5="20db5e4ddb0cd5b04c4bf09cdc95592f" sha1="362078633d549d3270b3b3b6b0e0d0243321d9ae" />
-	</game>
-	<game name="Cruis'n World (Europe)" cloneof="Cruis'n World (Europe) (Rev 1)">
-		<description>Cruis'n World (Europe)</description>
-		<rom name="Cruis'n World (Europe).n64" />
-		<rom name="Cruis'n World (Europe).z64" size="12582912" crc="e46ce079" md5="af950a1b6c460d7fc3e78375d35047ef" sha1="ee508f14c936265d101c9699b5ae1a722b3e7d9e" />
-	</game>
-	<game name="Cruis'n World (USA)" cloneof="Cruis'n World (Europe) (Rev 1)">
-		<description>Cruis'n World (USA)</description>
-		<rom name="Cruis'n World (USA).n64" />
-		<release name="Cruis'n World (USA)" region="USA" />
-		<rom name="Cruis'n World (USA).z64" size="12582912" crc="a123769f" md5="aada4cbd938e58a447b399a1d46f03e6" sha1="6da1a6a2bda687d50e798d80c342948ad1738202" />
-	</game>
-	<game name="Custom Robo (Japan)">
-		<description>Custom Robo (Japan)</description>
-		<rom name="Custom Robo (Japan).n64" />
-		<release name="Custom Robo (Japan)" region="JPN" />
-		<rom name="Custom Robo (Japan).z64" size="16777216" crc="f2fae693" md5="a06d2e83cf2628915e8847f609474661" sha1="49de08f08400a477485c4798d6cd81d95842c806" />
-	</game>
-	<game name="Zuhe Jiqiren (China) (iQue)" cloneof="Custom Robo (Japan)">
-		<description>Zuhe Jiqiren (China) (iQue)</description>
-		<rom name="Zuhe Jiqiren (China) (iQue).n64" />
-		<rom name="Zuhe Jiqiren (China) (iQue).z64" size="16793600" crc="76742798" md5="33f2bc6847985f96de8177147dcd3b85" sha1="563755afd3cf8d30ec10e100a2e032addf429246" />
-	</game>
-	<game name="Custom Robo V2 (Japan)">
-		<description>Custom Robo V2 (Japan)</description>
-		<rom name="Custom Robo V2 (Japan).n64" />
-		<release name="Custom Robo V2 (Japan)" region="JPN" />
-		<rom name="Custom Robo V2 (Japan).z64" size="16777216" crc="c8201454" md5="115118dd5e0f02d82ba1bf070a7b78f1" sha1="f9515c2482af8df791339536f60260509c424f6a" status="verified" />
-	</game>
-	<game name="CyberTiger (Europe)">
-		<description>CyberTiger (Europe)</description>
-		<rom name="CyberTiger (Europe).n64" />
-		<release name="CyberTiger (Europe)" region="EUR" />
-		<rom name="CyberTiger (Europe).z64" size="16777216" crc="7319d9af" md5="8c4a4cd472d610cda5459b3a92f21d30" sha1="ae220ac1cd6d892098937dc639c925f9ef158759" />
-	</game>
-	<game name="CyberTiger (USA)" cloneof="CyberTiger (Europe)">
-		<description>CyberTiger (USA)</description>
-		<rom name="CyberTiger (USA).n64" />
-		<release name="CyberTiger (USA)" region="USA" />
-		<rom name="CyberTiger (USA).z64" size="16777216" crc="10cc5f15" md5="88072f30d4f9cf384b2b3a0300649218" sha1="14e0635ccc2a80c77fd0a888a2e7977c55c6e129" />
-	</game>
-	<game name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<rom name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="c61f6bb9" md5="1408fcf68b60d845f090107ef355a7e5" sha1="5499b5284c04cee98186e68198d6bfe73fee0cdb" />
-	</game>
-	<game name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)" cloneof="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)</description>
-		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es).n64" />
-		<release name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)" region="USA" />
-		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es).z64" size="16777216" crc="3177a905" md5="02192b4b3797983bbe5e452336584208" sha1="2c840e2991d6a2af63c4efe830240fc49d93fc9a" />
-	</game>
-	<game name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07)" cloneof="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07)</description>
-		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07).n64" />
-		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07).z64" size="33554432" crc="1e48d155" md5="08ce7620b31851cbb05d386fe22c7109" sha1="145e0cb7f3a0e866945631dcf633d31b26c7e6bc" />
-	</game>
-	<game name="Dance Dance Revolution - Disney Dancing Museum (Japan)">
-		<description>Dance Dance Revolution - Disney Dancing Museum (Japan)</description>
-		<rom name="Dance Dance Revolution - Disney Dancing Museum (Japan).n64" />
-		<release name="Dance Dance Revolution - Disney Dancing Museum (Japan)" region="JPN" />
-		<rom name="Dance Dance Revolution - Disney Dancing Museum (Japan).z64" size="33554432" crc="43ee0117" md5="0b86fa9259e2b751111a1701091644b1" sha1="9ada4f62d209fb35c52103f2253ddcc137f90c5d" />
-	</game>
-	<game name="Dark Rift (Europe)">
-		<description>Dark Rift (Europe)</description>
-		<rom name="Dark Rift (Europe).n64" />
-		<release name="Dark Rift (Europe)" region="EUR" />
-		<rom name="Dark Rift (Europe).z64" size="8388608" crc="d2a19c71" md5="4242fde5b74f22aaf5746459e126121f" sha1="18b02fc18411acd770bf3f25b2707669dac2ec5d" status="verified" />
-	</game>
-	<game name="Dark Rift (USA)" cloneof="Dark Rift (Europe)">
-		<description>Dark Rift (USA)</description>
-		<rom name="Dark Rift (USA).n64" />
-		<release name="Dark Rift (USA)" region="USA" />
-		<rom name="Dark Rift (USA).z64" size="8388608" crc="83fd222f" md5="ecb170ebbfda0e932c07524040bcc36c" sha1="3254442626ca2f2ac74400dc1c6a306f5d1b6ceb" />
-	</game>
-	<game name="Space Dynamites (Japan)" cloneof="Dark Rift (Europe)">
-		<description>Space Dynamites (Japan)</description>
-		<rom name="Space Dynamites (Japan).n64" />
-		<release name="Space Dynamites (Japan)" region="JPN" />
-		<rom name="Space Dynamites (Japan).z64" size="8388608" crc="8cb4b948" md5="7f9cdbbb1aaaaf0983c64988ef9c58be" sha1="def172a1b2d17a6ebbbc0551172de4ae46b88e48" />
-	</game>
-	<game name="Densha de Go! 64 (Japan)">
-		<description>Densha de Go! 64 (Japan)</description>
-		<rom name="Densha de Go! 64 (Japan).n64" />
-		<release name="Densha de Go! 64 (Japan)" region="JPN" />
-		<rom name="Densha de Go! 64 (Japan).z64" size="33554432" crc="7bfc71e0" md5="772fa166e5db51effc77fb8d832ac4d2" sha1="5b99d3af55dfd04a5acc11b9d25a3330c1e45708" />
-	</game>
-	<game name="Derby Stallion 64 (Japan)">
-		<description>Derby Stallion 64 (Japan)</description>
-		<rom name="Derby Stallion 64 (Japan).n64" />
-		<release name="Derby Stallion 64 (Japan)" region="JPN" />
-		<rom name="Derby Stallion 64 (Japan).z64" size="33554432" crc="a9417994" md5="7f57463856540104b21a5289312b626f" sha1="9a2b7dfa38fbf9cd07ff676c0e484d7b97db606b" />
-	</game>
-	<game name="Derby Stallion 64 (Japan) (Beta)" cloneof="Derby Stallion 64 (Japan)">
-		<description>Derby Stallion 64 (Japan) (Beta)</description>
-		<rom name="Derby Stallion 64 (Japan) (Beta).n64" />
-		<rom name="Derby Stallion 64 (Japan) (Beta).z64" size="33554432" crc="8ec950a9" md5="1051e1402ee110f3c5e372c9e1c5b338" sha1="bd03f18c456d5db90475dcf1aae2237c82d7446a" />
-	</game>
-	<game name="Destruction Derby 64 (Europe) (En,Fr,De)">
-		<description>Destruction Derby 64 (Europe) (En,Fr,De)</description>
-		<rom name="Destruction Derby 64 (Europe) (En,Fr,De).n64" />
-		<release name="Destruction Derby 64 (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Destruction Derby 64 (Europe) (En,Fr,De).z64" size="16777216" crc="7ad9e429" md5="bda717ecc8434f12f313342485828b58" sha1="eed379520c7fc7d08ebe5a076683bd56f3a0a04f" />
-	</game>
-	<game name="Destruction Derby 64 (USA)" cloneof="Destruction Derby 64 (Europe) (En,Fr,De)">
-		<description>Destruction Derby 64 (USA)</description>
-		<rom name="Destruction Derby 64 (USA).n64" />
-		<release name="Destruction Derby 64 (USA)" region="USA" />
-		<rom name="Destruction Derby 64 (USA).z64" size="16777216" crc="38f1b5d9" md5="7fccb47498eec06e96ae9372247d1e90" sha1="a2c0799e13566d1b723299592cfcac9387f25fa7" />
-	</game>
-	<game name="Dezaemon 3D (Japan)">
-		<description>Dezaemon 3D (Japan)</description>
-		<rom name="Dezaemon 3D (Japan).n64" />
-		<release name="Dezaemon 3D (Japan)" region="JPN" />
-		<rom name="Dezaemon 3D (Japan).z64" size="16777216" crc="9e978488" md5="54be265e7b2c28ab92bf1a4130acb5a2" sha1="1c10a85a2b6a782e6302b19c2387e2d58983a8d4" />
-	</game>
-	<game name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
-		<description>Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)</description>
-		<rom name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1).n64" />
-		<release name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)" region="EUR" />
-		<rom name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1).z64" size="12582912" crc="b1e87639" md5="6b2bafe540e0af052a78e85b992be999" sha1="b7f628073237b3d211d40406aa0884ff8fdd70d5" />
-	</game>
-	<game name="Diddy Kong Racing (Europe) (En,Fr,De)" cloneof="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
-		<description>Diddy Kong Racing (Europe) (En,Fr,De)</description>
-		<rom name="Diddy Kong Racing (Europe) (En,Fr,De).n64" />
-		<rom name="Diddy Kong Racing (Europe) (En,Fr,De).z64" size="12582912" crc="4a13323c" md5="0f0b7b78b345fbf2581d834cb4a81245" sha1="dd5d64dd140cb7aa28404fa35abdcaba33c29260" />
-	</game>
-	<game name="Diddy Kong Racing (Japan)" cloneof="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
-		<description>Diddy Kong Racing (Japan)</description>
-		<rom name="Diddy Kong Racing (Japan).n64" />
-		<release name="Diddy Kong Racing (Japan)" region="JPN" />
-		<rom name="Diddy Kong Racing (Japan).z64" size="12582912" crc="b566fb94" md5="10747662a55241b9234cd114c940504f" sha1="23ba3d302025153d111416e751027cef11213a19" status="verified" />
-	</game>
-	<game name="Diddy Kong Racing (USA) (En,Fr)" cloneof="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
-		<description>Diddy Kong Racing (USA) (En,Fr)</description>
-		<rom name="Diddy Kong Racing (USA) (En,Fr).n64" />
-		<rom name="Diddy Kong Racing (USA) (En,Fr).z64" size="12582912" crc="eb759206" md5="4f0e07f0eeac7e5d7ce3a75461888d03" sha1="0cb115d8716dbbc2922fda38e533b9fe63bb9670" status="verified" />
-	</game>
-	<game name="Diddy Kong Racing (USA) (En,Fr) (Rev 1)" cloneof="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
-		<description>Diddy Kong Racing (USA) (En,Fr) (Rev 1)</description>
-		<rom name="Diddy Kong Racing (USA) (En,Fr) (Rev 1).n64" />
-		<release name="Diddy Kong Racing (USA) (En,Fr) (Rev 1)" region="USA" />
-		<rom name="Diddy Kong Racing (USA) (En,Fr) (Rev 1).z64" size="12582912" crc="5acca298" md5="b31f8cca50f31acc9b999ed5b779d6ed" sha1="6d96743d46f8c0cd0edb0ec5600b003c89b93755" />
-	</game>
-	<game name="Die Hard 64 (USA) (Proto) (Level 1)">
-		<description>Die Hard 64 (USA) (Proto) (Level 1)</description>
-		<rom name="Die Hard 64 (USA) (Proto) (Level 1).n64" />
-		<release name="Die Hard 64 (USA) (Proto) (Level 1)" region="USA" />
-		<rom name="Die Hard 64 (USA) (Proto) (Level 1).z64" size="33554432" crc="5e826037" md5="820929ebbe6fd332ac1720f94b745a8b" sha1="bc384f588c47e7a4c69ca5afd21189919050ae46" />
-	</game>
-	<game name="Die Hard 64 (USA) (Proto) (Level 2)" cloneof="Die Hard 64 (USA) (Proto) (Level 1)">
-		<description>Die Hard 64 (USA) (Proto) (Level 2)</description>
-		<rom name="Die Hard 64 (USA) (Proto) (Level 2).n64" />
-		<rom name="Die Hard 64 (USA) (Proto) (Level 2).z64" size="33554432" crc="d1d593cf" md5="3d1e03b097f2124f8f713013d8219291" sha1="25282d4cb5c41affa4149e8bbb215f48e65bad8e" />
-	</game>
-	<game name="Die Hard 64 (USA) (Proto) (Level 3)" cloneof="Die Hard 64 (USA) (Proto) (Level 1)">
-		<description>Die Hard 64 (USA) (Proto) (Level 3)</description>
-		<rom name="Die Hard 64 (USA) (Proto) (Level 3).n64" />
-		<rom name="Die Hard 64 (USA) (Proto) (Level 3).z64" size="33554432" crc="70943925" md5="1b28c4ca21648d318bc6dd3ef27bb1fa" sha1="0971545144930f221a4350e98866c8cd1ee22af5" />
-	</game>
-	<game name="Dinosaur Planet (USA) (Proto) (2000-12-01)">
-		<description>Dinosaur Planet (USA) (Proto) (2000-12-01)</description>
-		<rom name="Dinosaur Planet (USA) (Proto) (2000-12-01).n64" />
-		<rom name="Dinosaur Planet (USA) (Proto) (2000-12-01).z64" size="67108864" crc="a7daf9fa" md5="49f7bb346ade39d1915c22e090ffd748" sha1="cb9760b49198f7b754593a01c8ed642211caacde" />
-	</game>
-	<game name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)">
-		<description>Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).z64" size="20971520" crc="c4b0d9ea" md5="e8b403a0f0e212fa5c1220af10d9c379" sha1="c42fafb06be6eb7de08370d07f19571b7661074b" />
-	</game>
-	<game name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)" cloneof="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)">
-		<description>Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)</description>
-		<rom name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).n64" />
-		<release name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)" region="USA" />
-		<rom name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).z64" size="20971520" crc="7fdec270" md5="0e0e920ab13ef13508f5a98cc4cd2ff8" sha1="e31a7567d408c890065029ba537f830765b17d94" />
-	</game>
-	<game name="Donkey Kong 64 (Europe) (En,Fr,De,Es)">
-		<description>Donkey Kong 64 (Europe) (En,Fr,De,Es)</description>
-		<rom name="Donkey Kong 64 (Europe) (En,Fr,De,Es).n64" />
-		<release name="Donkey Kong 64 (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Donkey Kong 64 (Europe) (En,Fr,De,Es).z64" size="33554432" crc="a28c71c6" md5="118e9ce360b97a6f8dab2c9f30660bf5" sha1="f96af883845308106600d84e0618c1a066dc6676" status="verified" />
-	</game>
-	<game name="Donkey Kong 64 (Japan)" cloneof="Donkey Kong 64 (Europe) (En,Fr,De,Es)">
-		<description>Donkey Kong 64 (Japan)</description>
-		<rom name="Donkey Kong 64 (Japan).n64" />
-		<release name="Donkey Kong 64 (Japan)" region="JPN" />
-		<rom name="Donkey Kong 64 (Japan).z64" size="33554432" crc="919f7e74" md5="5b677f4bf93d6578252fcad2c8ceb637" sha1="f0ad2b2bbf04d574ed7afbb1bb6a4f0511dcd87d" status="verified" />
-	</game>
-	<game name="Donkey Kong 64 (USA)" cloneof="Donkey Kong 64 (Europe) (En,Fr,De,Es)">
-		<description>Donkey Kong 64 (USA)</description>
-		<rom name="Donkey Kong 64 (USA).n64" />
-		<release name="Donkey Kong 64 (USA)" region="USA" />
-		<rom name="Donkey Kong 64 (USA).z64" size="33554432" crc="d44b4fc6" md5="9ec41abf2519fc386cadd0731f6e868c" sha1="cf806ff2603640a748fca5026ded28802f1f4a50" status="verified" />
-	</game>
-	<game name="Donkey Kong 64 (USA) (Demo) (Kiosk)" cloneof="Donkey Kong 64 (Europe) (En,Fr,De,Es)">
-		<description>Donkey Kong 64 (USA) (Demo) (Kiosk)</description>
-		<rom name="Donkey Kong 64 (USA) (Demo) (Kiosk).n64" />
-		<rom name="Donkey Kong 64 (USA) (Demo) (Kiosk).z64" size="33554432" crc="c83dfa15" md5="98a5836e3a5da7bd0b5819e7498acea2" sha1="b4717e602f07ca9be0d4822813c658cd8b99f993" />
-	</game>
-	<game name="Doom 64 (Europe)">
-		<description>Doom 64 (Europe)</description>
-		<rom name="Doom 64 (Europe).n64" />
-		<release name="Doom 64 (Europe)" region="EUR" />
-		<rom name="Doom 64 (Europe).z64" size="8388608" crc="d985c356" md5="190ccca6526dc4a1f611e3b40f5131c0" sha1="b63060f69bb4e1547da1d762e740d19393977055" />
-	</game>
-	<game name="Doom 64 (Japan)" cloneof="Doom 64 (Europe)">
-		<description>Doom 64 (Japan)</description>
-		<rom name="Doom 64 (Japan).n64" />
-		<release name="Doom 64 (Japan)" region="JPN" />
-		<rom name="Doom 64 (Japan).z64" size="8388608" crc="c8f3af5b" md5="06f15ef2228c1b1147c41dccaa07d9de" sha1="6b0d65e62626a92aa59ee4bff3f02715f6247692" />
-	</game>
-	<game name="Doom 64 (USA)" cloneof="Doom 64 (Europe)">
-		<description>Doom 64 (USA)</description>
-		<rom name="Doom 64 (USA).n64" />
-		<rom name="Doom 64 (USA).z64" size="8388608" crc="5cc1ade6" md5="b67748b64a2cc7efd2f3ad4504561e0e" sha1="799a588d73da3fcce8031026a8187da92b91c817" />
-	</game>
-	<game name="Doom 64 (USA) (Rev 1)" cloneof="Doom 64 (Europe)">
-		<description>Doom 64 (USA) (Rev 1)</description>
-		<rom name="Doom 64 (USA) (Rev 1).n64" />
-		<release name="Doom 64 (USA) (Rev 1)" region="USA" />
-		<rom name="Doom 64 (USA) (Rev 1).z64" size="8388608" crc="1d3a17b5" md5="1b1378bb9ee819f740550f566745af73" sha1="6fb0ce9c75bbe54b6e1ede337652b0221e5f2aad" />
-	</game>
-	<game name="Doraemon - Nobita to 3tsu no Seireiseki (Japan)">
-		<description>Doraemon - Nobita to 3tsu no Seireiseki (Japan)</description>
-		<rom name="Doraemon - Nobita to 3tsu no Seireiseki (Japan).n64" />
-		<release name="Doraemon - Nobita to 3tsu no Seireiseki (Japan)" region="JPN" />
-		<rom name="Doraemon - Nobita to 3tsu no Seireiseki (Japan).z64" size="8388608" crc="154e8b33" md5="c2166455e94e89e9e3ab612b4377c443" sha1="bbeb7b7a92a68b17ca72dcb9d7fb16f7b771c4f6" />
-	</game>
-	<game name="Doraemon 2 - Nobita to Hikari no Shinden (Japan)">
-		<description>Doraemon 2 - Nobita to Hikari no Shinden (Japan)</description>
-		<rom name="Doraemon 2 - Nobita to Hikari no Shinden (Japan).n64" />
-		<release name="Doraemon 2 - Nobita to Hikari no Shinden (Japan)" region="JPN" />
-		<rom name="Doraemon 2 - Nobita to Hikari no Shinden (Japan).z64" size="12582912" crc="0c1a0c38" md5="0580d96a71671c9e6972fdcf5897cc26" sha1="4b187360e1999556662c28b65dd179432ec61f9a" />
-	</game>
-	<game name="Doraemon 3 - Nobita no Machi SOS! (Japan)">
-		<description>Doraemon 3 - Nobita no Machi SOS! (Japan)</description>
-		<rom name="Doraemon 3 - Nobita no Machi SOS! (Japan).n64" />
-		<release name="Doraemon 3 - Nobita no Machi SOS! (Japan)" region="JPN" />
-		<rom name="Doraemon 3 - Nobita no Machi SOS! (Japan).z64" size="16777216" crc="d3b68be4" md5="a4a1d490ba67831775fc381b846e2168" sha1="dd9ba0f6cfc10c3b78401cc55d06ad534f39d5b1" />
-	</game>
-	<game name="Doubutsu no Mori (Japan)">
-		<description>Doubutsu no Mori (Japan)</description>
-		<rom name="Doubutsu no Mori (Japan).n64" />
-		<release name="Doubutsu no Mori (Japan)" region="JPN" />
-		<rom name="Doubutsu no Mori (Japan).z64" size="16777216" crc="9503e3f1" md5="a4f7c57c180297b2e7ba5a5feb44fe0b" sha1="e106dff7146f72415337c96deb14f630e1580efb" />
-	</game>
-	<game name="Dongwu Senlin (China) (iQue)" cloneof="Doubutsu no Mori (Japan)">
-		<description>Dongwu Senlin (China) (iQue)</description>
-		<rom name="Dongwu Senlin (China) (iQue).n64" />
-		<rom name="Dongwu Senlin (China) (iQue).z64" size="16138240" crc="4703c2dd" md5="af83e0cf36298e62e9eb2eb8c89aa710" sha1="b0f25508ccc99551190b86f88da6772942308f85" />
-	</game>
-	<game name="Dr. Mario 64 (USA)">
-		<description>Dr. Mario 64 (USA)</description>
-		<rom name="Dr. Mario 64 (USA).n64" />
-		<release name="Dr. Mario 64 (USA)" region="USA" />
-		<rom name="Dr. Mario 64 (USA).z64" size="4194304" crc="a4701927" md5="1a7936367413e5d6874abda6d623ad32" sha1="a130d3622ce40e0158db2da4247101f6e92206fc" />
-	</game>
-	<game name="Mario Yisheng (China) (iQue)" cloneof="Dr. Mario 64 (USA)">
-		<description>Mario Yisheng (China) (iQue)</description>
-		<rom name="Mario Yisheng (China) (iQue).n64" />
-		<rom name="Mario Yisheng (China) (iQue).z64" size="3358720" crc="61848015" md5="dd291b9c65420fd892107f6c665b7a45" sha1="e396df7729acc70c0e7ab988fca2b75ea167632d" />
-	</game>
-	<game name="Dragon Sword 64 (USA) (Proto) (1999-08-25)">
-		<description>Dragon Sword 64 (USA) (Proto) (1999-08-25)</description>
-		<rom name="Dragon Sword 64 (USA) (Proto) (1999-08-25).n64" />
-		<release name="Dragon Sword 64 (USA) (Proto) (1999-08-25)" region="USA" />
-		<rom name="Dragon Sword 64 (USA) (Proto) (1999-08-25).z64" size="33554432" crc="2296b50d" md5="942fc6737765ac718799a7f66202216c" sha1="4478a6405f61014478bbc35cee3a00ee1515d8ce" />
-	</game>
-	<game name="Dragon Sword 64 (Europe) (Proto)" cloneof="Dragon Sword 64 (USA) (Proto) (1999-08-25)">
-		<description>Dragon Sword 64 (Europe) (Proto)</description>
-		<rom name="Dragon Sword 64 (Europe) (Proto).n64" />
-		<release name="Dragon Sword 64 (Europe) (Proto)" region="EUR" />
-		<rom name="Dragon Sword 64 (Europe) (Proto).z64" size="33554432" crc="55ded416" md5="4d901e4e15f931fd09e803343017ebfe" sha1="e7827a1d0f3e7d222ecab414c260d185f9ef9749" />
-	</game>
-	<game name="Dual Heroes (Europe)">
-		<description>Dual Heroes (Europe)</description>
-		<rom name="Dual Heroes (Europe).n64" />
-		<release name="Dual Heroes (Europe)" region="EUR" />
-		<rom name="Dual Heroes (Europe).z64" size="12582912" crc="5a7e226b" md5="f120fadb52b414eb4fb7d13092ac3cdb" sha1="061b7956c3aadddc6fdc11aab885f95a71b7f463" />
-	</game>
-	<game name="Dual Heroes (Japan)" cloneof="Dual Heroes (Europe)">
-		<description>Dual Heroes (Japan)</description>
-		<rom name="Dual Heroes (Japan).n64" />
-		<release name="Dual Heroes (Japan)" region="JPN" />
-		<rom name="Dual Heroes (Japan).z64" size="12582912" crc="20f23dde" md5="e7652ed5ceceb5b1bc14495c58546d1c" sha1="cfd5992bcc3e0d90966d8a6fc6e0813e75473b14" />
-	</game>
-	<game name="Dual Heroes (USA)" cloneof="Dual Heroes (Europe)">
-		<description>Dual Heroes (USA)</description>
-		<rom name="Dual Heroes (USA).n64" />
-		<release name="Dual Heroes (USA)" region="USA" />
-		<rom name="Dual Heroes (USA).z64" size="12582912" crc="d09f4da8" md5="923d65e69f51858c697e0e5759cd038b" sha1="8fd879ce53e211d33a689015a78cff3fdd39db09" />
-	</game>
-	<game name="Duke Nukem - Zero Hour (Europe)">
-		<description>Duke Nukem - Zero Hour (Europe)</description>
-		<rom name="Duke Nukem - Zero Hour (Europe).n64" />
-		<release name="Duke Nukem - Zero Hour (Europe)" region="EUR" />
-		<rom name="Duke Nukem - Zero Hour (Europe).z64" size="33554432" crc="ea82f037" md5="86e98aaca0d90bf744da090539ba4ad8" sha1="c18ad90fb889f95773fef48c204ce06cff9e6be3" />
-	</game>
-	<game name="Duke Nukem - Zero Hour (France)" cloneof="Duke Nukem - Zero Hour (Europe)">
-		<description>Duke Nukem - Zero Hour (France)</description>
-		<rom name="Duke Nukem - Zero Hour (France).n64" />
-		<release name="Duke Nukem - Zero Hour (France)" region="FRA" />
-		<rom name="Duke Nukem - Zero Hour (France).z64" size="33554432" crc="7ecdfb28" md5="e2b73feb0843874ea831a2e0076fcb72" sha1="e69a4dda8cca88d4c149f2b00640da0ff04fa9c8" />
-	</game>
-	<game name="Duke Nukem - Zero Hour (USA)" cloneof="Duke Nukem - Zero Hour (Europe)">
-		<description>Duke Nukem - Zero Hour (USA)</description>
-		<rom name="Duke Nukem - Zero Hour (USA).n64" />
-		<release name="Duke Nukem - Zero Hour (USA)" region="USA" />
-		<rom name="Duke Nukem - Zero Hour (USA).z64" size="33554432" crc="9a3258d7" md5="026789d47db5fe202a76f89797b33ac7" sha1="de4db292cc6cf5dd1dd1d3c9700cf8e5c3078410" />
-	</game>
-	<game name="Duke Nukem 64 (Europe)">
-		<description>Duke Nukem 64 (Europe)</description>
-		<rom name="Duke Nukem 64 (Europe).n64" />
-		<release name="Duke Nukem 64 (Europe)" region="EUR" />
-		<rom name="Duke Nukem 64 (Europe).z64" size="8388608" crc="3275adb0" md5="8657cba95c409b74c1f5632cbc36643f" sha1="6cc06f6097f90228bd7d7784fa7d20ba17e82eef" status="verified" />
-	</game>
-	<game name="Duke Nukem 64 (France)" cloneof="Duke Nukem 64 (Europe)">
-		<description>Duke Nukem 64 (France)</description>
-		<rom name="Duke Nukem 64 (France).n64" />
-		<release name="Duke Nukem 64 (France)" region="FRA" />
-		<rom name="Duke Nukem 64 (France).z64" size="8388608" crc="b9c9f07a" md5="e2e79c7167bdb26e176d220904739c91" sha1="2c48706c4280a51e52691331543606e4170a19a9" />
-	</game>
-	<game name="Duke Nukem 64 (USA)" cloneof="Duke Nukem 64 (Europe)">
-		<description>Duke Nukem 64 (USA)</description>
-		<rom name="Duke Nukem 64 (USA).n64" />
-		<release name="Duke Nukem 64 (USA)" region="USA" />
-		<rom name="Duke Nukem 64 (USA).z64" size="8388608" crc="dbfd5a53" md5="c7f1a43764a26da2e43f2a36a5f76e4c" sha1="98d6778004becc672eba0a5e887f6e3f3d1b5c15" status="verified" />
-	</game>
-	<game name="Duke Nukem 64 (Europe) (Beta)" cloneof="Duke Nukem 64 (Europe)">
-		<description>Duke Nukem 64 (Europe) (Beta)</description>
-		<rom name="Duke Nukem 64 (Europe) (Beta).n64" />
-		<rom name="Duke Nukem 64 (Europe) (Beta).z64" size="8388608" crc="4a82d036" md5="bb2472b3f8a41fbf3aec3ccef7ea8c78" sha1="bd6ed4a342290eab3d99be392986e085e91315ac" />
-	</game>
-	<game name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)">
-		<description>Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="61a56330" md5="bf2df4b86faa2181a7acfe2643fa2293" sha1="f02c1afd18c1cbe309472cbe5b3b3f04b22db7ee" />
-	</game>
-	<game name="Earthworm Jim 3D (USA)" cloneof="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)">
-		<description>Earthworm Jim 3D (USA)</description>
-		<rom name="Earthworm Jim 3D (USA).n64" />
-		<release name="Earthworm Jim 3D (USA)" region="USA" />
-		<rom name="Earthworm Jim 3D (USA).z64" size="16777216" crc="9e6579c5" md5="980dfb38ad9a883119de135f45b7db36" sha1="eab14f23640cd6148d4888902cdcc00dd6111bf9" />
-	</game>
-	<game name="ECW Hardcore Revolution (Europe)">
-		<description>ECW Hardcore Revolution (Europe)</description>
-		<rom name="ECW Hardcore Revolution (Europe).n64" />
-		<release name="ECW Hardcore Revolution (Europe)" region="EUR" />
-		<rom name="ECW Hardcore Revolution (Europe).z64" size="33554432" crc="be8feead" md5="1830ede2557e8685e6f76d05cc65076a" sha1="226cad0c48e9e0d1dc928298518ca8b2d6eae5ed" status="verified" />
-	</game>
-	<game name="ECW Hardcore Revolution (USA)" cloneof="ECW Hardcore Revolution (Europe)">
-		<description>ECW Hardcore Revolution (USA)</description>
-		<rom name="ECW Hardcore Revolution (USA).n64" />
-		<release name="ECW Hardcore Revolution (USA)" region="USA" />
-		<rom name="ECW Hardcore Revolution (USA).z64" size="33554432" crc="36d368ef" md5="8eebb16b7a4d39ae8bc8cccbc41f0a01" sha1="d460dc1eb24ef3e1e27c6b125c8c8d8324a64125" />
-	</game>
-	<game name="ECW Hardcore Revolution (Germany)" cloneof="ECW Hardcore Revolution (Europe)">
-		<description>ECW Hardcore Revolution (Germany)</description>
-		<rom name="ECW Hardcore Revolution (Germany).n64" />
-		<release name="ECW Hardcore Revolution (Germany)" region="GER" />
-		<rom name="ECW Hardcore Revolution (Germany).z64" size="33554432" crc="e9cf3d9f" md5="5d1e41aa28169e71b4919fa08f1acd9b" sha1="cdabb42be0755d186ad6cae6427fb7c0a12b2e7b" />
-	</game>
-	<game name="Eikou no Saint Andrews (Japan)">
-		<description>Eikou no Saint Andrews (Japan)</description>
-		<rom name="Eikou no Saint Andrews (Japan).n64" />
-		<release name="Eikou no Saint Andrews (Japan)" region="JPN" />
-		<rom name="Eikou no Saint Andrews (Japan).z64" size="8388608" crc="1699d2d6" md5="935dd85ad198bbde92161cdce47cbfb3" sha1="5686b49ac9a60ebfc1d1abf6214f7bc06849abf4" />
-	</game>
-	<game name="Excitebike 64 (Europe)">
-		<description>Excitebike 64 (Europe)</description>
-		<rom name="Excitebike 64 (Europe).n64" />
-		<release name="Excitebike 64 (Europe)" region="EUR" />
-		<rom name="Excitebike 64 (Europe).z64" size="16777216" crc="0b881e60" md5="8fa253fd69b73df9a831ef2f731491f2" sha1="5abfb6024f935ef5fe0067f39fd594c50697c749" />
-	</game>
-	<game name="Excitebike 64 (Japan)" cloneof="Excitebike 64 (Europe)">
-		<description>Excitebike 64 (Japan)</description>
-		<rom name="Excitebike 64 (Japan).n64" />
-		<release name="Excitebike 64 (Japan)" region="JPN" />
-		<rom name="Excitebike 64 (Japan).z64" size="16777216" crc="03bfd065" md5="bf15a61aff71c93bf5e05243f57bca1d" sha1="e2c8d01fc66c0a575e79cb338678f1fd065226d6" />
-	</game>
-	<game name="Excitebike 64 (USA)" cloneof="Excitebike 64 (Europe)">
-		<description>Excitebike 64 (USA)</description>
-		<rom name="Excitebike 64 (USA).n64" />
-		<rom name="Excitebike 64 (USA).z64" size="16777216" crc="fc459192" md5="7200d1c1cf489fafff767729f215e6e6" sha1="a847dd011e98204ad198cadeb6c80dda10d9a40e" />
-	</game>
-	<game name="Excitebike 64 (USA) (Demo) (Kiosk)" cloneof="Excitebike 64 (Europe)">
-		<description>Excitebike 64 (USA) (Demo) (Kiosk)</description>
-		<rom name="Excitebike 64 (USA) (Demo) (Kiosk).n64" />
-		<rom name="Excitebike 64 (USA) (Demo) (Kiosk).z64" size="16777216" crc="be6298b0" md5="e0018c33346714b63a55c0e040f23dea" sha1="daaf564815e9eef3fc163b9546b5880ee256274b" />
-	</game>
-	<game name="Excitebike 64 (USA) (Rev 1)" cloneof="Excitebike 64 (Europe)">
-		<description>Excitebike 64 (USA) (Rev 1)</description>
-		<rom name="Excitebike 64 (USA) (Rev 1).n64" />
-		<release name="Excitebike 64 (USA) (Rev 1)" region="USA" />
-		<rom name="Excitebike 64 (USA) (Rev 1).z64" size="16777216" crc="143926ce" md5="21954e4e404d9e87dbdb87dd309f3e94" sha1="c2fac422af135409c1b38569b309f9d452c81c35" />
-	</game>
-	<game name="Yueye Motuo (China) (iQue)" cloneof="Excitebike 64 (Europe)">
-		<description>Yueye Motuo (China) (iQue)</description>
-		<rom name="Yueye Motuo (China) (iQue).n64" />
-		<rom name="Yueye Motuo (China) (iQue).z64" size="16072704" crc="d7ad44fd" md5="f4b41863440137c6a3ba22942f3e0da2" sha1="e20d95e7c53c3d7ed7857bb89f0c79c94578bb4f" />
-	</game>
-	<game name="Extreme-G (Europe) (En,Fr,De,Es,It)">
-		<description>Extreme-G (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="Extreme-G (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Extreme-G (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Extreme-G (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="0b71b1ea" md5="3b2ca0da0810c95b31df8c1fb8811be2" sha1="e7120856ecc9a7f29c21f45130eca0eca8a7bfec" status="verified" />
-	</game>
-	<game name="Extreme-G (Japan)" cloneof="Extreme-G (Europe) (En,Fr,De,Es,It)">
-		<description>Extreme-G (Japan)</description>
-		<rom name="Extreme-G (Japan).n64" />
-		<release name="Extreme-G (Japan)" region="JPN" />
-		<rom name="Extreme-G (Japan).z64" size="8388608" crc="750dc9a7" md5="a7cd65e5a4a8838d1cd452ba66e74df6" sha1="d9d6f7cc456b530fd3233ef2d8d6b9f845cee043" />
-	</game>
-	<game name="Extreme-G (USA)" cloneof="Extreme-G (Europe) (En,Fr,De,Es,It)">
-		<description>Extreme-G (USA)</description>
-		<rom name="Extreme-G (USA).n64" />
-		<release name="Extreme-G (USA)" region="USA" />
-		<rom name="Extreme-G (USA).z64" size="8388608" crc="04cb74ec" md5="3e660d3f991c0529e90bfec0244db31a" sha1="eb9b273431970a6124319a8fd125f0b2cacd8966" />
-	</game>
-	<game name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)">
-		<description>Extreme-G XG2 (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="1a57f416" md5="bb7f98e657fb4b5fcc7dc04bd72e2d2b" sha1="ca6db450d29a6cc0d4a6fbb3468a1ed725cef51e" />
-	</game>
-	<game name="Extreme-G XG2 (Japan)" cloneof="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)">
-		<description>Extreme-G XG2 (Japan)</description>
-		<rom name="Extreme-G XG2 (Japan).n64" />
-		<release name="Extreme-G XG2 (Japan)" region="JPN" />
-		<rom name="Extreme-G XG2 (Japan).z64" size="12582912" crc="7c8a36da" md5="f17884a2c16fb6fd11a74d65b1388b4a" sha1="94efb5d7247a075a9cc782d39b5e8af56d5f434f" />
-	</game>
-	<game name="Extreme-G XG2 (USA)" cloneof="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)">
-		<description>Extreme-G XG2 (USA)</description>
-		<rom name="Extreme-G XG2 (USA).n64" />
-		<release name="Extreme-G XG2 (USA)" region="USA" />
-		<rom name="Extreme-G XG2 (USA).z64" size="12582912" crc="81a4c28b" md5="44fe06ba3686c02a7988f27600a533da" sha1="ed0a50086ef9a89f5b445c20ab6f365165959630" />
-	</game>
-	<game name="F-1 World Grand Prix (Europe)">
-		<description>F-1 World Grand Prix (Europe)</description>
-		<rom name="F-1 World Grand Prix (Europe).n64" />
-		<release name="F-1 World Grand Prix (Europe)" region="EUR" />
-		<rom name="F-1 World Grand Prix (Europe).z64" size="12582912" crc="1f4e651a" md5="fac450eaff8fa46a1414db02e6eeab9f" sha1="d812098662c4f8f73deb06d140e46a7754ce3b42" />
-	</game>
-	<game name="F-1 World Grand Prix (France)" cloneof="F-1 World Grand Prix (Europe)">
-		<description>F-1 World Grand Prix (France)</description>
-		<rom name="F-1 World Grand Prix (France).n64" />
-		<release name="F-1 World Grand Prix (France)" region="FRA" />
-		<rom name="F-1 World Grand Prix (France).z64" size="12582912" crc="57cd299d" md5="35f6c42d5a9284688284c24250f4d6be" sha1="dd68b3624f2f8a0f821a391b690ecc5bb4fef2fd" />
-	</game>
-	<game name="F-1 World Grand Prix (Germany)" cloneof="F-1 World Grand Prix (Europe)">
-		<description>F-1 World Grand Prix (Germany)</description>
-		<rom name="F-1 World Grand Prix (Germany).n64" />
-		<release name="F-1 World Grand Prix (Germany)" region="GER" />
-		<rom name="F-1 World Grand Prix (Germany).z64" size="12582912" crc="0f1984dc" md5="a8c78454c70bd73375aaf69c4078d5da" sha1="2ae85db9d6e9f3b85e4478577d5eb049ec4040c9" />
-	</game>
-	<game name="F-1 World Grand Prix (Japan)" cloneof="F-1 World Grand Prix (Europe)">
-		<description>F-1 World Grand Prix (Japan)</description>
-		<rom name="F-1 World Grand Prix (Japan).n64" />
-		<release name="F-1 World Grand Prix (Japan)" region="JPN" />
-		<rom name="F-1 World Grand Prix (Japan).z64" size="12582912" crc="f7bacbc3" md5="f248f0aae609111ba9dff9fd7afbc485" sha1="595bfa62ec34f7884ff46137c92771cde4d8d6fe" />
-	</game>
-	<game name="F-1 World Grand Prix (USA)" cloneof="F-1 World Grand Prix (Europe)">
-		<description>F-1 World Grand Prix (USA)</description>
-		<rom name="F-1 World Grand Prix (USA).n64" />
-		<release name="F-1 World Grand Prix (USA)" region="USA" />
-		<rom name="F-1 World Grand Prix (USA).z64" size="12582912" crc="7dc9ef2c" md5="a81b1de864df3f4bb0903760be673f21" sha1="dd17545adc8fe2af2a713ab48c5f71801222edaf" />
-	</game>
-	<game name="F-1 World Grand Prix (Europe) (Beta)" cloneof="F-1 World Grand Prix (Europe)">
-		<description>F-1 World Grand Prix (Europe) (Beta)</description>
-		<rom name="F-1 World Grand Prix (Europe) (Beta).n64" />
-		<rom name="F-1 World Grand Prix (Europe) (Beta).z64" size="12582912" crc="bebbc6c8" md5="9fbe3363da6c146ef2e29605bca834ff" sha1="63bd69c382eca5e569eddf7456f6435a7dce484f" />
-	</game>
-	<game name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es)">
-		<description>F-1 World Grand Prix II (Europe) (En,Fr,De,Es)</description>
-		<rom name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es).n64" />
-		<release name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es).z64" size="12582912" crc="803d33df" md5="bc0fd2468ac7769a37c3c58cd5699585" sha1="53ed343a757b8a14814732393d02b3d780bccab5" />
-	</game>
-	<game name="F-Zero X (Europe)">
-		<description>F-Zero X (Europe)</description>
-		<rom name="F-Zero X (Europe).n64" />
-		<release name="F-Zero X (Europe)" region="EUR" />
-		<rom name="F-Zero X (Europe).z64" size="16777216" crc="2d6f7e8b" md5="ee79a8fe287b5dcaea584439363342fc" sha1="af9038bcb543a2b4faaab876dbdab4663859e092" status="verified" />
-	</game>
-	<game name="F-Zero X (Japan)" cloneof="F-Zero X (Europe)">
-		<description>F-Zero X (Japan)</description>
-		<rom name="F-Zero X (Japan).n64" />
-		<release name="F-Zero X (Japan)" region="JPN" />
-		<rom name="F-Zero X (Japan).z64" size="16777216" crc="6b1cef83" md5="58d200d43620007314304f4e6c9e6528" sha1="a418b0151521b76691fa03f8658c8b567c69498b" status="verified" />
-	</game>
-	<game name="F-Zero X (USA)" cloneof="F-Zero X (Europe)">
-		<description>F-Zero X (USA)</description>
-		<rom name="F-Zero X (USA).n64" />
-		<release name="F-Zero X (USA)" region="USA" />
-		<rom name="F-Zero X (USA).z64" size="16777216" crc="0b561fba" md5="753437d0d8ada1d12f3f9cf0f0a5171f" sha1="5f658e88ffa9de23cba6986a8fd3d3a90d7b4340" status="verified" />
-	</game>
-	<game name="F-Zero X - Weilai Saiche (China) (iQue)" cloneof="F-Zero X (Europe)">
-		<description>F-Zero X - Weilai Saiche (China) (iQue)</description>
-		<rom name="F-Zero X - Weilai Saiche (China) (iQue).n64" />
-		<rom name="F-Zero X - Weilai Saiche (China) (iQue).z64" size="16334848" crc="3d30385a" md5="4024477aaed7dd5ff5ea60bf568123b7" sha1="3c7fa54be9c0124c502f1c8df53765f82d401508" />
-	</game>
-	<game name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)">
-		<description>F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)</description>
-		<rom name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual).n64" />
-		<release name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)" region="CHN" />
-		<rom name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual).z64" size="294912" crc="8ebc6ed5" md5="9729fc397e8d178ea974869e07df0502" sha1="26b4f91a0e2ea2e6994bcdc42b54d8c7e2279d98" />
-	</game>
-	<game name="F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual)" cloneof="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)">
-		<description>F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual)</description>
-		<rom name="F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual).n64" />
-		<rom name="F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual).z64" size="180224" crc="88331ad2" md5="8400c0875e16f599c1b7fc433e339d58" sha1="8199c5b4dec4174bd2ff1c901bb47f356cf16503" />
-	</game>
-	<game name="F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta)">
-		<description>F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta)</description>
-		<rom name="F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta).n64" />
-		<rom name="F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta).z64" size="33554432" crc="68fe1cec" md5="95bf2153aaad6faff3fb42fecd2f0200" sha1="6aa870ec53602650638b50d7c89cac026be481f0" />
-	</game>
-	<game name="F1 Pole Position 64 (Europe) (En,Fr,De)">
-		<description>F1 Pole Position 64 (Europe) (En,Fr,De)</description>
-		<rom name="F1 Pole Position 64 (Europe) (En,Fr,De).n64" />
-		<release name="F1 Pole Position 64 (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="F1 Pole Position 64 (Europe) (En,Fr,De).z64" size="8388608" crc="ed750623" md5="a6bd93ea576cdf8569f68171452f7e8a" sha1="685feb2e8615d5d50944093eb0552858d3e12583" />
-	</game>
-	<game name="F1 Pole Position 64 (USA) (En,Fr,De)" cloneof="F1 Pole Position 64 (Europe) (En,Fr,De)">
-		<description>F1 Pole Position 64 (USA) (En,Fr,De)</description>
-		<rom name="F1 Pole Position 64 (USA) (En,Fr,De).n64" />
-		<release name="F1 Pole Position 64 (USA) (En,Fr,De)" region="USA" />
-		<rom name="F1 Pole Position 64 (USA) (En,Fr,De).z64" size="8388608" crc="30a24d89" md5="049db657f4223d949f56e9dc5b6a9180" sha1="6e6bdaefc9980f066cd2abc5fa7f29f2353ca8b1" />
-	</game>
-	<game name="Human Grand Prix - The New Generation (Japan)" cloneof="F1 Pole Position 64 (Europe) (En,Fr,De)">
-		<description>Human Grand Prix - The New Generation (Japan)</description>
-		<rom name="Human Grand Prix - The New Generation (Japan).n64" />
-		<release name="Human Grand Prix - The New Generation (Japan)" region="JPN" />
-		<rom name="Human Grand Prix - The New Generation (Japan).z64" size="8388608" crc="31e102e3" md5="97e706ed9cc6f30708ffdc187c85d59f" sha1="b8dfe78c7abf1e33edad0b5ecec1c9f1f3c8b576" />
-	</game>
-	<game name="F1 Racing Championship (Europe) (En,Fr,De,Es,It)">
-		<description>F1 Racing Championship (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="F1 Racing Championship (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="F1 Racing Championship (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="F1 Racing Championship (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="2da744f5" md5="9581fc6ceac86dc8a2aee4053043e422" sha1="3bce20f58ef9f377299858b7f2dabd0a02d2e9b9" />
-	</game>
-	<game name="F1 Racing Championship (Brazil) (En,Fr)" cloneof="F1 Racing Championship (Europe) (En,Fr,De,Es,It)">
-		<description>F1 Racing Championship (Brazil) (En,Fr)</description>
-		<rom name="F1 Racing Championship (Brazil) (En,Fr).n64" />
-		<release name="F1 Racing Championship (Brazil) (En,Fr)" region="BRA" />
-		<rom name="F1 Racing Championship (Brazil) (En,Fr).z64" size="16777216" crc="c05b9184" md5="44d5f87127053a21db120bd108b7ac0c" sha1="4c95cee963c9f8b477c41c03afccb3362a14e7ce" />
-	</game>
-	<game name="Famista 64 (Japan)">
-		<description>Famista 64 (Japan)</description>
-		<rom name="Famista 64 (Japan).n64" />
-		<release name="Famista 64 (Japan)" region="JPN" />
-		<rom name="Famista 64 (Japan).z64" size="12582912" crc="9fb0e6c9" md5="d99b1a3f6d72defd76f3620959b94944" sha1="f4acb365c8a0dffdf2e93a726fd5e805ab857c56" />
-	</game>
-	<game name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)">
-		<description>FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)</description>
-		<rom name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).n64" />
-		<release name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)" region="EUR" />
-		<rom name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).z64" size="12582912" crc="137cb3cc" md5="26b18d35984528ae2f90adbb2f2642f7" sha1="676b4d14ad74ccc92ee4b19aa9130ddce42e0e9c" status="verified" />
-	</game>
-	<game name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)" cloneof="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)">
-		<description>FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)</description>
-		<rom name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).n64" />
-		<release name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)" region="USA" />
-		<rom name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).z64" size="12582912" crc="28b1221c" md5="2c6d146a8473511cfcfbbe8518f49d71" sha1="148d6424d2135afefecde74092701c491027c23e" />
-	</game>
-	<game name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)" cloneof="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)">
-		<description>FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)</description>
-		<rom name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).n64" />
-		<release name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)" region="JPN" />
-		<rom name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).z64" size="12582912" crc="ae346df6" md5="3611779f29997267622cbc80e2d087cc" sha1="d8a0c9ef8ff258d061a639e7572d0d9e3038a895" />
-	</game>
-	<game name="FIFA 64 (Europe) (En,Fr,De)">
-		<description>FIFA 64 (Europe) (En,Fr,De)</description>
-		<rom name="FIFA 64 (Europe) (En,Fr,De).n64" />
-		<release name="FIFA 64 (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="FIFA 64 (Europe) (En,Fr,De).z64" size="8388608" crc="ae2583fb" md5="9a7006212947ee7648ee1d13162e55e0" sha1="eacdf23e27ec1e0639042bf03804222851e4f151" />
-	</game>
-	<game name="FIFA Soccer 64 (USA) (En,Fr,De)" cloneof="FIFA 64 (Europe) (En,Fr,De)">
-		<description>FIFA Soccer 64 (USA) (En,Fr,De)</description>
-		<rom name="FIFA Soccer 64 (USA) (En,Fr,De).n64" />
-		<release name="FIFA Soccer 64 (USA) (En,Fr,De)" region="USA" />
-		<rom name="FIFA Soccer 64 (USA) (En,Fr,De).z64" size="8388608" crc="57de7cab" md5="cc7c58a032aaba19e72ccbfa6b3eeff6" sha1="603c5bf64497dca86c4eb802f97f1c32e75a68a8" />
-	</game>
-	<game name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)">
-		<description>FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)</description>
-		<rom name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" />
-		<release name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)" region="EUR" />
-		<rom name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).z64" size="16777216" crc="6eae1e6e" md5="6432c622c05ea9cd3217e280ac2ce37c" sha1="07400c53aef501887f73ef6a45ce04fe2f170fb0" />
-	</game>
-	<game name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)" cloneof="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)">
-		<description>FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)</description>
-		<rom name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" />
-		<release name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)" region="USA" />
-		<rom name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).z64" size="16777216" crc="6b2473a9" md5="148de3073727b9fd156f10afadd46864" sha1="735062e593715f128d3aad435de0e7a899aed127" />
-	</game>
-	<game name="Fighter Destiny 2 (USA)">
-		<description>Fighter Destiny 2 (USA)</description>
-		<rom name="Fighter Destiny 2 (USA).n64" />
-		<release name="Fighter Destiny 2 (USA)" region="USA" />
-		<rom name="Fighter Destiny 2 (USA).z64" size="16777216" crc="bb2563c6" md5="04dd2a319f4f5c22569b612cfdf9f00c" sha1="1dc12cfd908f56debcad6cf582bfdfc23a3ad725" />
-	</game>
-	<game name="Kakutou Denshou - F-Cup Maniax (Japan)" cloneof="Fighter Destiny 2 (USA)">
-		<description>Kakutou Denshou - F-Cup Maniax (Japan)</description>
-		<rom name="Kakutou Denshou - F-Cup Maniax (Japan).n64" />
-		<release name="Kakutou Denshou - F-Cup Maniax (Japan)" region="JPN" />
-		<rom name="Kakutou Denshou - F-Cup Maniax (Japan).z64" size="16777216" crc="db40a155" md5="dff0efe2b35fcde506d21b0c0bd373a5" sha1="f88f541d5913c99a9eac5ca4162e65b8a3828725" />
-	</game>
-	<game name="Fighters Destiny (Europe)">
-		<description>Fighters Destiny (Europe)</description>
-		<rom name="Fighters Destiny (Europe).n64" />
-		<release name="Fighters Destiny (Europe)" region="EUR" />
-		<rom name="Fighters Destiny (Europe).z64" size="12582912" crc="c9225511" md5="ef5cb24ce3fe4e0f850901205437b574" sha1="2763731085a9d86d357d8fef775c2d21d3c9f2b4" />
-	</game>
-	<game name="Fighters Destiny (France)" cloneof="Fighters Destiny (Europe)">
-		<description>Fighters Destiny (France)</description>
-		<rom name="Fighters Destiny (France).n64" />
-		<release name="Fighters Destiny (France)" region="FRA" />
-		<rom name="Fighters Destiny (France).z64" size="12582912" crc="0cc22034" md5="44b0be1c4b48f6119d3ac9424903d0eb" sha1="28c6486f4036295284a022b6d70d3bc2f64b20e8" />
-	</game>
-	<game name="Fighters Destiny (Germany)" cloneof="Fighters Destiny (Europe)">
-		<description>Fighters Destiny (Germany)</description>
-		<rom name="Fighters Destiny (Germany).n64" />
-		<release name="Fighters Destiny (Germany)" region="GER" />
-		<rom name="Fighters Destiny (Germany).z64" size="12582912" crc="5052168c" md5="1cf379aca2397222af9f3dc5d8e3c444" sha1="aef7792324c262c956e91ee01f57bed0c36bd825" />
-	</game>
-	<game name="Fighters Destiny (USA)" cloneof="Fighters Destiny (Europe)">
-		<description>Fighters Destiny (USA)</description>
-		<rom name="Fighters Destiny (USA).n64" />
-		<release name="Fighters Destiny (USA)" region="USA" />
-		<rom name="Fighters Destiny (USA).z64" size="12582912" crc="f45ea789" md5="d61d97a7658c419a25a9bac96b0a3df8" sha1="f87e1677602e38bac962424042e289ec58ec37b2" />
-	</game>
-	<game name="Fighting Cup (Japan)" cloneof="Fighters Destiny (Europe)">
-		<description>Fighting Cup (Japan)</description>
-		<rom name="Fighting Cup (Japan).n64" />
-		<release name="Fighting Cup (Japan)" region="JPN" />
-		<rom name="Fighting Cup (Japan).z64" size="12582912" crc="8a1c261e" md5="722c3a74a90305d6079a37994cebf5b2" sha1="011bdbaa1bc6d6a5540a749cf1a90bf6a35fd94b" />
-	</game>
-	<game name="Fighting Force 64 (Europe)">
-		<description>Fighting Force 64 (Europe)</description>
-		<rom name="Fighting Force 64 (Europe).n64" />
-		<release name="Fighting Force 64 (Europe)" region="EUR" />
-		<rom name="Fighting Force 64 (Europe).z64" size="16777216" crc="4052c176" md5="0035e8205336982e362402aaea37d147" sha1="705d2b553fab526c908e46c048be3a3338ae2a86" />
-	</game>
-	<game name="Fighting Force 64 (USA)" cloneof="Fighting Force 64 (Europe)">
-		<description>Fighting Force 64 (USA)</description>
-		<rom name="Fighting Force 64 (USA).n64" />
-		<release name="Fighting Force 64 (USA)" region="USA" />
-		<rom name="Fighting Force 64 (USA).z64" size="16777216" crc="8456841e" md5="e7008d17fd71d9c2bda1362c885388b2" sha1="6b4e78201ad5c5d0bd932652f233d9732316cdc2" />
-	</game>
-	<game name="Flying Dragon (Europe)">
-		<description>Flying Dragon (Europe)</description>
-		<rom name="Flying Dragon (Europe).n64" />
-		<release name="Flying Dragon (Europe)" region="EUR" />
-		<rom name="Flying Dragon (Europe).z64" size="12582912" crc="c3066e59" md5="add115aad0ab7d33bfd243936d809178" sha1="3f4462d85d5b5ddc6edaeef45b682eeff7f4b144" />
-	</game>
-	<game name="Flying Dragon (USA)" cloneof="Flying Dragon (Europe)">
-		<description>Flying Dragon (USA)</description>
-		<rom name="Flying Dragon (USA).n64" />
-		<release name="Flying Dragon (USA)" region="USA" />
-		<rom name="Flying Dragon (USA).z64" size="12582912" crc="91bc9aeb" md5="272b359d8f8ac48acbf053c262f422e4" sha1="5472fe1dcaaacaecba8d1bed8eab4a2146e58665" />
-	</game>
-	<game name="Hiryuu no Ken Twin (Japan)" cloneof="Flying Dragon (Europe)">
-		<description>Hiryuu no Ken Twin (Japan)</description>
-		<rom name="Hiryuu no Ken Twin (Japan).n64" />
-		<release name="Hiryuu no Ken Twin (Japan)" region="JPN" />
-		<rom name="Hiryuu no Ken Twin (Japan).z64" size="12582912" crc="ba6a687e" md5="73084495f3209c54900525436bbbc531" sha1="c7a76b061c383600378e52a39dada8d2be58325b" status="verified" />
-	</game>
-	<game name="Forsaken (Europe) (En,Fr,Es,It)">
-		<description>Forsaken (Europe) (En,Fr,Es,It)</description>
-		<rom name="Forsaken (Europe) (En,Fr,Es,It).n64" />
-		<release name="Forsaken (Europe) (En,Fr,Es,It)" region="EUR" />
-		<rom name="Forsaken (Europe) (En,Fr,Es,It).z64" size="8388608" crc="5ed736d9" md5="8286ded701dfa22436d311bd5b93bd29" sha1="ac24c6e48fcd03c32aef484188ba842b619ff613" status="verified" />
-	</game>
-	<game name="Forsaken (Germany)" cloneof="Forsaken (Europe) (En,Fr,Es,It)">
-		<description>Forsaken (Germany)</description>
-		<rom name="Forsaken (Germany).n64" />
-		<release name="Forsaken (Germany)" region="GER" />
-		<rom name="Forsaken (Germany).z64" size="8388608" crc="9793abc2" md5="74650f7154e0b2dd7c364f511b0d6a77" sha1="f1be08780d117c44fc10a0dba792d6c5be7d4093" />
-	</game>
-	<game name="Forsaken 64 (USA)" cloneof="Forsaken (Europe) (En,Fr,Es,It)">
-		<description>Forsaken 64 (USA)</description>
-		<rom name="Forsaken 64 (USA).n64" />
-		<release name="Forsaken 64 (USA)" region="USA" />
-		<rom name="Forsaken 64 (USA).z64" size="8388608" crc="76c4333d" md5="5cdee5503a57d14533c66b35a5848899" sha1="7c670b224acfa960df902c866febb679806cb3fb" />
-	</game>
-	<game name="Fox Sports College Hoops '99 (USA)">
-		<description>Fox Sports College Hoops '99 (USA)</description>
-		<rom name="Fox Sports College Hoops '99 (USA).n64" />
-		<release name="Fox Sports College Hoops '99 (USA)" region="USA" />
-		<rom name="Fox Sports College Hoops '99 (USA).z64" size="12582912" crc="67eaf0f3" md5="360dc6be6d06dca12e53c077ac0d2571" sha1="a8ce01a7d6d01be19ffb87cb54cc069494efb596" />
-	</game>
-	<game name="Freak Boy (Unknown) (Proto)">
-		<description>Freak Boy (Unknown) (Proto)</description>
-		<rom name="Freak Boy (Unknown) (Proto).n64" />
-		<rom name="Freak Boy (Unknown) (Proto).z64" size="16777216" crc="40632bec" md5="19d8cc329244f73f9a0e0750e3688d58" sha1="9326914cd8271e220d6289837f8780f63f98ef30" />
-	</game>
-	<game name="Frogger 2 (USA) (Proto 2)">
-		<description>Frogger 2 (USA) (Proto 2)</description>
-		<rom name="Frogger 2 (USA) (Proto 2).n64" />
-		<release name="Frogger 2 (USA) (Proto 2)" region="USA" />
-		<rom name="Frogger 2 (USA) (Proto 2).z64" size="33554432" crc="a8f81f39" md5="27f61a55e27ea7f1ede4ca11966acc7c" sha1="412d60ec37b71621368fe1885272f74385a7c5a3" />
-	</game>
-	<game name="Frogger 2 (USA) (Proto 1)" cloneof="Frogger 2 (USA) (Proto 2)">
-		<description>Frogger 2 (USA) (Proto 1)</description>
-		<rom name="Frogger 2 (USA) (Proto 1).n64" />
-		<rom name="Frogger 2 (USA) (Proto 1).z64" size="33554432" crc="8d62268e" md5="097189b4c9bf6775e4685951b6e66f24" sha1="637cafe4abdc3fc0ef0703e3a47ea6a633b16fa3" />
-	</game>
-	<game name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)">
-		<description>Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)</description>
-		<rom name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).n64" />
-		<release name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)" region="JPN" />
-		<rom name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).z64" size="33554432" crc="2aa6d2a1" md5="bbcde4966bee5602a80d9b8c1011dfa6" sha1="f97b070a1fa6ab3d190b36d6b68a2ef182d35233" />
-	</game>
-	<game name="G.A.S.P!! Fighters' NEXTream (Europe)">
-		<description>G.A.S.P!! Fighters' NEXTream (Europe)</description>
-		<rom name="G.A.S.P!! Fighters' NEXTream (Europe).n64" />
-		<release name="G.A.S.P!! Fighters' NEXTream (Europe)" region="EUR" />
-		<rom name="G.A.S.P!! Fighters' NEXTream (Europe).z64" size="12582912" crc="5aa63b04" md5="316c59dae45c20250a0419a937e7d65b" sha1="b069f2c0b6ab4fbd486861c4d3aaf8a149ab4529" />
-	</game>
-	<game name="Deadly Arts (USA)" cloneof="G.A.S.P!! Fighters' NEXTream (Europe)">
-		<description>Deadly Arts (USA)</description>
-		<rom name="Deadly Arts (USA).n64" />
-		<release name="Deadly Arts (USA)" region="USA" />
-		<rom name="Deadly Arts (USA).z64" size="12582912" crc="3db8130e" md5="a2a4a0318dab366a595336b6f80ff3ab" sha1="aa8566669575e3fea05daf5688d4fe05df735cd9" />
-	</game>
-	<game name="G.A.S.P!! Fighters' NEXTream (Japan)" cloneof="G.A.S.P!! Fighters' NEXTream (Europe)">
-		<description>G.A.S.P!! Fighters' NEXTream (Japan)</description>
-		<rom name="G.A.S.P!! Fighters' NEXTream (Japan).n64" />
-		<release name="G.A.S.P!! Fighters' NEXTream (Japan)" region="JPN" />
-		<rom name="G.A.S.P!! Fighters' NEXTream (Japan).z64" size="12582912" crc="6ead2d89" md5="6c73558de5a1eee6597d7264f9a11b0c" sha1="86693e6c1623708438ebf23ab0e78dd6ea8c8fa7" />
-	</game>
-	<game name="GameBooster 64 (Europe) (v1.1) (Unl)">
-		<description>GameBooster 64 (Europe) (v1.1) (Unl)</description>
-		<rom name="GameBooster 64 (Europe) (v1.1) (Unl).z64" />
-		<rom name="GameBooster 64 (Europe) (v1.1) (Unl).n64" />
-		<release name="GameBooster 64 (Europe) (v1.1) (Unl)" region="EUR" />
-		<rom name="GameBooster 64 (Europe) (v1.1) (Unl).bin" size="262144" crc="35b99bd9" md5="1a56fe2b2fe339c7dd4ff8d37ec8654b" sha1="d79ee0482443c046b9e865a78f3d4507b7478af4" />
-	</game>
-	<game name="GameBooster 64 (USA) (v1.1) (Unl)" cloneof="GameBooster 64 (Europe) (v1.1) (Unl)">
-		<description>GameBooster 64 (USA) (v1.1) (Unl)</description>
-		<rom name="GameBooster 64 (USA) (v1.1) (Unl).z64" />
-		<rom name="GameBooster 64 (USA) (v1.1) (Unl).n64" />
-		<release name="GameBooster 64 (USA) (v1.1) (Unl)" region="USA" />
-		<rom name="GameBooster 64 (USA) (v1.1) (Unl).bin" size="262144" crc="e0b8edae" md5="60d0264b38e22ef0d6b9549e4c81c29f" sha1="5d0f244584d6cc0b0ced714409412f61de181e57" />
-	</game>
-	<game name="Gauntlet Legends (Europe)">
-		<description>Gauntlet Legends (Europe)</description>
-		<rom name="Gauntlet Legends (Europe).n64" />
-		<release name="Gauntlet Legends (Europe)" region="EUR" />
-		<rom name="Gauntlet Legends (Europe).z64" size="16777216" crc="b7b3a489" md5="28c2108a375f7731e719333a09439d2f" sha1="29f19e0405dca66c7383fb94104a22758a9d06dd" />
-	</game>
-	<game name="Gauntlet Legends (Japan)" cloneof="Gauntlet Legends (Europe)">
-		<description>Gauntlet Legends (Japan)</description>
-		<rom name="Gauntlet Legends (Japan).n64" />
-		<release name="Gauntlet Legends (Japan)" region="JPN" />
-		<rom name="Gauntlet Legends (Japan).z64" size="16777216" crc="8d133db0" md5="3b2615d754a61e45b1034d555d830a78" sha1="8389b01e5872053f1f39bc586db9fa012d46c5fa" />
-	</game>
-	<game name="Gauntlet Legends (USA)" cloneof="Gauntlet Legends (Europe)">
-		<description>Gauntlet Legends (USA)</description>
-		<rom name="Gauntlet Legends (USA).n64" />
-		<release name="Gauntlet Legends (USA)" region="USA" />
-		<rom name="Gauntlet Legends (USA).z64" size="16777216" crc="64765e82" md5="9cb963e8b71f18568f78ec1af120362e" sha1="0489dcce749c6a5102681d288ed0616a4b94e99d" />
-	</game>
-	<game name="Getter Love!! - Cho Renai Party Game Tanjou (Japan)">
-		<description>Getter Love!! - Cho Renai Party Game Tanjou (Japan)</description>
-		<rom name="Getter Love!! - Cho Renai Party Game Tanjou (Japan).n64" />
-		<release name="Getter Love!! - Cho Renai Party Game Tanjou (Japan)" region="JPN" />
-		<rom name="Getter Love!! - Cho Renai Party Game Tanjou (Japan).z64" size="12582912" crc="724ecae7" md5="5270d98f9e67dc7ef354ece109c2a18f" sha1="942d161abf00b612486388eee98a2c51fc990147" />
-	</game>
-	<game name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)">
-		<description>Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)</description>
-		<rom name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).n64" />
-		<release name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)" region="EUR" />
-		<rom name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).z64" size="33554432" crc="6bc4a056" md5="9f0492a34d7a2d7c4e9f29dc1848a04a" sha1="54653ba26a12521ccd886212fffdf2f6427c2fea" />
-	</game>
-	<game name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" cloneof="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)">
-		<description>Gex 3 - Deep Cover Gecko (Europe) (Fr,De)</description>
-		<rom name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De).n64" />
-		<release name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" region="FRA" />
-		<release name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" region="GER" />
-		<rom name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De).z64" size="33554432" crc="a43cb8e4" md5="43b9a7a5ccb6ea3f4860f9f80d73669d" sha1="4bcd958526d9145acf4e3ee7ee484e62dc1bb4ba" />
-	</game>
-	<game name="Gex 3 - Deep Cover Gecko (USA)" cloneof="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)">
-		<description>Gex 3 - Deep Cover Gecko (USA)</description>
-		<rom name="Gex 3 - Deep Cover Gecko (USA).n64" />
-		<release name="Gex 3 - Deep Cover Gecko (USA)" region="USA" />
-		<rom name="Gex 3 - Deep Cover Gecko (USA).z64" size="33554432" crc="87a7d099" md5="6770ddec84eb21a5e0d0f55dfd52a01a" sha1="467bc88942e02d542e1a4705dcab98ab7281819f" />
-	</game>
-	<game name="Gex 64 - Enter the Gecko (Europe)">
-		<description>Gex 64 - Enter the Gecko (Europe)</description>
-		<rom name="Gex 64 - Enter the Gecko (Europe).n64" />
-		<release name="Gex 64 - Enter the Gecko (Europe)" region="EUR" />
-		<rom name="Gex 64 - Enter the Gecko (Europe).z64" size="16777216" crc="a7c92bea" md5="5bba457e286d250101ce274e0e58080d" sha1="c5318e2660fed61782bb170e780b89305aa8c3dc" />
-	</game>
-	<game name="Gex 64 - Enter the Gecko (USA)" cloneof="Gex 64 - Enter the Gecko (Europe)">
-		<description>Gex 64 - Enter the Gecko (USA)</description>
-		<rom name="Gex 64 - Enter the Gecko (USA).n64" />
-		<release name="Gex 64 - Enter the Gecko (USA)" region="USA" />
-		<rom name="Gex 64 - Enter the Gecko (USA).z64" size="16777216" crc="c545ce80" md5="47f9d900c97ece154bb40a9c6dccd3fd" sha1="16042cd0dfa5439ca436f1bf05ebfb7e9f730cda" />
-	</game>
-	<game name="Glover (Europe) (En,Fr,De)">
-		<description>Glover (Europe) (En,Fr,De)</description>
-		<rom name="Glover (Europe) (En,Fr,De).n64" />
-		<release name="Glover (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Glover (Europe) (En,Fr,De).z64" size="8388608" crc="90eceb4a" md5="2f2163c53db135792331df00398b3f87" sha1="a5209925761c4ef08e5d446a55bc957505308a31" status="verified" />
-	</game>
-	<game name="Glover (USA)" cloneof="Glover (Europe) (En,Fr,De)">
-		<description>Glover (USA)</description>
-		<rom name="Glover (USA).n64" />
-		<release name="Glover (USA)" region="USA" />
-		<rom name="Glover (USA).z64" size="8388608" crc="f874571c" md5="87aa5740dff79291ee97832da1f86205" sha1="270be17b3c8da9b88a7b99c2a545b0bce16837f4" />
-	</game>
-	<game name="Glover (USA) (Beta) (1998-07-16)" cloneof="Glover (Europe) (En,Fr,De)">
-		<description>Glover (USA) (Beta) (1998-07-16)</description>
-		<rom name="Glover (USA) (Beta) (1998-07-16).n64" />
-		<rom name="Glover (USA) (Beta) (1998-07-16).z64" size="67108864" crc="7a866221" md5="43c3375bbd6496b6c51d08ec193bc8ed" sha1="a60bb3856218b554beee25d30dcf05e6d0308f52" />
-	</game>
-	<game name="Glover (USA) (Rev 1) (Proto)" cloneof="Glover (Europe) (En,Fr,De)">
-		<description>Glover (USA) (Rev 1) (Proto)</description>
-		<rom name="Glover (USA) (Rev 1) (Proto).n64" />
-		<rom name="Glover (USA) (Rev 1) (Proto).z64" size="25165824" crc="5e091e8f" md5="9cc14c73eb1202c3d19633ee05ad5fc4" sha1="3da3074fe998dbc6c47791a5b6dcbb5143b0fad8" />
-	</game>
-	<game name="Whack 'n' Roll (Unknown) (Beta) (1998-02-05)" cloneof="Glover (Europe) (En,Fr,De)">
-		<description>Whack 'n' Roll (Unknown) (Beta) (1998-02-05)</description>
-		<rom name="Whack 'n' Roll (Unknown) (Beta) (1998-02-05).z64" />
-		<rom name="Whack 'n' Roll (Unknown) (Beta) (1998-02-05).n64" size="3823288" crc="74df67bb" md5="aab9c595a91b9f26e12cae2ff2649881" sha1="1d8f3b0cc37dc357cddc8075fc749bc7d66b5331" />
-	</game>
-	<game name="Glover 2 (USA) (Proto 2)">
-		<description>Glover 2 (USA) (Proto 2)</description>
-		<rom name="Glover 2 (USA) (Proto 2).n64" />
-		<release name="Glover 2 (USA) (Proto 2)" region="USA" />
-		<rom name="Glover 2 (USA) (Proto 2).z64" size="33554432" crc="400aecc7" md5="a8567ddabd3672fff18bc5df933cf8c7" sha1="9e2d87385cf0b3b250222bc5e5ffc2750e13393b" />
-	</game>
-	<game name="Glover 2 (USA) (Proto 1)" cloneof="Glover 2 (USA) (Proto 2)">
-		<description>Glover 2 (USA) (Proto 1)</description>
-		<rom name="Glover 2 (USA) (Proto 1).n64" />
-		<rom name="Glover 2 (USA) (Proto 1).z64" size="33554432" crc="d0809afb" md5="4e15d92cca23e1a01bb65246431b5c5a" sha1="58750c5fb47e35badd41eaf748cc9cdb3b24f64a" />
-	</game>
-	<game name="Goemon - Mononoke Sugoroku (Japan)">
-		<description>Goemon - Mononoke Sugoroku (Japan)</description>
-		<rom name="Goemon - Mononoke Sugoroku (Japan).n64" />
-		<release name="Goemon - Mononoke Sugoroku (Japan)" region="JPN" />
-		<rom name="Goemon - Mononoke Sugoroku (Japan).z64" size="16777216" crc="965c4575" md5="2bde49f2855030de342976c9a95b81b3" sha1="accc27a72e9bd8bcac011009a08df7f7aae3b2fe" />
-	</game>
-	<game name="Golden Nugget 64 (USA)">
-		<description>Golden Nugget 64 (USA)</description>
-		<rom name="Golden Nugget 64 (USA).n64" />
-		<release name="Golden Nugget 64 (USA)" region="USA" />
-		<rom name="Golden Nugget 64 (USA).z64" size="8388608" crc="70594d3c" md5="231bac1afb3de138072c2d697783059b" sha1="1c0b0e11804585a17fe1f8776cf5744963d5e2d7" />
-	</game>
-	<game name="GoldenEye 007 (Europe)">
-		<description>GoldenEye 007 (Europe)</description>
-		<rom name="GoldenEye 007 (Europe).n64" />
-		<release name="GoldenEye 007 (Europe)" region="EUR" />
-		<rom name="GoldenEye 007 (Europe).z64" size="12582912" crc="9ec14aeb" md5="cff69b70a8ad674a0efe5558765855c9" sha1="167c3c433dec1f1eb921736f7d53fac8cb45ee31" status="verified" />
-	</game>
-	<game name="GoldenEye 007 (Japan)" cloneof="GoldenEye 007 (Europe)">
-		<description>GoldenEye 007 (Japan)</description>
-		<rom name="GoldenEye 007 (Japan).n64" />
-		<release name="GoldenEye 007 (Japan)" region="JPN" />
-		<rom name="GoldenEye 007 (Japan).z64" size="12582912" crc="a6be19dd" md5="1880da358f875c0740d4a6731e110109" sha1="2a5dade32f7fad6c73c659d2026994632c1b3174" />
-	</game>
-	<game name="GoldenEye 007 (USA)" cloneof="GoldenEye 007 (Europe)">
-		<description>GoldenEye 007 (USA)</description>
-		<rom name="GoldenEye 007 (USA).n64" />
-		<release name="GoldenEye 007 (USA)" region="USA" />
-		<rom name="GoldenEye 007 (USA).z64" size="12582912" crc="b6330846" md5="70c525880240c1e838b8b1be35666c3b" sha1="abe01e4aeb033b6c0836819f549c791b26cfde83" status="verified" />
-	</game>
-	<game name="GT 64 - Championship Edition (Europe) (En,Fr,De)">
-		<description>GT 64 - Championship Edition (Europe) (En,Fr,De)</description>
-		<rom name="GT 64 - Championship Edition (Europe) (En,Fr,De).n64" />
-		<release name="GT 64 - Championship Edition (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="GT 64 - Championship Edition (Europe) (En,Fr,De).z64" size="12582912" crc="6dfb4747" md5="628aa3cd492559b705488f634797e045" sha1="a4d0d694f521cef69f64acaee3eb420a64f28e4d" status="verified" />
-	</game>
-	<game name="City-Tour GP - Zen-Nihon GT Senshuken (Japan)" cloneof="GT 64 - Championship Edition (Europe) (En,Fr,De)">
-		<description>City-Tour GP - Zen-Nihon GT Senshuken (Japan)</description>
-		<rom name="City-Tour GP - Zen-Nihon GT Senshuken (Japan).n64" />
-		<release name="City-Tour GP - Zen-Nihon GT Senshuken (Japan)" region="JPN" />
-		<rom name="City-Tour GP - Zen-Nihon GT Senshuken (Japan).z64" size="16777216" crc="e272bdf6" md5="2a0bf5a9a136d57af01d199b16899634" sha1="2b543707f5bdba52a49d71755615d6cf38e23e76" />
-	</game>
-	<game name="GT 64 - Championship Edition (USA)" cloneof="GT 64 - Championship Edition (Europe) (En,Fr,De)">
-		<description>GT 64 - Championship Edition (USA)</description>
-		<rom name="GT 64 - Championship Edition (USA).n64" />
-		<release name="GT 64 - Championship Edition (USA)" region="USA" />
-		<rom name="GT 64 - Championship Edition (USA).z64" size="12582912" crc="bc627da7" md5="fe81aa381719fada693d803bae7d5eb9" sha1="b941246af78748f4e081f496dac0a9e2056d3d8d" />
-	</game>
-	<game name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25)" cloneof="GT 64 - Championship Edition (Europe) (En,Fr,De)">
-		<description>GT 64 - Championship Edition (USA) (Beta) (1998-05-25)</description>
-		<rom name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25).n64" />
-		<rom name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25).z64" size="16777216" crc="191bf504" md5="4690cab33d0bc10b62d62cecdcaa50a1" sha1="6b58306825ef85a3a128dd5bc0bc0c21f517b3a2" />
-	</game>
-	<game name="Hamster Monogatari 64 (Japan)">
-		<description>Hamster Monogatari 64 (Japan)</description>
-		<rom name="Hamster Monogatari 64 (Japan).n64" />
-		<release name="Hamster Monogatari 64 (Japan)" region="JPN" />
-		<rom name="Hamster Monogatari 64 (Japan).z64" size="12582912" crc="c1d98b78" md5="3d4c7b11076bafa4620bcc154c0eeef3" sha1="436627174830fb9941bd4f25efa6fa1024498a97" />
-	</game>
-	<game name="Harukanaru Augusta - Masters '98 (Japan)">
-		<description>Harukanaru Augusta - Masters '98 (Japan)</description>
-		<rom name="Harukanaru Augusta - Masters '98 (Japan).n64" />
-		<release name="Harukanaru Augusta - Masters '98 (Japan)" region="JPN" />
-		<rom name="Harukanaru Augusta - Masters '98 (Japan).z64" size="16777216" crc="51228f0c" md5="a02a4fb4b93e9847348440652cef8d4d" sha1="08af498bca98c79e3fa18c9c860091d5eb952e6e" />
-	</game>
-	<game name="Harvest Moon 64 (USA)">
-		<description>Harvest Moon 64 (USA)</description>
-		<rom name="Harvest Moon 64 (USA).n64" />
-		<release name="Harvest Moon 64 (USA)" region="USA" />
-		<rom name="Harvest Moon 64 (USA).z64" size="16777216" crc="decdc0ad" md5="6da848a70d83ece130d274124760928e" sha1="90631460f1876a14849df0541d534012b410a34c" />
-	</game>
-	<game name="Bokujou Monogatari 2 (Japan)" cloneof="Harvest Moon 64 (USA)">
+		<rom name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan).z64" size="16777216" crc="ff009c21" md5="47ea239717c4d225c9d0e9fd37b9fcb3" sha1="50439acb5784bea3a4bbba5188c2aeaa1442099d" sha256="51a0443883f3f94b20b6fb9a8688631c51bc7feafb143c51e48dc7198adfd1ca" serial="ND4J" />
+	</game>
+	<game name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It)" id="0034">
+		<description>All Star Tennis '99 (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="996e845f" md5="e3f4c868917a12bd5e84d94d1c260c7d" sha1="09ddbd45f4962735def65399b5792e3bb5bd7d3c" sha256="84bf65f8d325cebe502495ed959c3a1804363376897e2ab4812df5e7684965e4" status="verified" serial="NTNP" />
+	</game>
+	<game name="All Star Tennis 99 (USA)" id="0035" cloneofid="0034">
+		<description>All Star Tennis 99 (USA)</description>
+		<rom name="All Star Tennis 99 (USA).n64" />
+		<rom name="All Star Tennis 99 (USA).z64" size="8388608" crc="a7dcf638" md5="afc3dc9bb737d81903f6ce4875b63ae9" sha1="3a6446409d63dcac0d5c860a3e2888a378474887" sha256="c42c19a076522451233d9cf02ee73013c4017daced799a1f71601948c9117705" serial="NTNE" />
+	</game>
+	<game name="All-Star Baseball 2000 (Europe)" id="0038">
+		<description>All-Star Baseball 2000 (Europe)</description>
+		<rom name="All-Star Baseball 2000 (Europe).n64" />
+		<rom name="All-Star Baseball 2000 (Europe).z64" size="16777216" crc="d3c29aa4" md5="90448c4175ee9d0247674474dcabdfed" sha1="c8f41a27b9509da422b7ecf32f64df3e213194ea" sha256="2e30b758271c441eab2ed35dcf3a542fd46782522607c2fd6b1663771b756e07" status="verified" serial="NBEP" />
+	</game>
+	<game name="All-Star Baseball 2000 (USA)" id="0039" cloneofid="0038">
+		<description>All-Star Baseball 2000 (USA)</description>
+		<rom name="All-Star Baseball 2000 (USA).n64" />
+		<rom name="All-Star Baseball 2000 (USA).z64" size="16777216" crc="69e88471" md5="aada358ce97f06c4df5bf55987268844" sha1="4256a23902e22e6e8291f1931f8de4b2716fe480" sha256="f354489d79d6ca69a43f3bf95e0e112a6d3a20acdbf96ae847c4180aa0154791" serial="NBEE" />
+	</game>
+	<game name="All-Star Baseball 2001 (USA)" id="0040">
+		<description>All-Star Baseball 2001 (USA)</description>
+		<rom name="All-Star Baseball 2001 (USA).n64" />
+		<rom name="All-Star Baseball 2001 (USA).z64" size="16777216" crc="4d659e85" md5="6e01b8d425ae74ef5a0f875c700a3b18" sha1="4f1b8635322190bb3d0c6fc7d3ba844941f05574" sha256="35313f399fd98072bd7dd22d98814bb2b5e49aadcc654b51d558b639c438f144" serial="NASE" />
+	</game>
+	<game name="All-Star Baseball 99 (Europe)" id="0036">
+		<description>All-Star Baseball 99 (Europe)</description>
+		<rom name="All-Star Baseball 99 (Europe).n64" />
+		<rom name="All-Star Baseball 99 (Europe).z64" size="12582912" crc="d0de3584" md5="ed5f1e12da36dbec8a0a24ed98d4aed5" sha1="3ac0d13f2260797dabf99cfedabf7e3676c5b2e2" sha256="94c4b3f6964109fe237e158ba5a659d5c05b14361f35f6c36a3e6583434782ef" status="verified" serial="NBSP" />
+	</game>
+	<game name="All-Star Baseball 99 (USA)" id="0037" cloneofid="0036">
+		<description>All-Star Baseball 99 (USA)</description>
+		<rom name="All-Star Baseball 99 (USA).n64" />
+		<rom name="All-Star Baseball 99 (USA).z64" size="12582912" crc="6d25b36f" md5="78551d23f230b58b9f449cdb4a285761" sha1="aa576624f2a66034cb0d6e621ba16a0d3beaca3a" sha256="018f19f4174f4efd2c2bb7aabf92a9218436bdbbf2fd65085801d6c86a0a9516" serial="NBSE" />
+	</game>
+	<game name="Armorines - Project S.W.A.R.M. (Europe)" id="0041">
+		<description>Armorines - Project S.W.A.R.M. (Europe)</description>
+		<rom name="Armorines - Project S.W.A.R.M. (Europe).n64" />
+		<rom name="Armorines - Project S.W.A.R.M. (Europe).z64" size="16777216" crc="600bc49e" md5="0c2cbafec6f184ad39ef29b2b5e0f44a" sha1="66f2b431d2275b2563692bfd053d4c0118e0e0c2" sha256="558588b3649c7313cc694610ce81344dfe9a829d63e315c7c108d1a27d7d987b" status="verified" serial="NARP" />
+	</game>
+	<game name="Armorines - Project S.W.A.R.M. (Germany)" id="0042" cloneofid="0041">
+		<description>Armorines - Project S.W.A.R.M. (Germany)</description>
+		<rom name="Armorines - Project S.W.A.R.M. (Germany).n64" />
+		<rom name="Armorines - Project S.W.A.R.M. (Germany).z64" size="16777216" crc="5bab9100" md5="2bc48b3e6f61896b9bc7bef5205cc49c" sha1="68f9dda2863f7625a36f115419956dd9f249afe6" sha256="aebd316ab12bae8bf84f2cab21023a3cb08ae1bec04f6bc574cad415dfb3c090" serial="NARD" />
+	</game>
+	<game name="Armorines - Project S.W.A.R.M. (USA)" id="0043" cloneofid="0041">
+		<description>Armorines - Project S.W.A.R.M. (USA)</description>
+		<rom name="Armorines - Project S.W.A.R.M. (USA).n64" />
+		<rom name="Armorines - Project S.W.A.R.M. (USA).z64" size="16777216" crc="630a19e2" md5="6e6e7a703c131adaddf4175e9037a2eb" sha1="d9f55acf77a54eeb7f62577aa5711769ebeadde3" sha256="6c999d00089e384a1d85bec52c3474d789f905a49726fc1d901cdc367ebf7524" status="verified" serial="NARE" />
+	</game>
+	<game name="Army Men - Air Combat (USA)" id="0044">
+		<description>Army Men - Air Combat (USA)</description>
+		<rom name="Army Men - Air Combat (USA).n64" />
+		<rom name="Army Men - Air Combat (USA).z64" size="8388608" crc="1952cc87" md5="755df7f57edf87706d4c80ff15883312" sha1="eb9bacb12eb6665be9936a3e1dfd6d57b2eaabdb" sha256="9edae0d4d39ccb493bfaf8dcd3075db2582dea1b70ffcc477ee15a0048d97eea" serial="NACE" />
+	</game>
+	<game name="Army Men - Sarge's Heroes (Europe) (En,Fr,De)" id="0045">
+		<description>Army Men - Sarge's Heroes (Europe) (En,Fr,De)</description>
+		<rom name="Army Men - Sarge's Heroes (Europe) (En,Fr,De).n64" />
+		<rom name="Army Men - Sarge's Heroes (Europe) (En,Fr,De).z64" size="8388608" crc="e79048e2" md5="53e2872612760133ab7b2cc2e22b847c" sha1="00e594fa64da61c2ad3138a31a22b9854bb3fafa" sha256="25d3091b4d0713099006933349c4b6e01e79e1f108596abbc5342a4d7d647066" status="verified" serial="NAMP" />
+	</game>
+	<game name="Army Men - Sarge's Heroes (USA)" id="0046" cloneofid="0045">
+		<description>Army Men - Sarge's Heroes (USA)</description>
+		<rom name="Army Men - Sarge's Heroes (USA).n64" />
+		<rom name="Army Men - Sarge's Heroes (USA).z64" size="8388608" crc="2fe786f6" md5="b8085c2edb1c6d23e52ed8c06d92b4f8" sha1="1824380911579424e50042d45aef4851f7ab25a7" sha256="b1992d8069cb7c14d5be4c351578058631cae9e1b2f29656ae7fb9d5ecc1dc22" serial="NAME" />
+	</game>
+	<game name="Army Men - Sarge's Heroes 2 (USA)" id="0047">
+		<description>Army Men - Sarge's Heroes 2 (USA)</description>
+		<rom name="Army Men - Sarge's Heroes 2 (USA).n64" />
+		<rom name="Army Men - Sarge's Heroes 2 (USA).z64" size="8388608" crc="79a71608" md5="6eea5c4a6256092ed8f9ba8861c689c6" sha1="f32b6de2f87928378f26ca17b68b27d87fdefce1" sha256="ee8568e107b6d33128a5384d7614acac530cc834417e2c8e3d65e7ed9b82d546" serial="N32E" />
+	</game>
+	<game name="Asteroids Hyper 64 (USA)" id="0048">
+		<description>Asteroids Hyper 64 (USA)</description>
+		<rom name="Asteroids Hyper 64 (USA).n64" />
+		<rom name="Asteroids Hyper 64 (USA).z64" size="4194304" crc="f5ce3d91" md5="874c7b7b365d2c20aaa1a0c90c93f9b8" sha1="329f4d560b0ba7da622edd9b84523e86e265fffe" sha256="db8871295af1083038d959f1a4c8ac43a8b7cafb84bcc9717ef0c9f4bd6b60b8" serial="NAHE" />
+	</game>
+	<game name="Automobili Lamborghini (Europe)" id="0049">
+		<description>Automobili Lamborghini (Europe)</description>
+		<rom name="Automobili Lamborghini (Europe).n64" />
+		<rom name="Automobili Lamborghini (Europe).z64" size="4194304" crc="3baf58d5" md5="7853f02dc66a35bc8c2bc33d03b8f0ca" sha1="513c9511539bf2361ff20ee1f19dc03f618b5214" sha256="740a878157b15c0cd65e2623dea3ab9c90b6984ad709d8543b7e50f33e88fc62" status="verified" serial="NLCP" />
+	</game>
+	<game name="Automobili Lamborghini (USA)" id="0050" cloneofid="0049">
+		<description>Automobili Lamborghini (USA)</description>
+		<rom name="Automobili Lamborghini (USA).n64" />
+		<rom name="Automobili Lamborghini (USA).z64" size="4194304" crc="a4374eac" md5="ec39579f066a9714ff030d07dec3c9d3" sha1="78b36b48040426478011caef5e11884af2e80375" sha256="cab2467684a58bc19c787423d704a961aa497629763367d9fe691172de58591c" serial="NLCE" />
+	</game>
+	<game name="Baku Bomberman (Japan)" id="0051" cloneofid="0087">
+		<description>Baku Bomberman (Japan)</description>
+		<rom name="Baku Bomberman (Japan).n64" />
+		<rom name="Baku Bomberman (Japan).z64" size="8388608" crc="22f54a52" md5="8183688a4b7d0a390496b5655bcd252e" sha1="4813b147d552f72fdb0b306469bf9aa0f820fd5b" sha256="7a36567a0a26dfdcb6f24eb454be9f9cd815cf96d6660867845e8a55434084cf" serial="NBMJ" />
+	</game>
+	<game name="Baku Bomberman 2 (Japan)" id="0052" cloneofid="0090">
+		<description>Baku Bomberman 2 (Japan)</description>
+		<rom name="Baku Bomberman 2 (Japan).n64" />
+		<rom name="Baku Bomberman 2 (Japan).z64" size="16777216" crc="86bbc278" md5="ca956015b6820dcff1c814f3532e18b1" sha1="179cab7426755f14bd3f4999f3789eb6d7af64c4" sha256="45c622c2e6d65ceb255c531b499c78d0e1880c32e9e9d7b804c617549f3da7cb" serial="NBVJ" />
+	</game>
+	<game name="Bakuretsu Muteki Bangaioh (Japan)" id="0053">
+		<description>Bakuretsu Muteki Bangaioh (Japan)</description>
+		<rom name="Bakuretsu Muteki Bangaioh (Japan).n64" />
+		<rom name="Bakuretsu Muteki Bangaioh (Japan).z64" size="12582912" crc="6ab7fec6" md5="8107825ac2a522057422463ed81e276b" sha1="2dbfe78f97b8d6e1a33b73d244be831d18b0491e" sha256="60f0117bd8e48f8049a72f5b8bd0957f08282f2b687f0a1fea71f4597dfd4c4a" serial="NBNJ" />
+	</game>
+	<game name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)" id="0054">
+		<description>Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)</description>
+		<rom name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).n64" />
+		<rom name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).z64" size="12582912" crc="ef8c2f34" md5="09fd63afa1156405e618752fc583df93" sha1="28e6d11f6f48c86a9b7c112c672109e1c2d7e5d0" sha256="2e48f2efdd1895d7d5b3119ca4b3abb4b509249389f9b6d6e3c74cfe4a20c530" status="verified" serial="NBJJ" />
+	</game>
+	<game name="Banjo to Kazooie no Daibouken (Japan)" id="0055" cloneofid="0057">
+		<description>Banjo to Kazooie no Daibouken (Japan)</description>
+		<rom name="Banjo to Kazooie no Daibouken (Japan).n64" />
+		<rom name="Banjo to Kazooie no Daibouken (Japan).z64" size="16777216" crc="8f7c9324" md5="3d3855a86fd5a1b4d30beb0f5a4a85af" sha1="90726d7e7cd5bf6cdfd38f45c9acbf4d45bd9fd8" sha256="f766bdb553dd38bf1ce1b9395647aa44abb85503ef08592c8c1a94b15eb6dbfb" status="verified" serial="NBKJ" />
+	</game>
+	<game name="Banjo to Kazooie no Daibouken 2 (Japan)" id="0056" cloneofid="0061">
+		<description>Banjo to Kazooie no Daibouken 2 (Japan)</description>
+		<rom name="Banjo to Kazooie no Daibouken 2 (Japan).n64" />
+		<rom name="Banjo to Kazooie no Daibouken 2 (Japan).z64" size="33554432" crc="258c58d0" md5="715a8816f30fa24b8d174dc5cb6f25a9" sha1="5a5172383037d171f121790959962703be1f373c" sha256="0abe75ee302623440c6af4ab1f702f0874ce290865eddef09f816ed10216a54d" status="verified" serial="NB7J" />
+	</game>
+	<game name="Banjo-Kazooie (Europe) (En,Fr,De)" id="0057">
+		<description>Banjo-Kazooie (Europe) (En,Fr,De)</description>
+		<rom name="Banjo-Kazooie (Europe) (En,Fr,De).n64" />
+		<rom name="Banjo-Kazooie (Europe) (En,Fr,De).z64" size="16777216" crc="525899c9" md5="06a43bacf5c0687f596df9b018ca6d7f" sha1="bb359a75941df74bf7290212c89fbc6e2c5601fe" sha256="d4e7534d8bcdc329386bf28dcb86e35136e793622f3e6913342500d17e89a931" status="verified" serial="NBKP" />
+	</game>
+	<game name="Banjo-Kazooie (USA)" id="0058" cloneofid="0057">
+		<description>Banjo-Kazooie (USA)</description>
+		<rom name="Banjo-Kazooie (USA).n64" />
+		<rom name="Banjo-Kazooie (USA).z64" size="16777216" crc="ad429961" md5="b29599651a13f681c9923d69354bf4a3" sha1="1fe1632098865f639e22c11b9a81ee8f29c75d7a" sha256="59875835b9a5128bb0054315a7f929e2071c2001e528d70bf543e1d6680e6eff" status="verified" serial="NBKE" />
+	</game>
+	<game name="Banjo-Kazooie (USA) (Rev 1)" id="0059" cloneofid="0057">
+		<description>Banjo-Kazooie (USA) (Rev 1)</description>
+		<rom name="Banjo-Kazooie (USA) (Rev 1).n64" />
+		<rom name="Banjo-Kazooie (USA) (Rev 1).z64" size="16777216" crc="fb7ffb10" md5="b11f476d4bc8e039355241e871dc08cf" sha1="ded6ee166e740ad1bc810fd678a84b48e245ab80" sha256="f9ad43f64c3a38b0ca4067e24f570dcb8f3f8fec077c5c342484bcbec7ff6d22" status="verified" serial="NBKE" />
+	</game>
+	<game name="Banjo-Tooie (Australia)" id="0060" cloneofid="0061">
+		<description>Banjo-Tooie (Australia)</description>
+		<rom name="Banjo-Tooie (Australia).n64" />
+		<rom name="Banjo-Tooie (Australia).z64" size="33554432" crc="2736266a" md5="61b5c5c3e5e1a81e5d37072c01b39b76" sha1="4ca2d332f6e6b018777afc6a8b7880b38b6dfb79" sha256="017495239c491c5f3575de171527732a80b597cbb6331bfa984efc677801df43" serial="NB7U" />
+	</game>
+	<game name="Banjo-Tooie (Europe) (En,Fr,De,Es)" id="0061">
+		<description>Banjo-Tooie (Europe) (En,Fr,De,Es)</description>
+		<rom name="Banjo-Tooie (Europe) (En,Fr,De,Es).n64" />
+		<rom name="Banjo-Tooie (Europe) (En,Fr,De,Es).z64" size="33554432" crc="1ec12f5a" md5="8b2e56f18421a67bca861427453a1e19" sha1="93bf2fac1387320ad07251cb4b64fd36bac1d7a6" sha256="82d5b9062263daad5108645049de3f06c9db00a2eeffa409876af74e43437748" status="verified" serial="NB7P" />
+	</game>
+	<game name="Banjo-Tooie (USA)" id="0062" cloneofid="0061">
+		<description>Banjo-Tooie (USA)</description>
+		<rom name="Banjo-Tooie (USA).n64" />
+		<rom name="Banjo-Tooie (USA).z64" size="33554432" crc="bab803ef" md5="40e98faa24ac3ebe1d25cb5e5ddf49e4" sha1="af1a89e12b638b8d82cc4c085c8e01d4cba03fb3" sha256="9ec37fba6890362eba86fb855697a9cff1519275531b172083a1a6a045483583" status="verified" serial="NB7E" />
+	</game>
+	<game name="Bass Rush - ECOGEAR PowerWorm Championship (Japan)" id="0063">
+		<description>Bass Rush - ECOGEAR PowerWorm Championship (Japan)</description>
+		<rom name="Bass Rush - ECOGEAR PowerWorm Championship (Japan).n64" />
+		<rom name="Bass Rush - ECOGEAR PowerWorm Championship (Japan).z64" size="33554432" crc="383b86ef" md5="2c618f6c69c3b4803f08762a03835139" sha1="1718c9048cb7849a59d48138a058b20bf191ebf6" sha256="e0ccd9ca6f27ac49d28d72eb7978be7eaf43ec0dd15c532be2312a0d6387f526" serial="NVBJ" />
+	</game>
+	<game name="Bassmasters 2000 (USA)" id="0064">
+		<description>Bassmasters 2000 (USA)</description>
+		<rom name="Bassmasters 2000 (USA).n64" />
+		<rom name="Bassmasters 2000 (USA).z64" size="12582912" crc="6b09092e" md5="930c7f6e5863471dde1816d28a10eb88" sha1="946b3e08a1a4de4f917ad547bb24f533b737f712" sha256="dece8932dfdcb7f42e4118c4f763b198098fee854c90cfe71e8d5bd2e6e02efe" serial="NB4E" />
+	</game>
+	<game name="Bassmasters 2000 (USA) (Beta)" id="1056" cloneofid="0064">
+		<description>Bassmasters 2000 (USA) (Beta)</description>
+		<rom name="Bassmasters 2000 (USA) (Beta).n64" />
+		<rom name="Bassmasters 2000 (USA) (Beta).z64" size="33554432" crc="86f8e439" md5="684f4f7cefcc0863710799c8a43dd882" sha1="aa5e9d5eccd278bc59d995e31431715d67e93fe2" sha256="8c638f6d2e7ad367d7bd207fbdf4d62b12734dd23a54e195427ee6adfe114cd0" serial="!none" />
+	</game>
+	<game name="Batman Beyond - Return of the Joker (USA)" id="0065" cloneofid="0066">
+		<description>Batman Beyond - Return of the Joker (USA)</description>
+		<rom name="Batman Beyond - Return of the Joker (USA).n64" />
+		<rom name="Batman Beyond - Return of the Joker (USA).z64" size="4194304" crc="35299f9c" md5="a08676124b326b1035b202c83a97468f" sha1="f7382358250965e9757ba9a89fe42d033dbe7fe8" sha256="7ce0f1304c46f16613ff3d414c9b011a0a34bcd2a67db1b3cbd063cfb7d5d38b" serial="NJQE" />
+	</game>
+	<game name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De)" id="0066">
+		<description>Batman of the Future - Return of the Joker (Europe) (En,Fr,De)</description>
+		<rom name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De).n64" />
+		<rom name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De).z64" size="4194304" crc="82a4bb8a" md5="a5ee8a6c34863e3d0eb8c06ae8668b30" sha1="3954131395f98e605072bea11cc85842da58f754" sha256="f96affc5a89bff0843a2e35a6dee9ea1fe8ae65719519a742780877419f5ce60" status="verified" serial="NJQP" />
+	</game>
+	<game name="BattleTanx (USA)" id="0067">
+		<description>BattleTanx (USA)</description>
+		<rom name="BattleTanx (USA).n64" />
+		<rom name="BattleTanx (USA).z64" size="8388608" crc="6c230765" md5="3406a505c22bac2f40d9bfc6ff08cf86" sha1="535860d941738ac1210c20a9b80114fea0e0ff17" sha256="c5b7cf3523de025e3f18e2c8df2deb0eced5613e7c46cb8c6c5a4f22644ead3f" status="verified" serial="NBXE" />
+	</game>
+	<game name="BattleTanx - Global Assault (Europe) (En,Fr,De)" id="0068">
+		<description>BattleTanx - Global Assault (Europe) (En,Fr,De)</description>
+		<rom name="BattleTanx - Global Assault (Europe) (En,Fr,De).n64" />
+		<rom name="BattleTanx - Global Assault (Europe) (En,Fr,De).z64" size="8388608" crc="c99c6030" md5="d6e667fe10afe8f7116888efde98ae0e" sha1="aefade7a37a4716ddc82a6b67ba085cbf7c27259" sha256="8c0f538d32243d7d230ff28432326fbb17ea59bec2e2d9815dc04317dbe70db0" status="verified" serial="NBQP" />
+	</game>
+	<game name="BattleTanx - Global Assault (USA)" id="0069" cloneofid="0068">
+		<description>BattleTanx - Global Assault (USA)</description>
+		<rom name="BattleTanx - Global Assault (USA).n64" />
+		<rom name="BattleTanx - Global Assault (USA).z64" size="8388608" crc="31beb053" md5="654557c316f901a2ca6f7f4b43343147" sha1="805248fb0a0ee694cad8d7dc927b631d860dd8cf" sha256="88268ce770ff39f2ca839848b842c87866df6c5ddaf775f180b2522c18ff6221" serial="NBQE" />
+	</game>
+	<game name="Battlezone - Rise of the Black Dogs (USA)" id="0070">
+		<description>Battlezone - Rise of the Black Dogs (USA)</description>
+		<rom name="Battlezone - Rise of the Black Dogs (USA).n64" />
+		<rom name="Battlezone - Rise of the Black Dogs (USA).z64" size="16777216" crc="736f9d5c" md5="266c0989ed0929df499389954779ea97" sha1="85b4febbe6fbd1ecfc883905e43e68e7188c44f9" sha256="67d85ce25cb54aba71191cde04c230a3883a2b7e49581b6f309219c61ace0bcc" serial="NZOE" />
+	</game>
+	<game name="Beetle Adventure Racing! (Europe) (En,Fr,De)" id="0071">
+		<description>Beetle Adventure Racing! (Europe) (En,Fr,De)</description>
+		<rom name="Beetle Adventure Racing! (Europe) (En,Fr,De).n64" />
+		<rom name="Beetle Adventure Racing! (Europe) (En,Fr,De).z64" size="16777216" crc="5b6c6e4c" md5="a94135d163e6091c960adc918c1fb8a7" sha1="85b3b95d587d2646f781b04cf5239804d105685a" sha256="ef0c7bfa39712b841cc0d5b87ab6f8faf15a6877e587168a48ddff0c9c3bef87" status="verified" serial="NNSP" />
+	</game>
+	<game name="Beetle Adventure Racing! (Japan)" id="0072" cloneofid="0071">
+		<description>Beetle Adventure Racing! (Japan)</description>
+		<rom name="Beetle Adventure Racing! (Japan).n64" />
+		<rom name="Beetle Adventure Racing! (Japan).z64" size="16777216" crc="49e75825" md5="5ffd43089b7334072b2b74421618d973" sha1="d6e943a8733d3c09795f4be24b75c7fb0c30a27d" sha256="26bd3bbea7773aa46c5b94e4570fad5c413cc933ee06166718017732bddd851e" serial="NB8J" />
+	</game>
+	<game name="Beetle Adventure Racing! (USA) (En,Fr,De)" id="0073" cloneofid="0071">
+		<description>Beetle Adventure Racing! (USA) (En,Fr,De)</description>
+		<rom name="Beetle Adventure Racing! (USA) (En,Fr,De).n64" />
+		<rom name="Beetle Adventure Racing! (USA) (En,Fr,De).z64" size="16777216" crc="f4a97c73" md5="cf97c336479ddbf1217e4dde89d9d2d3" sha1="e5ab4d226c08d22f68a2edcc48870203e67454b8" sha256="6addd60de277c83351eff83099e4dab25ac45279b6401728cfda9eea2f1380df" serial="NNSE" />
+	</game>
+	<game name="Big Mountain 2000 (USA)" id="0074">
+		<description>Big Mountain 2000 (USA)</description>
+		<rom name="Big Mountain 2000 (USA).n64" />
+		<rom name="Big Mountain 2000 (USA).z64" size="12582912" crc="3ac924bc" md5="bf6780e2982c16d4a4fdb553be8f9226" sha1="e28f3ebfb7bc706cce639fc1874243e1d4995d1d" sha256="d42bf9fd1a49daff13a4626196b2fc5f3d8af27b607ce7eabfec0addaec7abee" serial="NMUE" />
+	</game>
+	<game name="Bio F.R.E.A.K.S. (Europe)" id="0075">
+		<description>Bio F.R.E.A.K.S. (Europe)</description>
+		<rom name="Bio F.R.E.A.K.S. (Europe).n64" />
+		<rom name="Bio F.R.E.A.K.S. (Europe).z64" size="16777216" crc="2c4eb906" md5="42672ba5e98cd21d7f3e3745e69038dd" sha1="8a85ec7d68954a36569f28f6a26981d6f283fd6d" sha256="66037309dc4d7619ff31548e3ed9bf3cd1e3d0f17e484aee87f748bf6e42ade6" status="verified" serial="NBFP" />
+	</game>
+	<game name="Bio F.R.E.A.K.S. (USA)" id="0076" cloneofid="0075">
+		<description>Bio F.R.E.A.K.S. (USA)</description>
+		<rom name="Bio F.R.E.A.K.S. (USA).n64" />
+		<rom name="Bio F.R.E.A.K.S. (USA).z64" size="16777216" crc="dfbf448c" md5="b90ab8f7605d971cc7a6d9ba5e67d1af" sha1="e20e9124480b559aa7148412c8993804501e180d" sha256="7967e3d7a8441339b7e58f2180404034fc44548a477fbce73caf546eb50d74a3" serial="NBFE" />
+	</game>
+	<game name="Biohazard 2 (Japan)" id="0077" cloneofid="0620">
+		<description>Biohazard 2 (Japan)</description>
+		<rom name="Biohazard 2 (Japan).n64" />
+		<rom name="Biohazard 2 (Japan).z64" size="67108864" crc="4f9d569f" md5="f77d70959222276491222f31ebff3bf1" sha1="7492139f237c547ef32955c7cc6b9a5e6dcaa55d" sha256="f64a3c4a3873cf145e577ee710366fd638bb8d03f6f01549f81e04df738fd425" serial="NB5J" />
+	</game>
+	<game name="Blast Corps (Europe) (En,De)" id="0078">
+		<description>Blast Corps (Europe) (En,De)</description>
+		<rom name="Blast Corps (Europe) (En,De).n64" />
+		<rom name="Blast Corps (Europe) (En,De).z64" size="8388608" crc="4c820695" md5="889d4d337ad11ce94357511c725eab6a" sha1="460212600f8b9f0da95219c4c7330f2e626d9a7e" sha256="9a9246c1128ae4e1cfc6b9b0137894a9575202ce9cd62bf4b9405fb0cdfbd506" status="verified" serial="NBCP" />
+	</game>
+	<game name="Blast Corps (USA)" id="0079" cloneofid="0078">
+		<description>Blast Corps (USA)</description>
+		<rom name="Blast Corps (USA).n64" />
+		<rom name="Blast Corps (USA).z64" size="8388608" crc="767a95e7" md5="a8dfdff49144627492da9b0b65b91845" sha1="185a6ef7ba1adb243278062c81a7d4e119bda58c" sha256="902769f9d27d888a35d8bdbec88ae9f4f3f33583323475678e99b6456eeaa6f5" status="verified" serial="NBCE" />
+	</game>
+	<game name="Blast Corps (USA) (Rev 1)" id="0080" cloneofid="0078">
+		<description>Blast Corps (USA) (Rev 1)</description>
+		<rom name="Blast Corps (USA) (Rev 1).n64" />
+		<rom name="Blast Corps (USA) (Rev 1).z64" size="8388608" crc="9cbbccf1" md5="5875fc73069077c93e214233b60f0bdc" sha1="483f7161aea39de8b45c9fbc70a2c3883c4dea8c" sha256="42e4d8cde3c106637a25bbfa62d74cc2e5c1eed1d64de5bbb0b1c4896b185927" serial="NBCE" />
+	</game>
+	<game name="Blastdozer (Japan)" id="0081" cloneofid="0078">
+		<description>Blastdozer (Japan)</description>
+		<rom name="Blastdozer (Japan).n64" />
+		<rom name="Blastdozer (Japan).z64" size="8388608" crc="081a3641" md5="16b82d53d7f038a8fe67a78027720516" sha1="b147fdbeb661c89107c440b00dc4810508f58636" sha256="88b8ab9ea99dd0d226c3699d1386c7e4b3253ce0b4ab1d298855a4c82bd28229" serial="NBCJ" />
+	</game>
+	<game name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)" id="0082">
+		<description>Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)</description>
+		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="8fb41658" md5="31b4a8ed52b48e756b344c9f22736e50" sha1="d641afca71a7d83587f9d7105d5e6dffdeaa8016" sha256="2a7540a8cb2d0f2eec24bc99e8c9af505a17f32e3aa2e43394a4ac94867dc2c8" status="verified" serial="NBPP" />
+	</game>
+	<game name="Blues Brothers 2000 (USA)" id="0083" cloneofid="0082">
+		<description>Blues Brothers 2000 (USA)</description>
+		<rom name="Blues Brothers 2000 (USA).n64" />
+		<rom name="Blues Brothers 2000 (USA).z64" size="16777216" crc="c6f49764" md5="997fd8f79cd6f3cd1c1c1fd21e358717" sha1="ed0fe7c9a2e8015bdf8262d35065f53c6fcea60f" sha256="3ca0ac99c1611125783d474825b9d912b7b2e491d17468b0db6fb29b941fc985" serial="NBPE" />
+	</game>
+	<game name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2000-01-15) (#53)" id="1058" cloneofid="0082">
+		<description>Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2000-01-15) (#53)</description>
+		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2000-01-15) (#53).n64" />
+		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2000-01-15) (#53).z64" size="33554432" crc="bb1ca04d" md5="410bf50920c28ce6d2c36174f659b0d7" sha1="b0f2546c0dbc4d8cc095337a288736e785219d02" sha256="b749fcead39e4f02e362620f7e3efba4efe4967dc82b89cbf7facea3ccdbefba" serial="!none" />
+	</game>
+	<game name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2000-01-15) (#20)" id="1067" cloneofid="0082">
+		<description>Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2000-01-15) (#20)</description>
+		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2000-01-15) (#20).n64" />
+		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl) (Beta) (2000-01-15) (#20).z64" size="33554432" crc="1ac60460" md5="0068e81bf8037e7c8af658f0ddae9400" sha1="ea4c2fc9f7ae4afadaeda4e1095282b16f427cee" sha256="89c1bedc4035cc14af28d11b5e223ca83bab824b2f6ab5940c9bac158b39d25c" />
+	</game>
+	<game name="Body Harvest (Europe) (En,Fr,De)" id="0084">
+		<description>Body Harvest (Europe) (En,Fr,De)</description>
+		<rom name="Body Harvest (Europe) (En,Fr,De).n64" />
+		<rom name="Body Harvest (Europe) (En,Fr,De).z64" size="12582912" crc="6a04cdae" md5="b27fa5e9ad0cb47bb3a74ffac7bc8edf" sha1="67750e2e7ab46fedf65a271ab7f4c7aad92ae355" sha256="e0340a9656384420eab6c92ac6e2d0b6eba38cb527cf1ec26e4b2057964984a4" status="verified" serial="NBHP" />
+	</game>
+	<game name="Body Harvest (USA)" id="0085" cloneofid="0084">
+		<description>Body Harvest (USA)</description>
+		<rom name="Body Harvest (USA).n64" />
+		<rom name="Body Harvest (USA).z64" size="12582912" crc="fabbdf02" md5="3b8585ed03e8ddb89d7de456317545e7" sha1="bbb6666f5014a473747ee4145f036d9fb25d7348" sha256="d4b2654d6d903e43454bffdf025eeb4a954d8fafefab64dc5f8cf0e6dd392a74" serial="NBHE" />
+	</game>
+	<game name="Bokujou Monogatari 2 (Japan)" id="0086" cloneofid="0274">
 		<description>Bokujou Monogatari 2 (Japan)</description>
 		<rom name="Bokujou Monogatari 2 (Japan).n64" />
-		<rom name="Bokujou Monogatari 2 (Japan).z64" size="16777216" crc="f97237c7" md5="1cf31e7f6e0deb2c18c39ddd4eed9e51" sha1="e41d15c394b5fefd4016add3883a794c48e7e232" />
+		<rom name="Bokujou Monogatari 2 (Japan).z64" size="16777216" crc="f97237c7" md5="1cf31e7f6e0deb2c18c39ddd4eed9e51" sha1="e41d15c394b5fefd4016add3883a794c48e7e232" sha256="d59d97b15e2282e279ea6097d69d013d59941722d918a911bf1618b31ab8d428" status="verified" serial="NYWJ" />
 	</game>
-	<game name="Bokujou Monogatari 2 (Japan) (Rev 1)" cloneof="Harvest Moon 64 (USA)">
+	<game name="Bokujou Monogatari 2 (Japan) (Rev 1)" id="0892" cloneofid="0274">
 		<description>Bokujou Monogatari 2 (Japan) (Rev 1)</description>
 		<rom name="Bokujou Monogatari 2 (Japan) (Rev 1).n64" />
-		<rom name="Bokujou Monogatari 2 (Japan) (Rev 1).z64" size="16777216" crc="20fd2939" md5="e627b898a7692c08b595a8d2178e34a0" sha1="211313fe7ca7a4e0bf376afcf7c83c51e5c7f1a0" />
+		<rom name="Bokujou Monogatari 2 (Japan) (Rev 1).z64" size="16777216" crc="20fd2939" md5="e627b898a7692c08b595a8d2178e34a0" sha1="211313fe7ca7a4e0bf376afcf7c83c51e5c7f1a0" sha256="914ad2eb454fb7382be9e88670e580d265106b08fbe68a6f2db5fbaa3e57fe7f" serial="NYWJ" />
 	</game>
-	<game name="Bokujou Monogatari 2 (Japan) (Rev 2)" cloneof="Harvest Moon 64 (USA)">
+	<game name="Bokujou Monogatari 2 (Japan) (Rev 2)" id="0893" cloneofid="0274">
 		<description>Bokujou Monogatari 2 (Japan) (Rev 2)</description>
 		<rom name="Bokujou Monogatari 2 (Japan) (Rev 2).n64" />
-		<release name="Bokujou Monogatari 2 (Japan) (Rev 2)" region="JPN" />
-		<rom name="Bokujou Monogatari 2 (Japan) (Rev 2).z64" size="16777216" crc="9181c1b7" md5="24e3ee6a54278db65c463804f2bb6223" sha1="74c5fd9647b702e889a5f2094d4bc4001bd6f68b" />
-	</game>
-	<game name="Heiwa Pachinko World 64 (Japan)">
-		<description>Heiwa Pachinko World 64 (Japan)</description>
-		<rom name="Heiwa Pachinko World 64 (Japan).n64" />
-		<release name="Heiwa Pachinko World 64 (Japan)" region="JPN" />
-		<rom name="Heiwa Pachinko World 64 (Japan).z64" size="8388608" crc="99a427fa" md5="5e8539e037eea88c5a2746f60e431c8d" sha1="d48a484febaac3bd146130434921861890503b29" />
-	</game>
-	<game name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<rom name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="b1954b08" md5="1546877fd85c00a83515005727e5fda5" sha1="d2e26f4aecf488f87e1ab36395280385b060d229" />
-	</game>
-	<game name="Hercules - The Legendary Journeys (USA)" cloneof="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Hercules - The Legendary Journeys (USA)</description>
-		<rom name="Hercules - The Legendary Journeys (USA).n64" />
-		<release name="Hercules - The Legendary Journeys (USA)" region="USA" />
-		<rom name="Hercules - The Legendary Journeys (USA).z64" size="16777216" crc="4948892b" md5="6bbd8c42f6ef8f5b9541d6f4db657dd7" sha1="5c3c4345be505763fc51a9e3713f5787e4044646" />
-	</game>
-	<game name="Hexen (Europe)">
-		<description>Hexen (Europe)</description>
-		<rom name="Hexen (Europe).n64" />
-		<release name="Hexen (Europe)" region="EUR" />
-		<rom name="Hexen (Europe).z64" size="8388608" crc="5369efb4" md5="2080262a251d270f9ce819887f2104a7" sha1="1a929ae2a7930cf4b762fa28a9d20338c5fed847" />
-	</game>
-	<game name="Hexen (France)" cloneof="Hexen (Europe)">
-		<description>Hexen (France)</description>
-		<rom name="Hexen (France).n64" />
-		<release name="Hexen (France)" region="FRA" />
-		<rom name="Hexen (France).z64" size="8388608" crc="e373fa31" md5="a5921c00111200257284ce0aba0904ca" sha1="476d3b340ba2a1b1acc1d0cc97ac6e25a5136ca2" />
-	</game>
-	<game name="Hexen (Germany)" cloneof="Hexen (Europe)">
-		<description>Hexen (Germany)</description>
-		<rom name="Hexen (Germany).n64" />
-		<release name="Hexen (Germany)" region="GER" />
-		<rom name="Hexen (Germany).z64" size="8388608" crc="e4821c4b" md5="08cbb141dec604e4dad2787f237d57a2" sha1="8d10ca2860d72c3c1adb409485936c4ba3f18396" />
-	</game>
-	<game name="Hexen (Japan)" cloneof="Hexen (Europe)">
-		<description>Hexen (Japan)</description>
-		<rom name="Hexen (Japan).n64" />
-		<release name="Hexen (Japan)" region="JPN" />
-		<rom name="Hexen (Japan).z64" size="8388608" crc="571da09a" md5="672152cf4dcb5d0a19662c11eff71452" sha1="3e3e2b012bbb873338b0573f6e11426e38f8b5cd" />
-	</game>
-	<game name="Hexen (USA)" cloneof="Hexen (Europe)">
-		<description>Hexen (USA)</description>
-		<rom name="Hexen (USA).n64" />
-		<release name="Hexen (USA)" region="USA" />
-		<rom name="Hexen (USA).z64" size="8388608" crc="1d35e110" md5="eb98f1b8c6898af7417f6882946da9b3" sha1="a602839132f6cca71f175fb72039897705ba4661" />
-	</game>
-	<game name="Hey You, Pikachu! (USA)">
-		<description>Hey You, Pikachu! (USA)</description>
-		<rom name="Hey You, Pikachu! (USA).n64" />
-		<release name="Hey You, Pikachu! (USA)" region="USA" />
-		<rom name="Hey You, Pikachu! (USA).z64" size="16777216" crc="b18b2734" md5="1280c78f286fc1c437a4905ee42c47f1" sha1="da1a1e47a86720f9d54fb2d2d247480041bda824" />
-	</game>
-	<game name="Pikachuu Genki de Chuu (Japan)" cloneof="Hey You, Pikachu! (USA)">
-		<description>Pikachuu Genki de Chuu (Japan)</description>
-		<rom name="Pikachuu Genki de Chuu (Japan).n64" />
-		<release name="Pikachuu Genki de Chuu (Japan)" region="JPN" />
-		<rom name="Pikachuu Genki de Chuu (Japan).z64" size="16777216" crc="3f6245ae" md5="e0bcb2758edf0ac6ab7db36d98e1e57c" sha1="a28c689e58f58b4a2a672d3d010436661d247476" status="verified" />
-	</game>
-	<game name="Holy Magic Century (Europe)">
-		<description>Holy Magic Century (Europe)</description>
-		<rom name="Holy Magic Century (Europe).n64" />
-		<release name="Holy Magic Century (Europe)" region="EUR" />
-		<rom name="Holy Magic Century (Europe).z64" size="16777216" crc="84ff9890" md5="80cc112f62e9a8581a1bb6a1d1e1488b" sha1="139607eba03326fbe9d899663c56e64042d51e84" />
-	</game>
-	<game name="Eltale Monsters (Japan)" cloneof="Holy Magic Century (Europe)">
-		<description>Eltale Monsters (Japan)</description>
-		<rom name="Eltale Monsters (Japan).n64" />
-		<release name="Eltale Monsters (Japan)" region="JPN" />
-		<rom name="Eltale Monsters (Japan).z64" size="16777216" crc="24d937bf" md5="9b456acb96291fc8b55232a08ae03346" sha1="4161b5c100ec82b0241b20ca8f81366e23564ccb" />
-	</game>
-	<game name="Holy Magic Century (France)" cloneof="Holy Magic Century (Europe)">
-		<description>Holy Magic Century (France)</description>
-		<rom name="Holy Magic Century (France).n64" />
-		<release name="Holy Magic Century (France)" region="FRA" />
-		<rom name="Holy Magic Century (France).z64" size="16777216" crc="284170ed" md5="988f5abd96259196343659e913666820" sha1="610bf1f4a5cbeb2d6dc3ae1dafc5b3b818f69c26" />
-	</game>
-	<game name="Holy Magic Century (Germany)" cloneof="Holy Magic Century (Europe)">
-		<description>Holy Magic Century (Germany)</description>
-		<rom name="Holy Magic Century (Germany).n64" />
-		<release name="Holy Magic Century (Germany)" region="GER" />
-		<rom name="Holy Magic Century (Germany).z64" size="16777216" crc="d1934cf6" md5="ab676c3e9d26a77450ddb4aacd1a3861" sha1="ac5457fff3fcc8d6acffb60fa9a99846d36facf8" />
-	</game>
-	<game name="Quest 64 (USA)" cloneof="Holy Magic Century (Europe)">
-		<description>Quest 64 (USA)</description>
-		<rom name="Quest 64 (USA).n64" />
-		<release name="Quest 64 (USA)" region="USA" />
-		<rom name="Quest 64 (USA).z64" size="16777216" crc="d75b45c6" md5="ea552e33973468233a0712c251abdb6b" sha1="91b96e938c6d91699057fad91d726ee5a23ce33a" />
-	</game>
-	<game name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De)">
-		<description>Hot Wheels - Turbo Racing (Europe) (En,Fr,De)</description>
-		<rom name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De).n64" />
-		<release name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De).z64" size="16777216" crc="850633a7" md5="ef34da35ef8a0734843cb182c19feb26" sha1="fbcfd6d466931e5cb71fe880c52ea692c3f84d75" />
-	</game>
-	<game name="Hot Wheels - Turbo Racing (USA)" cloneof="Hot Wheels - Turbo Racing (Europe) (En,Fr,De)">
-		<description>Hot Wheels - Turbo Racing (USA)</description>
-		<rom name="Hot Wheels - Turbo Racing (USA).n64" />
-		<release name="Hot Wheels - Turbo Racing (USA)" region="USA" />
-		<rom name="Hot Wheels - Turbo Racing (USA).z64" size="12582912" crc="a5c92148" md5="4311a1aef1898678331f7e3486055307" sha1="94913a07e49005ffd43dfdfa16ff5862bdb93748" />
-	</game>
-	<game name="Hybrid Heaven (Europe) (En,Fr,De)">
-		<description>Hybrid Heaven (Europe) (En,Fr,De)</description>
-		<rom name="Hybrid Heaven (Europe) (En,Fr,De).n64" />
-		<release name="Hybrid Heaven (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Hybrid Heaven (Europe) (En,Fr,De).z64" size="16777216" crc="e76627ff" md5="da861c4d9202f661575466450a27c412" sha1="d2210d492bad952b055a4269e45fd89631c32d25" status="verified" />
-	</game>
-	<game name="Hybrid Heaven (Japan)" cloneof="Hybrid Heaven (Europe) (En,Fr,De)">
-		<description>Hybrid Heaven (Japan)</description>
-		<rom name="Hybrid Heaven (Japan).n64" />
-		<release name="Hybrid Heaven (Japan)" region="JPN" />
-		<rom name="Hybrid Heaven (Japan).z64" size="16777216" crc="e769de96" md5="9946eff915fc947a226407ac1f7b35c4" sha1="09f4d3200b0bd4b984a80248af07de3c40b5cc26" />
-	</game>
-	<game name="Hybrid Heaven (USA)" cloneof="Hybrid Heaven (Europe) (En,Fr,De)">
-		<description>Hybrid Heaven (USA)</description>
-		<rom name="Hybrid Heaven (USA).n64" />
-		<release name="Hybrid Heaven (USA)" region="USA" />
-		<rom name="Hybrid Heaven (USA).z64" size="16777216" crc="15b57ef8" md5="c47e95bb32ab132c41d67bd243f9e02a" sha1="16dbc21620b52deab5c5abf8a309ac60adfbee85" />
-	</game>
-	<game name="Hydro Thunder (Europe)">
-		<description>Hydro Thunder (Europe)</description>
-		<rom name="Hydro Thunder (Europe).n64" />
-		<release name="Hydro Thunder (Europe)" region="EUR" />
-		<rom name="Hydro Thunder (Europe).z64" size="33554432" crc="863ab8f3" md5="434bb8de49011573ac38e893224c5623" sha1="0661b1b0e47bc02d9b0d87d1688fd466793c074b" />
-	</game>
-	<game name="Hydro Thunder (France)" cloneof="Hydro Thunder (Europe)">
-		<description>Hydro Thunder (France)</description>
-		<rom name="Hydro Thunder (France).n64" />
-		<release name="Hydro Thunder (France)" region="FRA" />
-		<rom name="Hydro Thunder (France).z64" size="33554432" crc="010f6242" md5="4b4c85d9dd2d460adafabae8db48b4fa" sha1="03fa91aec0819654f1ad0d12bb81ce3f5d7d08ae" />
-	</game>
-	<game name="Hydro Thunder (USA)" cloneof="Hydro Thunder (Europe)">
-		<description>Hydro Thunder (USA)</description>
-		<rom name="Hydro Thunder (USA).n64" />
-		<release name="Hydro Thunder (USA)" region="USA" />
-		<rom name="Hydro Thunder (USA).z64" size="33554432" crc="e744456f" md5="54f43e6b68782e98caabea5e7976b2be" sha1="f5d5054f97da0d68857f9824130147ec38ee7a76" />
-	</game>
-	<game name="Ide Yosuke no Mahjong Juku (Japan)">
-		<description>Ide Yosuke no Mahjong Juku (Japan)</description>
-		<rom name="Ide Yosuke no Mahjong Juku (Japan).n64" />
-		<release name="Ide Yosuke no Mahjong Juku (Japan)" region="JPN" />
-		<rom name="Ide Yosuke no Mahjong Juku (Japan).z64" size="12582912" crc="dbd96deb" md5="92a6ffa1c8d537c7a97c5c613cae05c6" sha1="26e3210f45c78d72eae61cb066d08d6e00c0ea87" />
-	</game>
-	<game name="Iggy's Reckin' Balls (Europe)">
-		<description>Iggy's Reckin' Balls (Europe)</description>
-		<rom name="Iggy's Reckin' Balls (Europe).n64" />
-		<release name="Iggy's Reckin' Balls (Europe)" region="EUR" />
-		<rom name="Iggy's Reckin' Balls (Europe).z64" size="4194304" crc="9bf26065" md5="25b297143e9e5ccbb4b80a7fb6af399b" sha1="da3c5ba5849e104383ea4c3df1fbdb8253f184c9" />
-	</game>
-	<game name="Iggy-kun no Bura Bura Poyon (Japan)" cloneof="Iggy's Reckin' Balls (Europe)">
-		<description>Iggy-kun no Bura Bura Poyon (Japan)</description>
-		<rom name="Iggy-kun no Bura Bura Poyon (Japan).n64" />
-		<release name="Iggy-kun no Bura Bura Poyon (Japan)" region="JPN" />
-		<rom name="Iggy-kun no Bura Bura Poyon (Japan).z64" size="4194304" crc="26cc1266" md5="c70b0b680807f2b8c2c3d5dc495fa8c2" sha1="ebb8c0c99d000a366d2dba0d8d184ec18aa82d43" />
-	</game>
-	<game name="Iggy's Reckin' Balls (USA)" cloneof="Iggy's Reckin' Balls (Europe)">
-		<description>Iggy's Reckin' Balls (USA)</description>
-		<rom name="Iggy's Reckin' Balls (USA).n64" />
-		<release name="Iggy's Reckin' Balls (USA)" region="USA" />
-		<rom name="Iggy's Reckin' Balls (USA).z64" size="4194304" crc="6a6fbd5d" md5="464211abb602ee1005974d2d835a3bcf" sha1="1a32230e0ef147b3c8c07ece5aec96458286b4af" />
-	</game>
-	<game name="In-Fisherman - Bass Hunter 64 (Europe)">
-		<description>In-Fisherman - Bass Hunter 64 (Europe)</description>
-		<rom name="In-Fisherman - Bass Hunter 64 (Europe).n64" />
-		<release name="In-Fisherman - Bass Hunter 64 (Europe)" region="EUR" />
-		<rom name="In-Fisherman - Bass Hunter 64 (Europe).z64" size="8388608" crc="00da3704" md5="bf3e84cdd01cac05987fd8da5191534b" sha1="d36374be227e972b1c0b6f2cfbb8fdd724aa1074" />
-	</game>
-	<game name="In-Fisherman - Bass Hunter 64 (USA)" cloneof="In-Fisherman - Bass Hunter 64 (Europe)">
-		<description>In-Fisherman - Bass Hunter 64 (USA)</description>
-		<rom name="In-Fisherman - Bass Hunter 64 (USA).n64" />
-		<release name="In-Fisherman - Bass Hunter 64 (USA)" region="USA" />
-		<rom name="In-Fisherman - Bass Hunter 64 (USA).z64" size="8388608" crc="d8eb5e6e" md5="c605f40bf669e00a5e51baf0d00621ea" sha1="4aa373e23876c89a549c98036f456b564d779217" />
-	</game>
-	<game name="Indiana Jones and the Infernal Machine (USA)">
-		<description>Indiana Jones and the Infernal Machine (USA)</description>
-		<rom name="Indiana Jones and the Infernal Machine (USA).n64" />
-		<release name="Indiana Jones and the Infernal Machine (USA)" region="USA" />
-		<rom name="Indiana Jones and the Infernal Machine (USA).z64" size="33554432" crc="4978eb57" md5="70de1eab508596b6bbefd168b5d07194" sha1="93300d63412d6c7432109b5ad2e4a8b9348e9538" />
-	</game>
-	<game name="Indiana Jones and the Infernal Machine (Australia) (Proto)" cloneof="Indiana Jones and the Infernal Machine (USA)">
-		<description>Indiana Jones and the Infernal Machine (Australia) (Proto)</description>
-		<rom name="Indiana Jones and the Infernal Machine (Australia) (Proto).n64" />
-		<rom name="Indiana Jones and the Infernal Machine (Australia) (Proto).z64" size="33554432" crc="337219be" md5="63d7ab29ba3dfc5d5b12c1d9c5832355" sha1="8465af5538c4b636834a8b2cd5a7decadf0e8841" />
-	</game>
-	<game name="Indy Racing 2000 (USA)">
-		<description>Indy Racing 2000 (USA)</description>
-		<rom name="Indy Racing 2000 (USA).n64" />
-		<release name="Indy Racing 2000 (USA)" region="USA" />
-		<rom name="Indy Racing 2000 (USA).z64" size="16777216" crc="a5163f29" md5="a7781d441af55c4ff8afc68ab3a59313" sha1="015bf0e0bc700a80a2606d3578e4a9b7645e99ec" />
-	</game>
-	<game name="International Superstar Soccer '98 (Europe)">
-		<description>International Superstar Soccer '98 (Europe)</description>
-		<rom name="International Superstar Soccer '98 (Europe).n64" />
-		<release name="International Superstar Soccer '98 (Europe)" region="EUR" />
-		<rom name="International Superstar Soccer '98 (Europe).z64" size="12582912" crc="bf23945d" md5="34489365b550f32c97337d86d52d8c84" sha1="ccaffee3a793a0c3a5e7c48fbc4a4759ef29153f" status="verified" />
-	</game>
-	<game name="International Superstar Soccer '98 (USA)" cloneof="International Superstar Soccer '98 (Europe)">
-		<description>International Superstar Soccer '98 (USA)</description>
-		<rom name="International Superstar Soccer '98 (USA).n64" />
-		<release name="International Superstar Soccer '98 (USA)" region="USA" />
-		<rom name="International Superstar Soccer '98 (USA).z64" size="12582912" crc="b85fa721" md5="7dcc05b98e2fa690b478808ebbad5d1a" sha1="053735184d414e0a1bbd888f3c931252ea1b92fd" />
-	</game>
-	<game name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02)" cloneof="International Superstar Soccer '98 (Europe)">
-		<description>International Superstar Soccer '98 (Europe) (Beta) (1998-03-02)</description>
-		<rom name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02).n64" />
-		<rom name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02).z64" size="16777216" crc="a63dcb66" md5="21ea0b80849b084ac3138fde780e5dbb" sha1="2fb15e4517ebe84f4a354e555716105fe69dd993" />
-	</game>
-	<game name="Jikkyou World Soccer - World Cup France '98 (Japan)" cloneof="International Superstar Soccer '98 (Europe)">
-		<description>Jikkyou World Soccer - World Cup France '98 (Japan)</description>
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan).n64" />
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan).z64" size="16777216" crc="5c721850" md5="a05e7db2409deecca36e48e9d931cacb" sha1="bb1c7a8634ba6078843532264a8676f80d5b79fc" />
-	</game>
-	<game name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1)" cloneof="International Superstar Soccer '98 (Europe)">
-		<description>Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1).n64" />
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1).z64" size="16777216" crc="68dbcc04" md5="538b54c2aaea73faa3a021d42a3225be" sha1="e9ed8a0ed5b7b20b80f0e140cc4b7261a89143bb" />
-	</game>
-	<game name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)" cloneof="International Superstar Soccer '98 (Europe)">
-		<description>Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)</description>
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2).n64" />
-		<release name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)" region="JPN" />
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2).z64" size="16777216" crc="f63f9a5e" md5="2e5fd9303138e8f558bf67bb9e799960" sha1="8ea26072dd7da07c567ebca7c25071739ec563fb" />
-	</game>
-	<game name="International Superstar Soccer 2000 (Europe) (En,De)">
-		<description>International Superstar Soccer 2000 (Europe) (En,De)</description>
-		<rom name="International Superstar Soccer 2000 (Europe) (En,De).n64" />
-		<release name="International Superstar Soccer 2000 (Europe) (En,De)" region="EUR" />
-		<rom name="International Superstar Soccer 2000 (Europe) (En,De).z64" size="16777216" crc="69572558" md5="9f101b6f6bef4f267deb5c6c37a24b97" sha1="e7078e5f1e899382b1cc145df43ee8cfaa924297" status="verified" />
-	</game>
-	<game name="International Superstar Soccer 2000 (Europe) (Fr,It)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
-		<description>International Superstar Soccer 2000 (Europe) (Fr,It)</description>
-		<rom name="International Superstar Soccer 2000 (Europe) (Fr,It).n64" />
-		<release name="International Superstar Soccer 2000 (Europe) (Fr,It)" region="FRA" />
-		<release name="International Superstar Soccer 2000 (Europe) (Fr,It)" region="ITA" />
-		<rom name="International Superstar Soccer 2000 (Europe) (Fr,It).z64" size="16777216" crc="8a16a6a9" md5="cc2be97a16744860fae8a94611479c4c" sha1="b0505e13ba0f029ea735378c50b224fd618be302" status="verified" />
-	</game>
-	<game name="International Superstar Soccer 2000 (USA) (En,Es)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
-		<description>International Superstar Soccer 2000 (USA) (En,Es)</description>
-		<rom name="International Superstar Soccer 2000 (USA) (En,Es).n64" />
-		<rom name="International Superstar Soccer 2000 (USA) (En,Es).z64" size="16777216" crc="dcd0538f" md5="23a4ed8d79882594206173b1d476f0e9" sha1="e7bd36c410ce881d8b8dc853cb4b7b7961bf6a62" />
-	</game>
-	<game name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
-		<description>International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)</description>
-		<rom name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1).n64" />
-		<release name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)" region="USA" />
-		<rom name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1).z64" size="16777216" crc="4c433fdd" md5="de9498be76134bd066aa714ce2c71a16" sha1="47a993fe1316dfd9e208603370d3dddae05f1d1b" />
-	</game>
-	<game name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
-		<description>Jikkyou J.League 1999 - Perfect Striker 2 (Japan)</description>
-		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan).n64" />
-		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan).z64" size="16777216" crc="2ef647d3" md5="1fb40ee386b58feab6cf29ddb33bcccc" sha1="2967b60aa29954fc684fdf28a0e2c335759695fe" />
-	</game>
-	<game name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
-		<description>Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1).n64" />
-		<release name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)" region="JPN" />
-		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1).z64" size="16777216" crc="f96c2be1" md5="d9f8b84fd6fd21f0b1d750062ac86efc" sha1="65a69b9e8a0c5c49e1badec27bf65c426ea0cc16" />
-	</game>
-	<game name="International Superstar Soccer 64 (Europe)">
-		<description>International Superstar Soccer 64 (Europe)</description>
-		<rom name="International Superstar Soccer 64 (Europe).n64" />
-		<release name="International Superstar Soccer 64 (Europe)" region="EUR" />
-		<rom name="International Superstar Soccer 64 (Europe).z64" size="8388608" crc="8c839268" md5="376803f28ca8b2133671783419933ca2" sha1="3b53fd76bb37b923b0fe61e50057ae773a25170a" status="verified" />
-	</game>
-	<game name="International Superstar Soccer 64 (USA)" cloneof="International Superstar Soccer 64 (Europe)">
-		<description>International Superstar Soccer 64 (USA)</description>
-		<rom name="International Superstar Soccer 64 (USA).n64" />
-		<release name="International Superstar Soccer 64 (USA)" region="USA" />
-		<rom name="International Superstar Soccer 64 (USA).z64" size="8388608" crc="0ea249b9" md5="6a345402ae1db5ce1041365e36126bce" sha1="d2c258ee3844be77049e4af5208f8f2bb073a86e" />
-	</game>
-	<game name="Jikkyou World Soccer 3 (Japan)" cloneof="International Superstar Soccer 64 (Europe)">
-		<description>Jikkyou World Soccer 3 (Japan)</description>
-		<rom name="Jikkyou World Soccer 3 (Japan).n64" />
-		<release name="Jikkyou World Soccer 3 (Japan)" region="JPN" />
-		<rom name="Jikkyou World Soccer 3 (Japan).z64" size="8388608" crc="3ba9e644" md5="ef0f425689586850a6f5796124b0c85b" sha1="a06528ce7a1c007f3e8dfae199b6e65b3dbc034d" />
-	</game>
-	<game name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate)" cloneof="International Superstar Soccer 64 (Europe)">
-		<description>Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate)</description>
-		<rom name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate).n64" />
-		<release name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate)" region="BRA" />
-		<rom name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate).z64" size="8388608" crc="c296eca1" md5="14f1f43a0314c3e36d9d248e1f03ec2e" sha1="93119cee958ad7a7b28f6a945cfaa7829fe340da" />
-	</game>
-	<game name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)">
-		<description>International Track &amp; Field - Summer Games (Europe) (En,Fr,De)</description>
-		<rom name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De).n64" />
-		<release name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De).z64" size="12582912" crc="b3181ee0" md5="970488fb7d9c5c25bd924e6f898b84a0" sha1="b3d5a2128813bd077dd3e161978e3c1717e278e0" />
-	</game>
-	<game name="Ganbare! Nippon! Olympics 2000 (Japan)" cloneof="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)">
-		<description>Ganbare! Nippon! Olympics 2000 (Japan)</description>
-		<rom name="Ganbare! Nippon! Olympics 2000 (Japan).n64" />
-		<release name="Ganbare! Nippon! Olympics 2000 (Japan)" region="JPN" />
-		<rom name="Ganbare! Nippon! Olympics 2000 (Japan).z64" size="12582912" crc="73133cd2" md5="8d8f3a8393f3f5489b3b144369565594" sha1="f683446894a704df016b90cc3409ecdb70cba0aa" />
-	</game>
-	<game name="International Track &amp; Field 2000 (USA)" cloneof="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)">
-		<description>International Track &amp; Field 2000 (USA)</description>
-		<rom name="International Track &amp; Field 2000 (USA).n64" />
-		<release name="International Track &amp; Field 2000 (USA)" region="USA" />
-		<rom name="International Track &amp; Field 2000 (USA).z64" size="12582912" crc="da443f0b" md5="35662cfd07fd6af4bab90ca23f7c98e6" sha1="61d7958e61b50fd933faf5d3ae70807fa53818fb" />
-	</game>
-	<game name="iQue Club (China) (v3) (iQue)">
-		<description>iQue Club (China) (v3) (iQue)</description>
-		<rom name="iQue Club (China) (v3) (iQue).n64" />
-		<release name="iQue Club (China) (v3) (iQue)" region="CHN" />
-		<rom name="iQue Club (China) (v3) (iQue).z64" size="573440" crc="6a2c6dcb" md5="f9190dbaf547d6d3f5f3569accf26061" sha1="da6511a6f75e9770381b6225fc2057ac39e884fc" />
-	</game>
-	<game name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)">
-		<description>Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)</description>
-		<rom name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).n64" />
-		<release name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)" region="JPN" />
-		<rom name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).z64" size="16777216" crc="576915d4" md5="13893db9e919c4e7cf0c0b0064ccb554" sha1="c722ba7fd7c44fee474233db3fd251177a83a9ab" />
-	</game>
-	<game name="J.League Dynamite Soccer 64 (Japan)">
-		<description>J.League Dynamite Soccer 64 (Japan)</description>
-		<rom name="J.League Dynamite Soccer 64 (Japan).n64" />
-		<release name="J.League Dynamite Soccer 64 (Japan)" region="JPN" />
-		<rom name="J.League Dynamite Soccer 64 (Japan).z64" size="8388608" crc="dc0b2c8f" md5="1247b093e0fd6ccfd50d15de59301076" sha1="b5618ffde759bcef12a19b336cf940df24f52209" />
-	</game>
-	<game name="J.League Eleven Beat 1997 (Japan)">
-		<description>J.League Eleven Beat 1997 (Japan)</description>
-		<rom name="J.League Eleven Beat 1997 (Japan).n64" />
-		<release name="J.League Eleven Beat 1997 (Japan)" region="JPN" />
-		<rom name="J.League Eleven Beat 1997 (Japan).z64" size="8388608" crc="7d0eed6a" md5="30e23d3de446e37e5e7fbef6794a6fc9" sha1="0403902145ced0c42252981bc6c8fef2f76ccc08" />
-	</game>
-	<game name="J.League Live 64 (Japan)">
-		<description>J.League Live 64 (Japan)</description>
-		<rom name="J.League Live 64 (Japan).n64" />
-		<release name="J.League Live 64 (Japan)" region="JPN" />
-		<rom name="J.League Live 64 (Japan).z64" size="8388608" crc="4c536dd7" md5="209db8333eeb526ae9a91209175348ce" sha1="447e573eb019bf4acd48b926c89701e09198ee36" />
-	</game>
-	<game name="J.League Tactics Soccer (Japan) (Rev 1)">
-		<description>J.League Tactics Soccer (Japan) (Rev 1)</description>
-		<rom name="J.League Tactics Soccer (Japan) (Rev 1).n64" />
-		<release name="J.League Tactics Soccer (Japan) (Rev 1)" region="JPN" />
-		<rom name="J.League Tactics Soccer (Japan) (Rev 1).z64" size="12582912" crc="156e705e" md5="793dbf504e20c92f6b73b4e8a25a220c" sha1="9a47293d82c161f1cb146673ac6ad96c1730c624" />
-	</game>
-	<game name="J.League Tactics Soccer (Japan)" cloneof="J.League Tactics Soccer (Japan) (Rev 1)">
-		<description>J.League Tactics Soccer (Japan)</description>
-		<rom name="J.League Tactics Soccer (Japan).n64" />
-		<rom name="J.League Tactics Soccer (Japan).z64" size="12582912" crc="976a2d12" md5="800acc7d609ecdb3e09e68cbd05f5fa0" sha1="853cecc41c00f1bbc9972dffb94b78bdb0dfa274" />
-	</game>
-	<game name="Jangou Simulation Mahjong Dou 64 (Japan)">
-		<description>Jangou Simulation Mahjong Dou 64 (Japan)</description>
-		<rom name="Jangou Simulation Mahjong Dou 64 (Japan).n64" />
-		<release name="Jangou Simulation Mahjong Dou 64 (Japan)" region="JPN" />
-		<rom name="Jangou Simulation Mahjong Dou 64 (Japan).z64" size="8388608" crc="d1c1681e" md5="8ee01de7da2e9ad08d7ed913a5ee8632" sha1="f2f96b00709ac81ba8228bb38a8396824c29ce51" />
-	</game>
-	<game name="Jeopardy! (USA)">
-		<description>Jeopardy! (USA)</description>
-		<rom name="Jeopardy! (USA).n64" />
-		<release name="Jeopardy! (USA)" region="USA" />
-		<rom name="Jeopardy! (USA).z64" size="4194304" crc="e739947c" md5="a45f7200537c0d928a88cbba2dfeb680" sha1="c5bcf3eff6bcdd9e7846ce5fd5db3095db9c58ed" />
-	</game>
-	<game name="Jeremy McGrath Supercross 2000 (Europe)">
-		<description>Jeremy McGrath Supercross 2000 (Europe)</description>
-		<rom name="Jeremy McGrath Supercross 2000 (Europe).n64" />
-		<release name="Jeremy McGrath Supercross 2000 (Europe)" region="EUR" />
-		<rom name="Jeremy McGrath Supercross 2000 (Europe).z64" size="16777216" crc="5bf42ec4" md5="4c5be1bfc1cccff501eba2a685226962" sha1="7804a688c9f7ed39d9c1a33c0339f4317d3918dc" />
-	</game>
-	<game name="Jeremy McGrath Supercross 2000 (USA)" cloneof="Jeremy McGrath Supercross 2000 (Europe)">
-		<description>Jeremy McGrath Supercross 2000 (USA)</description>
-		<rom name="Jeremy McGrath Supercross 2000 (USA).n64" />
-		<release name="Jeremy McGrath Supercross 2000 (USA)" region="USA" />
-		<rom name="Jeremy McGrath Supercross 2000 (USA).z64" size="16777216" crc="2a5c9a06" md5="8046a4b8abd4353b2ab9696106ccf8d2" sha1="278ad55333b7b75970812ecb9e691111ca3cfc46" />
-	</game>
-	<game name="Jet Force Gemini (Europe) (En,Fr,De,Es)">
-		<description>Jet Force Gemini (Europe) (En,Fr,De,Es)</description>
-		<rom name="Jet Force Gemini (Europe) (En,Fr,De,Es).n64" />
-		<release name="Jet Force Gemini (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Jet Force Gemini (Europe) (En,Fr,De,Es).z64" size="33554432" crc="cfbed88c" md5="baaf237e71aa7526c9b2f01c08b68a53" sha1="50651c4e0c46332f7f0b45870263f0a8b9a49602" />
-	</game>
-	<game name="Jet Force Gemini (USA)" cloneof="Jet Force Gemini (Europe) (En,Fr,De,Es)">
-		<description>Jet Force Gemini (USA)</description>
-		<rom name="Jet Force Gemini (USA).n64" />
-		<release name="Jet Force Gemini (USA)" region="USA" />
-		<rom name="Jet Force Gemini (USA).z64" size="33554432" crc="6753d5a3" md5="772cc6eab2620d2d3cdc17bbc26c4f68" sha1="493ced9008dbe932d6e91179b68e8630cf23a023" />
-	</game>
-	<game name="Jet Force Gemini (USA) (Demo) (Kiosk)" cloneof="Jet Force Gemini (Europe) (En,Fr,De,Es)">
-		<description>Jet Force Gemini (USA) (Demo) (Kiosk)</description>
-		<rom name="Jet Force Gemini (USA) (Demo) (Kiosk).n64" />
-		<rom name="Jet Force Gemini (USA) (Demo) (Kiosk).z64" size="33554432" crc="fa061b96" md5="5bbe9ade7171f2e1daaa7c48fad38728" sha1="f00f7c7fb085d0df57dcb649793aced5be4e8562" />
-	</game>
-	<game name="Star Twins (Japan)" cloneof="Jet Force Gemini (Europe) (En,Fr,De,Es)">
-		<description>Star Twins (Japan)</description>
-		<rom name="Star Twins (Japan).n64" />
-		<release name="Star Twins (Japan)" region="JPN" />
-		<rom name="Star Twins (Japan).z64" size="33554432" crc="964506ce" md5="ca28a3645fc7ad969ebd75c5d6506e7a" sha1="15099233760b36e7afad7da36b9464da1512c4b1" />
-	</game>
-	<game name="Jikkyou G1 Stable (Japan) (Rev 1)">
-		<description>Jikkyou G1 Stable (Japan) (Rev 1)</description>
-		<rom name="Jikkyou G1 Stable (Japan) (Rev 1).n64" />
-		<release name="Jikkyou G1 Stable (Japan) (Rev 1)" region="JPN" />
-		<rom name="Jikkyou G1 Stable (Japan) (Rev 1).z64" size="16777216" crc="6fc0a31b" md5="482bdd39ad2574b943db780b12a9bdfb" sha1="ad0ebbb4b2ea4dffbfd99c77f9be530a479ef7e1" />
-	</game>
-	<game name="Jikkyou G1 Stable (Japan)" cloneof="Jikkyou G1 Stable (Japan) (Rev 1)">
-		<description>Jikkyou G1 Stable (Japan)</description>
-		<rom name="Jikkyou G1 Stable (Japan).n64" />
-		<rom name="Jikkyou G1 Stable (Japan).z64" size="16777216" crc="0a796c3e" md5="878d8a26fd02fdb08200464cb6f566ef" sha1="eb7b24bac29df362cab562662ae9a5de7d5fb0c3" />
-	</game>
-	<game name="Jikkyou J.League Perfect Striker (Japan)">
-		<description>Jikkyou J.League Perfect Striker (Japan)</description>
-		<rom name="Jikkyou J.League Perfect Striker (Japan).n64" />
-		<release name="Jikkyou J.League Perfect Striker (Japan)" region="JPN" />
-		<rom name="Jikkyou J.League Perfect Striker (Japan).z64" size="8388608" crc="8ed60dea" md5="58153ac5c4030d1bfd3c15cf57fb02e7" sha1="e1185922648a6b9dec1c820f43a292e480e396cc" status="verified" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)">
-		<description>Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1).n64" />
-		<release name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)" region="JPN" />
-		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1).z64" size="16777216" crc="bc7ef5c1" md5="f13d0803885b73b4a6b35eddd40b9253" sha1="8fc693bc19c362716cfbaa7d1ef513685bec99e0" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)">
-		<description>Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan).n64" />
-		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan).z64" size="16777216" crc="6a9e24d7" md5="7fc933a64884a382aa07605ea7204ff5" sha1="b24170ed95734dd12084ca3c82b678fabcbd4279" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)">
-		<description>Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1).n64" />
-		<release name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)" region="JPN" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1).z64" size="16777216" crc="753706ef" md5="b653c963ed8d3a749676810f07cfe4e5" sha1="2b9425be9c6f76eb6594d414299c24e19cf12992" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 2000 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)">
-		<description>Jikkyou Powerful Pro Yakyuu 2000 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan).n64" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan).z64" size="16777216" crc="351cde48" md5="23409668a6e6c4ece7b5fb0b7d0e8f2c" sha1="365d6efa2665b816a5e0e2233c890ddcd524c05d" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)">
-		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1).n64" />
-		<release name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)" region="JPN" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1).z64" size="12582912" crc="40e3ac61" md5="b454490eb44f0978f009fa41de8c478e" sha1="d11b2860925c3784cbd4ad163111414537c5378a" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)">
-		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan).n64" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan).z64" size="12582912" crc="480b953e" md5="fda57f65eb159278223eb9d03267c27f" sha1="7e27a27bad4f98500d7a68ec43ab7bffe5de03e1" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30)" cloneof="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)">
-		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30).n64" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30).z64" size="16777216" crc="1b8b9a68" md5="ada39573b25804610d8fafaff741b088" sha1="c780866c263f5d9ae8f70bad558b0de6d5795115" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)">
-		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2).n64" />
-		<release name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)" region="JPN" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2).z64" size="16777216" crc="c02fd9be" md5="68a27fbab060857c267a639931d2c3d6" sha1="a504c2978d8cfffccbb815cc00d96dc0b7bece3b" status="verified" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)">
-		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan).n64" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan).z64" size="16777216" crc="feec34f6" md5="e9f989e09e3f1519aefe619889a4f710" sha1="f1bc8d2a6b03ffab7355c4e7b5fa1c393421e9f9" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1)" cloneof="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)">
-		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1).n64" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1).z64" size="16777216" crc="7994c2fe" md5="6ef19bf8d8d6196390745f1b858ac16a" sha1="a830e30c8272220c5481f294aa5cb5014df05499" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)">
-		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2).n64" />
-		<release name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)" region="JPN" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2).z64" size="16777216" crc="fcc10356" md5="03bd8e5ca2b1b7d74398db4739979282" sha1="2763b83846165221c8b80bc4430f5b55779622e3" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)">
-		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan).n64" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan).z64" size="16777216" crc="1e53a7ba" md5="060d0313e23b660180441fcc7d24d7db" sha1="02924d963d214102cb723b0e54c901968aa51a1f" />
-	</game>
-	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1)" cloneof="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)">
-		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1).n64" />
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1).z64" size="16777216" crc="7ab7ebf4" md5="23ee24faba0edfb04b5b0407e174496b" sha1="828002c3f34eb357458a9a9c4fa989ba82927fe9" />
-	</game>
-	<game name="Jinsei Game 64 (Japan)">
-		<description>Jinsei Game 64 (Japan)</description>
-		<rom name="Jinsei Game 64 (Japan).n64" />
-		<release name="Jinsei Game 64 (Japan)" region="JPN" />
-		<rom name="Jinsei Game 64 (Japan).z64" size="16777216" crc="67a1a22c" md5="68230d510015ff6817ef898c0b8b636c" sha1="8759a3fc272c3f6259bbe2433eb34411705d8634" />
-	</game>
-	<game name="John Romero's Daikatana (Europe) (En,Fr,De)">
-		<description>John Romero's Daikatana (Europe) (En,Fr,De)</description>
-		<rom name="John Romero's Daikatana (Europe) (En,Fr,De).n64" />
-		<release name="John Romero's Daikatana (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="John Romero's Daikatana (Europe) (En,Fr,De).z64" size="16777216" crc="f88ac3ce" md5="7ab29c6ad2d8f4007d8213eb3411e0bd" sha1="0278c3f9b2780890c4c2a3ee8a10c550a1eda346" />
-	</game>
-	<game name="John Romero's Daikatana (Japan)" cloneof="John Romero's Daikatana (Europe) (En,Fr,De)">
-		<description>John Romero's Daikatana (Japan)</description>
-		<rom name="John Romero's Daikatana (Japan).n64" />
-		<release name="John Romero's Daikatana (Japan)" region="JPN" />
-		<rom name="John Romero's Daikatana (Japan).z64" size="16777216" crc="44b80fd7" md5="57d31ea7121dd5a05b547225efa5cfd7" sha1="4ed2ec28997865e301c5693639c2ec717c79a5bc" />
-	</game>
-	<game name="John Romero's Daikatana (USA)" cloneof="John Romero's Daikatana (Europe) (En,Fr,De)">
-		<description>John Romero's Daikatana (USA)</description>
-		<rom name="John Romero's Daikatana (USA).n64" />
-		<release name="John Romero's Daikatana (USA)" region="USA" />
-		<rom name="John Romero's Daikatana (USA).z64" size="16777216" crc="494950c6" md5="5b4c268422469f50b94779e655f2b798" sha1="08709013d512f3a2bed65b98ab451ec8b839d3b4" />
-	</game>
-	<game name="Ken Griffey Jr.'s Slugfest (USA)">
-		<description>Ken Griffey Jr.'s Slugfest (USA)</description>
-		<rom name="Ken Griffey Jr.'s Slugfest (USA).n64" />
-		<release name="Ken Griffey Jr.'s Slugfest (USA)" region="USA" />
-		<rom name="Ken Griffey Jr.'s Slugfest (USA).z64" size="16777216" crc="12d8f3e9" md5="eec0fab75af59e9c23e6de2132de89ff" sha1="ec33cd4d44bba163f89e435c2aefbf7313d8cece" />
-	</game>
-	<game name="Killer Instinct Gold (Europe)">
-		<description>Killer Instinct Gold (Europe)</description>
-		<rom name="Killer Instinct Gold (Europe).n64" />
-		<release name="Killer Instinct Gold (Europe)" region="EUR" />
-		<rom name="Killer Instinct Gold (Europe).z64" size="12582912" crc="5d0ee5d2" md5="c93d92f10a1a97d2ba87386be7d178fd" sha1="e0ed97c7310b012a5cf81c6f6678a75b8601b47e" status="verified" />
-	</game>
-	<game name="Killer Instinct Gold (USA)" cloneof="Killer Instinct Gold (Europe)">
-		<description>Killer Instinct Gold (USA)</description>
-		<rom name="Killer Instinct Gold (USA).n64" />
-		<rom name="Killer Instinct Gold (USA).z64" size="12582912" crc="31c76be7" md5="8e33ad20c31feb61d7230fad28846c5c" sha1="ba52e91b44450c548467044b26951353dc491e04" status="verified" />
-	</game>
-	<game name="Killer Instinct Gold (USA) (Rev 1)" cloneof="Killer Instinct Gold (Europe)">
-		<description>Killer Instinct Gold (USA) (Rev 1)</description>
-		<rom name="Killer Instinct Gold (USA) (Rev 1).n64" />
-		<rom name="Killer Instinct Gold (USA) (Rev 1).z64" size="12582912" crc="49ef8f2b" md5="4c9b419dc583c0df4ab908adf83bfc65" sha1="bcc599ed0f0b8b75a8068269958a2230ec7cb34c" />
-	</game>
-	<game name="Killer Instinct Gold (USA) (Rev 2)" cloneof="Killer Instinct Gold (Europe)">
-		<description>Killer Instinct Gold (USA) (Rev 2)</description>
-		<rom name="Killer Instinct Gold (USA) (Rev 2).n64" />
-		<release name="Killer Instinct Gold (USA) (Rev 2)" region="USA" />
-		<rom name="Killer Instinct Gold (USA) (Rev 2).z64" size="12582912" crc="0b5b5df8" md5="dd0a82fcc10397afb37f12bb7f94e67a" sha1="aaeb492b1e538af65a3544a97240675ef438a04f" />
-	</game>
-	<game name="Kiratto Kaiketsu! 64 Tanteidan (Japan)">
-		<description>Kiratto Kaiketsu! 64 Tanteidan (Japan)</description>
-		<rom name="Kiratto Kaiketsu! 64 Tanteidan (Japan).n64" />
-		<release name="Kiratto Kaiketsu! 64 Tanteidan (Japan)" region="JPN" />
-		<rom name="Kiratto Kaiketsu! 64 Tanteidan (Japan).z64" size="12582912" crc="7fdc3784" md5="32257bfffd9b2d680f582e148e9b0611" sha1="5340930ee4a26d8897c8734ee812e769c162be0f" />
-	</game>
-	<game name="Kirby 64 - The Crystal Shards (Europe)">
-		<description>Kirby 64 - The Crystal Shards (Europe)</description>
-		<rom name="Kirby 64 - The Crystal Shards (Europe).n64" />
-		<release name="Kirby 64 - The Crystal Shards (Europe)" region="EUR" />
-		<rom name="Kirby 64 - The Crystal Shards (Europe).z64" size="33554432" crc="5b8b89ef" md5="a44b7a612964a6d6139d0426e569d9c9" sha1="52e8382252ec9b629662153eae6f87ae3675b700" status="verified" />
-	</game>
-	<game name="Hoshi no Kirby 64 (Japan)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
-		<description>Hoshi no Kirby 64 (Japan)</description>
-		<rom name="Hoshi no Kirby 64 (Japan).n64" />
-		<rom name="Hoshi no Kirby 64 (Japan).z64" size="33554432" crc="ae7cb69d" md5="b1a67aebc2be89a800e5eb60c0dfa968" sha1="b9882992907a102bd33373585acc90b9c7eb1ba4" />
-	</game>
-	<game name="Hoshi no Kirby 64 (Japan) (Rev 1)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
-		<description>Hoshi no Kirby 64 (Japan) (Rev 1)</description>
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 1).n64" />
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 1).z64" size="33554432" crc="a263c1b9" md5="ffdb4456f799722bcfe430632c3986ae" sha1="2502ceb1afba83c90f3e7f98b283f667b85d4150" />
-	</game>
-	<game name="Hoshi no Kirby 64 (Japan) (Rev 2)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
-		<description>Hoshi no Kirby 64 (Japan) (Rev 2)</description>
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 2).n64" />
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 2).z64" size="33554432" crc="f4589aa8" md5="3ec0471e2cbee17471ddbf80c56606d5" sha1="c177f4e37eff98ef2d18fb1e94cd253fd366a218" />
-	</game>
-	<game name="Hoshi no Kirby 64 (Japan) (Rev 3)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
-		<description>Hoshi no Kirby 64 (Japan) (Rev 3)</description>
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 3).n64" />
-		<release name="Hoshi no Kirby 64 (Japan) (Rev 3)" region="JPN" />
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 3).z64" size="33554432" crc="6d5e1332" md5="35e039f8e79843917d02be06d00c457b" sha1="03257c820b7705400c32bde1bcc3161c55814605" status="verified" />
-	</game>
-	<game name="Kirby 64 - The Crystal Shards (USA)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
-		<description>Kirby 64 - The Crystal Shards (USA)</description>
-		<rom name="Kirby 64 - The Crystal Shards (USA).n64" />
-		<release name="Kirby 64 - The Crystal Shards (USA)" region="USA" />
-		<rom name="Kirby 64 - The Crystal Shards (USA).z64" size="33554432" crc="20a1c120" md5="d33e4254336383a17ff4728360562ada" sha1="6cea2d46b929a3bb347b060a77fccc83526fb855" status="verified" />
-	</game>
-	<game name="Knife Edge - Nose Gunner (Europe)">
-		<description>Knife Edge - Nose Gunner (Europe)</description>
-		<rom name="Knife Edge - Nose Gunner (Europe).n64" />
-		<release name="Knife Edge - Nose Gunner (Europe)" region="EUR" />
-		<rom name="Knife Edge - Nose Gunner (Europe).z64" size="8388608" crc="b77783be" md5="d31a94a5685a21a932cc886d64cc9b21" sha1="5359c747e91c9119fde3a7920333a9d0c04d251d" />
-	</game>
-	<game name="Knife Edge - Nose Gunner (Japan)" cloneof="Knife Edge - Nose Gunner (Europe)">
-		<description>Knife Edge - Nose Gunner (Japan)</description>
-		<rom name="Knife Edge - Nose Gunner (Japan).n64" />
-		<release name="Knife Edge - Nose Gunner (Japan)" region="JPN" />
-		<rom name="Knife Edge - Nose Gunner (Japan).z64" size="8388608" crc="3bc93017" md5="436ba873e9466aab237d9429348a5f70" sha1="b3242226237a401436d9d7a8d533296333e64240" />
-	</game>
-	<game name="Knife Edge - Nose Gunner (USA)" cloneof="Knife Edge - Nose Gunner (Europe)">
-		<description>Knife Edge - Nose Gunner (USA)</description>
-		<rom name="Knife Edge - Nose Gunner (USA).n64" />
-		<release name="Knife Edge - Nose Gunner (USA)" region="USA" />
-		<rom name="Knife Edge - Nose Gunner (USA).z64" size="8388608" crc="255ee1dd" md5="8043d829fcd4f8f72dd81e5c6dde916f" sha1="b247167e37e7f62924be6b0d2362a091fd2352ac" />
-	</game>
-	<game name="Knockout Kings 2000 (Europe)">
-		<description>Knockout Kings 2000 (Europe)</description>
-		<rom name="Knockout Kings 2000 (Europe).n64" />
-		<release name="Knockout Kings 2000 (Europe)" region="EUR" />
-		<rom name="Knockout Kings 2000 (Europe).z64" size="16777216" crc="58ce7d80" md5="e95d73ff55fbb63e79aa9eab14608584" sha1="181d220efaa3e06ac5a7baac4b6a351b762ec384" />
-	</game>
-	<game name="Knockout Kings 2000 (USA)" cloneof="Knockout Kings 2000 (Europe)">
-		<description>Knockout Kings 2000 (USA)</description>
-		<rom name="Knockout Kings 2000 (USA).n64" />
-		<release name="Knockout Kings 2000 (USA)" region="USA" />
-		<rom name="Knockout Kings 2000 (USA).z64" size="16777216" crc="074690d6" md5="008b473841ce4d9ac050d55f99b4b5d4" sha1="ae7229676da9acb39becb03246969693585b7728" />
-	</game>
-	<game name="Kobe Bryant in NBA Courtside (Europe)">
-		<description>Kobe Bryant in NBA Courtside (Europe)</description>
-		<rom name="Kobe Bryant in NBA Courtside (Europe).n64" />
-		<release name="Kobe Bryant in NBA Courtside (Europe)" region="EUR" />
-		<rom name="Kobe Bryant in NBA Courtside (Europe).z64" size="12582912" crc="1355a826" md5="c6b01c020fdfd2e5c037c5a330b161ad" sha1="6390dc1cd4600ca57069d92f39f108a4cc1b62f1" />
-	</game>
-	<game name="Kobe Bryant in NBA Courtside (USA)" cloneof="Kobe Bryant in NBA Courtside (Europe)">
-		<description>Kobe Bryant in NBA Courtside (USA)</description>
-		<rom name="Kobe Bryant in NBA Courtside (USA).n64" />
-		<release name="Kobe Bryant in NBA Courtside (USA)" region="USA" />
-		<rom name="Kobe Bryant in NBA Courtside (USA).z64" size="12582912" crc="86360bfb" md5="d37c79e4e4eabcb5dc6a07bd76688223" sha1="49346b3124750c14dddf56b9bb2fe38b618f28f2" />
-	</game>
-	<game name="Last Legion UX (Japan)">
-		<description>Last Legion UX (Japan)</description>
-		<rom name="Last Legion UX (Japan).n64" />
-		<release name="Last Legion UX (Japan)" region="JPN" />
-		<rom name="Last Legion UX (Japan).z64" size="12582912" crc="9db99881" md5="eb11fc0797ae1107201c4601fee5471a" sha1="dfdf852d0939466ad1f1627f4de29b7288a77589" />
-	</game>
-	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1).n64" />
-		<release name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)" region="EUR" />
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1).z64" size="33554432" crc="e2e6823d" md5="beccfded43a2f159d03555027462a950" sha1="bb4e4757d10727c7584c59c1f2e5f44196e9c293" />
-	</game>
-	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).n64" />
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).z64" size="33554432" crc="9ead1608" md5="13fab67e603b002ceaf0eea84130e973" sha1="c04599cdafee1c84a7af9a71df68f139179ada84" status="verified" />
-	</game>
-	<game name="Legend of Zelda, The - Majora's Mask (USA)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Legend of Zelda, The - Majora's Mask (USA)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (USA).n64" />
-		<release name="Legend of Zelda, The - Majora's Mask (USA)" region="USA" />
-		<rom name="Legend of Zelda, The - Majora's Mask (USA).z64" size="33554432" crc="b428d8a7" md5="2a0a8acb61538235bc1094d297fb6556" sha1="d6133ace5afaa0882cf214cf88daba39e266c078" status="verified" />
-	</game>
-	<game name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk).n64" />
-		<rom name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk).z64" size="33554432" crc="dcc110a0" md5="8f281800fba5ddcb1d2b377731fc0215" sha1="2f0744f2422b0421697a74b305cb1ef27041ab11" />
-	</game>
-	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug).n64" />
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug).z64" size="67108864" crc="04ea55ea" md5="02f963fa8f95e3a7f0b6c13d81999ba9" sha1="55541662a192c66e34a011d4bf6f4a0ec69899ae" />
-	</game>
-	<game name="Legend of Zelda, The - Majora's Mask (USA) (GameCube)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Legend of Zelda, The - Majora's Mask (USA) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (USA) (GameCube).n64" />
-		<rom name="Legend of Zelda, The - Majora's Mask (USA) (GameCube).z64" size="33554432" crc="b008458f" md5="ac0751dbc23ab2ec0c3144203aca0003" sha1="9743aa026e9269b339eb0e3044cd5830a440c1fd" status="verified" />
-	</game>
-	<game name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Legend of Zelda, The - Majora's Mask (Europe) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube).n64" />
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube).z64" size="33554432" crc="12836e19" md5="dbe9af0db46256e42b5c67902b696549" sha1="a849a65e56d57d4dd98b550524150f898df90a9f" />
-	</game>
-	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console).n64" />
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console).z64" size="33554432" crc="a83abf72" md5="609b47b79da21f3df9b31d06c95c09a1" sha1="c487db55c2c3a97ccd39ded13ef9fd9121dae729" />
-	</game>
-	<game name="Zelda no Densetsu - Mujura no Kamen (Japan)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Zelda no Densetsu - Mujura no Kamen (Japan)</description>
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan).n64" />
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan).z64" size="33554432" crc="0d33e1db" md5="15d1a2217cad61c39cfecbffa0703e25" sha1="5fb2301aacbf85278af30dca3e4194ad48599e36" status="verified" />
-	</game>
-	<game name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)</description>
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1).n64" />
-		<release name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)" region="JPN" />
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1).z64" size="33554432" crc="356c2e19" md5="c38a7f6f6b61862ea383a75cdf888279" sha1="41fdb879ab422ec158b4eafea69087f255ea8589" status="verified" />
-	</game>
-	<game name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
-		<description>Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube)</description>
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube).n64" />
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube).z64" size="33554432" crc="b9bf76df" md5="d3929aadf7640f8c5b4ce8321ad4393a" sha1="1438fd501e3e5b25461770af88c02ab1e41d3a7e" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1).n64" />
-		<release name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)" region="EUR" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1).z64" size="33554432" crc="a108f6e3" md5="d714580dd74c2c033f5e1b6dc0aeac77" sha1="cfbb98d392e4a9d39da8285d10cbef3974c2f012" status="verified" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).z64" size="33554432" crc="946fd0f7" md5="e040de91a74b61e3201db0e2323f768a" sha1="328a1f1beba30ce5e178f031662019eb32c5f3b5" status="verified" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (USA)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (USA)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA).z64" size="33554432" crc="cd16c529" md5="5bd1fe107bf8106b2ab6650abecd54d6" sha1="ad69c91157f6705e8ab06c79fe08aad47bb57ba7" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (USA) (Rev 1)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1).z64" size="33554432" crc="3fd2151e" md5="721fdcc6f5f34be55c43a807f2a16af4" sha1="d3ecb253776cd847a5aa63d859d8c89a2f37b364" status="verified" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2).n64" />
-		<release name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)" region="USA" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2).z64" size="33554432" crc="32120c23" md5="57a9719ad547c516342e1a15d5c28c3d" sha1="41b3bdc48d98c48529219919015a1af22f5057c2" status="verified" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (USA) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube).z64" size="33554432" crc="346de3ae" md5="cd09029edcfb7c097ac01986a0f83d3f" sha1="b82710ba2bd3b4c6ee8aa1a7e9acf787dfc72e9b" status="verified" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (Europe) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube).z64" size="33554432" crc="3fbd519f" md5="2c27b4e000e85fd78dbca551f1b1c965" sha1="0227d7c0074f2d0ac935631990da8ec5914597b4" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube).z64" size="67108864" crc="5d1b2996" md5="3c10b67a76616ae2c162def7528724cf" sha1="cee6bc3c2a634b41728f2af8da54d9bf8cc14099" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Beta)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (USA) (Beta)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Beta).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Beta).z64" size="33554432" crc="6c348aa8" md5="21f7b4a4ff463464bfc23498c1ab9da1" sha1="70537a3144c8813b115252c40065c117cb139dcd" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube).z64" size="67108864" crc="c188acda" md5="ab1ca59d0039e3b34d82db650b54d7b9" sha1="da19ca4aac723c155d55ae371107b8462044e350" />
-	</game>
-	<game name="Zelda Chuanshuo Shiguang Zhi Di (China) (iQue)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Zelda Chuanshuo Shiguang Zhi Di (China) (iQue)</description>
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (iQue).n64" />
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (iQue).z64" size="29868032" crc="f45c5532" md5="0ab48b2d44a74b3bb2d384f6170c2742" sha1="1015d0f3af34b89149bfd773580bbc66466af54e" />
-	</game>
-	<game name="Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue)</description>
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue).n64" />
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue).z64" size="29868032" crc="e8e3575f" md5="a475e9f8615513666a265c464708ae8f" sha1="8668469647423735cc05f55a479c9d3135fbf838" />
-	</game>
-	<game name="Zelda no Densetsu - Toki no Ocarina (Japan)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Zelda no Densetsu - Toki no Ocarina (Japan)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan).n64" />
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan).z64" size="33554432" crc="d423e8b0" md5="9f04c8e68534b870f707c247fa4b50fc" sha1="c892bbda3993e66bd0d56a10ecd30b1ee612210f" />
-	</game>
-	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1).n64" />
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1).z64" size="33554432" crc="26e73887" md5="1bf5f42b98c3e97948f01155f12e2d88" sha1="dbfc81f655187dc6fefd93fa6798face770d579d" status="verified" />
-	</game>
-	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2).n64" />
-		<release name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)" region="JPN" />
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2).z64" size="33554432" crc="2b2721ba" md5="2258052847bdd056c8406a9ef6427f13" sha1="fa5f5942b27480d60243c2d52c0e93e26b9e6b86" status="verified" />
-	</game>
-	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection).n64" />
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection).z64" size="33554432" crc="8c5b90c1" md5="0c13e0449a28ea5b925cdb8af8d29768" sha1="2ce2d1a9f0534c9cd9fa04ea5317b80da21e5e73" />
-	</game>
-	<game name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
-		<description>Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube).n64" />
-		<rom name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube).z64" size="33554432" crc="1c6ce8cb" md5="33fb7852c180b18ea0b9620b630f413f" sha1="0769c84615422d60f16925cd859593cdfa597f84" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)">
-		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube).n64" />
-		<release name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)" region="EUR" />
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube).z64" size="33554432" crc="832d6449" md5="1618403427e4344a57833043db5ce3c3" sha1="f46239439f59a2a594ef83cf68ef65043b1bffe2" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)">
-		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube).n64" />
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube).z64" size="67108864" crc="62f92704" md5="8ca71e87de4ce5e9f6ec916202a623e9" sha1="50bebedad9e0f10746a52b07239e47fa6c284d03" />
-	</game>
-	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)">
-		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube).n64" />
-		<release name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)" region="USA" />
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube).z64" size="33554432" crc="c744c4db" md5="da35577fe54579f6a266931cc75f512d" sha1="8b5d13aac69bfbf989861cfdc50b1d840945fc1d" />
-	</game>
-	<game name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)">
-		<description>Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube).n64" />
-		<release name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)" region="JPN" />
-		<rom name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube).z64" size="33554432" crc="122ff261" md5="69895c5c78442260f6eafb2506dc482a" sha1="dd14e143c4275861fe93ea79d0c02e36ae8c6c2f" />
-	</game>
-	<game name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)">
-		<description>LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)</description>
-		<rom name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" />
-		<release name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" region="EUR" />
-		<rom name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).z64" size="16777216" crc="c7d9b21c" md5="6310c7173385ed2b06020f3b90158e9e" sha1="6e9c4b097628f0147e9e79393dba6d7b4e59986f" />
-	</game>
-	<game name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" cloneof="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)">
-		<description>LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)</description>
-		<rom name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" />
-		<release name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" region="USA" />
-		<rom name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).z64" size="16777216" crc="4d1e1897" md5="26b5eaa13dc5b5e35307fe8c0cf5b6ba" sha1="8decc41869926e20da2eb3da526e6395aa33cece" />
-	</game>
-	<game name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)">
-		<description>Lode Runner 3-D (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="7148251d" md5="e62f4fdcc82c244ba9709e40756d9b62" sha1="3b198c0117da808b25fbc4e543d282228bb4780a" />
-	</game>
-	<game name="Lode Runner 3-D (Japan)" cloneof="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)">
-		<description>Lode Runner 3-D (Japan)</description>
-		<rom name="Lode Runner 3-D (Japan).n64" />
-		<release name="Lode Runner 3-D (Japan)" region="JPN" />
-		<rom name="Lode Runner 3-D (Japan).z64" size="8388608" crc="1d4fb466" md5="d2bd8dd8c3be1e8f0b8ae49206dbd7e5" sha1="a115c19e1dea438861437a326124c0e7a482de3b" />
-	</game>
-	<game name="Lode Runner 3-D (USA)" cloneof="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)">
-		<description>Lode Runner 3-D (USA)</description>
-		<rom name="Lode Runner 3-D (USA).n64" />
-		<release name="Lode Runner 3-D (USA)" region="USA" />
-		<rom name="Lode Runner 3-D (USA).z64" size="8388608" crc="4ea07453" md5="d038813541589f0b3f1f900f4fd22c9b" sha1="d3a13c0cfdff835fdf87d5dc7c5149fba564877f" />
-	</game>
-	<game name="Lylatwars (Europe) (En,Fr,De)">
-		<description>Lylatwars (Europe) (En,Fr,De)</description>
-		<rom name="Lylatwars (Europe) (En,Fr,De).n64" />
-		<release name="Lylatwars (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Lylatwars (Europe) (En,Fr,De).z64" size="12582912" crc="50a9c0b1" md5="884ccca35cbeedb8ed288326f9662100" sha1="05b307b8804f992af1a1e2fbafbd588501fdf799" status="verified" />
-	</game>
-	<game name="Lylat Wars (Australia) (En,Fr,De)" cloneof="Lylatwars (Europe) (En,Fr,De)">
-		<description>Lylat Wars (Australia) (En,Fr,De)</description>
-		<rom name="Lylat Wars (Australia) (En,Fr,De).n64" />
-		<release name="Lylat Wars (Australia) (En,Fr,De)" region="AUS" />
-		<rom name="Lylat Wars (Australia) (En,Fr,De).z64" size="12582912" crc="9a3425da" md5="7a99628edf0a6602d0c408f31b701435" sha1="47a8ccc11450f9044ca2292b9fc3c58949b9caac" />
-	</game>
-	<game name="Star Fox 64 (Japan)" cloneof="Lylatwars (Europe) (En,Fr,De)">
-		<description>Star Fox 64 (Japan)</description>
-		<rom name="Star Fox 64 (Japan).n64" />
-		<release name="Star Fox 64 (Japan)" region="JPN" />
-		<rom name="Star Fox 64 (Japan).z64" size="12582912" crc="411142a7" md5="446d5215c4d34eb8ab0f355f324b8d0e" sha1="9bd71afbecf4d0a43146e4e7a893395e19bf3220" status="verified" />
-	</game>
-	<game name="Star Fox 64 (USA)" cloneof="Lylatwars (Europe) (En,Fr,De)">
-		<description>Star Fox 64 (USA)</description>
-		<rom name="Star Fox 64 (USA).n64" />
-		<rom name="Star Fox 64 (USA).z64" size="12582912" crc="b1fcaa9c" md5="caf9a78db13ee00002ff63a3c0c5eabb" sha1="d8b1088520f7c5f81433292a9258c1184afa1457" status="verified" />
-	</game>
-	<game name="Star Fox 64 (USA) (Rev 1)" cloneof="Lylatwars (Europe) (En,Fr,De)">
-		<description>Star Fox 64 (USA) (Rev 1)</description>
-		<rom name="Star Fox 64 (USA) (Rev 1).n64" />
-		<release name="Star Fox 64 (USA) (Rev 1)" region="USA" />
-		<rom name="Star Fox 64 (USA) (Rev 1).z64" size="12582912" crc="b1b5fc46" md5="741a94eee093c4c8684e66b89f8685e8" sha1="09f0d105f476b00efa5303a3ebc42e60a7753b7a" status="verified" />
-	</game>
-	<game name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console)" cloneof="Lylatwars (Europe) (En,Fr,De)">
-		<description>Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console)</description>
-		<rom name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console).n64" />
-		<rom name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console).z64" size="12582912" crc="6508d4ad" md5="91fc4c63ca613530df22c8bb810cb2c3" sha1="a39f14f0d1224095717fabc021023203cb7561d5" />
-	</game>
-	<game name="Xingji Huohu (China) (v5) (iQue)" cloneof="Lylatwars (Europe) (En,Fr,De)">
-		<description>Xingji Huohu (China) (v5) (iQue)</description>
-		<rom name="Xingji Huohu (China) (v5) (iQue).n64" />
-		<rom name="Xingji Huohu (China) (v5) (iQue).z64" size="11829248" crc="0d28c3ed" md5="b2242070800bf82e78ce33dc92a1db84" sha1="c8a10699dea52f4bb2e2311935c1376dfb352e7a" />
-	</game>
-	<game name="Mace - The Dark Age (Europe)">
-		<description>Mace - The Dark Age (Europe)</description>
-		<rom name="Mace - The Dark Age (Europe).n64" />
-		<release name="Mace - The Dark Age (Europe)" region="EUR" />
-		<rom name="Mace - The Dark Age (Europe).z64" size="12582912" crc="57ddede1" md5="523883a766c662e8377cd256755b27b4" sha1="19fc1fe13a3c50a5d03d44d2e93440967c7f3618" />
-	</game>
-	<game name="Mace - The Dark Age (USA)" cloneof="Mace - The Dark Age (Europe)">
-		<description>Mace - The Dark Age (USA)</description>
-		<rom name="Mace - The Dark Age (USA).n64" />
-		<release name="Mace - The Dark Age (USA)" region="USA" />
-		<rom name="Mace - The Dark Age (USA).z64" size="12582912" crc="d2a363a6" md5="39a2bca1c17cd4cf1a9f3ae2b725b5c6" sha1="05d82a2c73ac536180b68137dbb9972a9e8e883e" />
-	</game>
-	<game name="Mace - The Dark Age (Unknown) (Beta)" cloneof="Mace - The Dark Age (Europe)">
-		<description>Mace - The Dark Age (Unknown) (Beta)</description>
-		<rom name="Mace - The Dark Age (Unknown) (Beta).n64" />
-		<rom name="Mace - The Dark Age (Unknown) (Beta).z64" size="13144800" crc="2b23212f" md5="3eb81ab11b8c58305a64ce06817d0538" sha1="c515895faaa5ebf0d043d285aaf51046b5e28b8f" />
-	</game>
-	<game name="Madden Football 64 (Europe)">
-		<description>Madden Football 64 (Europe)</description>
-		<rom name="Madden Football 64 (Europe).n64" />
-		<release name="Madden Football 64 (Europe)" region="EUR" />
-		<rom name="Madden Football 64 (Europe).z64" size="12582912" crc="fab3e50d" md5="67c96076459eb5f71733f39d7fcc76a3" sha1="acf22b715b11609f42df24abac143bc0221d12f4" />
-	</game>
-	<game name="Madden Football 64 (USA)" cloneof="Madden Football 64 (Europe)">
-		<description>Madden Football 64 (USA)</description>
-		<rom name="Madden Football 64 (USA).n64" />
-		<release name="Madden Football 64 (USA)" region="USA" />
-		<rom name="Madden Football 64 (USA).z64" size="12582912" crc="42e5fafa" md5="903b912ce88626900221731224e9dbe8" sha1="b0de34b759f18ad86d39a4c68c9840d35ce25809" />
-	</game>
-	<game name="Madden NFL 2000 (USA)">
-		<description>Madden NFL 2000 (USA)</description>
-		<rom name="Madden NFL 2000 (USA).n64" />
-		<release name="Madden NFL 2000 (USA)" region="USA" />
-		<rom name="Madden NFL 2000 (USA).z64" size="12582912" crc="ef5f997b" md5="955d19e26b4ba7cc941f86a54a0fc13d" sha1="ec01de96960ea23a9ee997f4456c5c8ee7baf7e4" />
-	</game>
-	<game name="Madden NFL 2001 (USA)">
-		<description>Madden NFL 2001 (USA)</description>
-		<rom name="Madden NFL 2001 (USA).n64" />
-		<release name="Madden NFL 2001 (USA)" region="USA" />
-		<rom name="Madden NFL 2001 (USA).z64" size="12582912" crc="245eaee8" md5="441fa65faa5c12339f89a0bb7db43c8f" sha1="93f5ba646098e1aa45ecec6312604a0932edd24b" />
-	</game>
-	<game name="Madden NFL 2002 (USA)">
-		<description>Madden NFL 2002 (USA)</description>
-		<rom name="Madden NFL 2002 (USA).n64" />
-		<release name="Madden NFL 2002 (USA)" region="USA" />
-		<rom name="Madden NFL 2002 (USA).z64" size="12582912" crc="f573f107" md5="ad0f2ec565d7575fb37512bc8df8a092" sha1="de51147a238158adc059d0cc75fd39bbb08dcfc6" />
-	</game>
-	<game name="Madden NFL 99 (Europe)">
-		<description>Madden NFL 99 (Europe)</description>
-		<rom name="Madden NFL 99 (Europe).n64" />
-		<release name="Madden NFL 99 (Europe)" region="EUR" />
-		<rom name="Madden NFL 99 (Europe).z64" size="12582912" crc="d0929942" md5="e7bf80861a0ab2a788959463d953b5d5" sha1="7c55ba6741dcf96208432507b8191b3c15f666df" />
-	</game>
-	<game name="Madden NFL 99 (USA)" cloneof="Madden NFL 99 (Europe)">
-		<description>Madden NFL 99 (USA)</description>
-		<rom name="Madden NFL 99 (USA).n64" />
-		<rom name="Madden NFL 99 (USA).z64" size="12582912" crc="2eb64fc2" md5="507ceab72ef2a1bf145bf190f5ce1c80" sha1="2e8595c6ea0267a0344c0e203b4b08f00a42b13a" />
-	</game>
-	<game name="Madden NFL 99 (USA) (Beta) (1998-08-05)" cloneof="Madden NFL 99 (Europe)">
-		<description>Madden NFL 99 (USA) (Beta) (1998-08-05)</description>
-		<rom name="Madden NFL 99 (USA) (Beta) (1998-08-05).n64" />
-		<rom name="Madden NFL 99 (USA) (Beta) (1998-08-05).z64" size="16777216" crc="033a2ca6" md5="5f3d42d5f96191f3ce50d70e0e42127a" sha1="80236fc4ce2bb95de513f3b2be74acec9da4804c" />
-	</game>
-	<game name="Madden NFL 99 (USA) (Rev 1)" cloneof="Madden NFL 99 (Europe)">
-		<description>Madden NFL 99 (USA) (Rev 1)</description>
-		<rom name="Madden NFL 99 (USA) (Rev 1).n64" />
-		<release name="Madden NFL 99 (USA) (Rev 1)" region="USA" />
-		<rom name="Madden NFL 99 (USA) (Rev 1).z64" size="12582912" crc="56769a44" md5="5ad80a8ef44dee1fdc456d66104165b4" sha1="68c0c53489b790568acb1d863b74b89975db4a62" />
-	</game>
-	<game name="Magical Tetris Challenge (Europe)">
-		<description>Magical Tetris Challenge (Europe)</description>
-		<rom name="Magical Tetris Challenge (Europe).n64" />
-		<release name="Magical Tetris Challenge (Europe)" region="EUR" />
-		<rom name="Magical Tetris Challenge (Europe).z64" size="16777216" crc="af3b099e" md5="20e51b27e8098a9d101b44689014c281" sha1="ecc73f8a0a530ee42a56b46611da6f74b728fe7d" />
-	</game>
-	<game name="Defi au Tetris Magique (France)" cloneof="Magical Tetris Challenge (Europe)">
+		<rom name="Bokujou Monogatari 2 (Japan) (Rev 2).z64" size="16777216" crc="9181c1b7" md5="24e3ee6a54278db65c463804f2bb6223" sha1="74c5fd9647b702e889a5f2094d4bc4001bd6f68b" sha256="fd0390c22834604f4c894d7507f6d6ba768fea60aa374d1382bde535c02cc265" serial="NYWJ" />
+	</game>
+	<game name="Bomberman 64 (Europe)" id="0087">
+		<description>Bomberman 64 (Europe)</description>
+		<rom name="Bomberman 64 (Europe).n64" />
+		<rom name="Bomberman 64 (Europe).z64" size="8388608" crc="525339c5" md5="b68f49aa8f6f7499184ac6b7b8570f2b" sha1="01e50f41733994bf229bee3b3d8aa9fd46441175" sha256="412112a3a7dbd712c9d7420028144b47691768aa6a26846c897abae8c9a69157" status="verified" serial="NBMP" />
+	</game>
+	<game name="Bomberman 64 (Japan)" id="0088">
+		<description>Bomberman 64 (Japan)</description>
+		<rom name="Bomberman 64 (Japan).n64" />
+		<rom name="Bomberman 64 (Japan).z64" size="16777216" crc="cb9bd3f5" md5="d54fd7067bd774e32b57f9c2c0496899" sha1="62f091b8b951238a7fb98459257ecc8a9095f6e9" sha256="5c7fb711f3885f3d8682955e5c88e4bb47c9bfbb996d8423b6da8f1e8f8884a2" />
+	</game>
+	<game name="Bomberman 64 (USA)" id="0089" cloneofid="0087">
+		<description>Bomberman 64 (USA)</description>
+		<rom name="Bomberman 64 (USA).n64" />
+		<rom name="Bomberman 64 (USA).z64" size="8388608" crc="3ed0e0dc" md5="093058ece14c8cc1a887b2087eb5cfe9" sha1="8a7648d8105ac4fc1ad942291b2ef89aeca921c9" sha256="e6da7c26127788cd894b88b71cc055ff9dec0d0f4f8e10d9b15b40153af2b52a" status="verified" serial="NBME" />
+	</game>
+	<game name="Bomberman 64 - The Second Attack! (USA)" id="0090">
+		<description>Bomberman 64 - The Second Attack! (USA)</description>
+		<rom name="Bomberman 64 - The Second Attack! (USA).n64" />
+		<rom name="Bomberman 64 - The Second Attack! (USA).z64" size="16777216" crc="57550007" md5="aec1fdb0f1caad86c9f457989a4ce482" sha1="66b1fd763793ecc6e03aa6c5d023df8de5351b9e" sha256="96f641120471a1d5dab848dffdeeeeb7c4002333a06763ae20e14af72126efd8" serial="NBVE" />
+	</game>
+	<game name="Bomberman Hero (Europe)" id="0091">
+		<description>Bomberman Hero (Europe)</description>
+		<rom name="Bomberman Hero (Europe).n64" />
+		<rom name="Bomberman Hero (Europe).z64" size="12582912" crc="59e39947" md5="f79ef0813157880ffbad6199e07579be" sha1="ba1e6a4cc323a83d7c14573c9128ab9f9b60e5f2" sha256="f0323b303dfd4fc0f8eafba20aa8dac25c764ec8ec7a2e4d5933d38f5a763fc3" status="verified" serial="NBDP" />
+	</game>
+	<game name="Bomberman Hero (USA)" id="0092" cloneofid="0091">
+		<description>Bomberman Hero (USA)</description>
+		<rom name="Bomberman Hero (USA).n64" />
+		<rom name="Bomberman Hero (USA).z64" size="12582912" crc="2cc2e634" md5="ef2453bff7ad0c4bfa9ab0bd6324ebf3" sha1="a36364b7e59351f7551ab351cb3b41ebc4be285b" sha256="e021ec484a88c528256dbff80617e599768b074b0918dcec081ecbf365386542" status="verified" serial="NBDE" />
+	</game>
+	<game name="Bomberman Hero - Mirian Oujo o Sukue! (Japan)" id="0093" cloneofid="0091">
+		<description>Bomberman Hero - Mirian Oujo o Sukue! (Japan)</description>
+		<rom name="Bomberman Hero - Mirian Oujo o Sukue! (Japan).n64" />
+		<rom name="Bomberman Hero - Mirian Oujo o Sukue! (Japan).z64" size="12582912" crc="69ceabcc" md5="ee273763c7391458865ff26c7ea0c3f1" sha1="ae3f4f7c31ddbd14843d9beb932fc5aa21746211" sha256="ce37c2dd12c17f413d94f802760ebf669ceef964044beb44879b3f87e40881d7" status="verified" serial="NBDJ" />
+	</game>
+	<game name="Bottom of the 9th (USA)" id="0094">
+		<description>Bottom of the 9th (USA)</description>
+		<rom name="Bottom of the 9th (USA).n64" />
+		<rom name="Bottom of the 9th (USA).z64" size="16777216" crc="1844c8ca" md5="fb19afd5e8c49978e6e6ae3622e0498a" sha1="4ee0e3768b9f23112e4e5ef0c81a2b29ae22eab2" sha256="f814ecc17de9e4035c324b35f636cef299149e8bf96b9d46fe07fbbcfb98cae3" serial="NBOE" />
+	</game>
+	<game name="Brunswick Circuit Pro Bowling (USA)" id="0095">
+		<description>Brunswick Circuit Pro Bowling (USA)</description>
+		<rom name="Brunswick Circuit Pro Bowling (USA).n64" />
+		<rom name="Brunswick Circuit Pro Bowling (USA).z64" size="8388608" crc="80d70173" md5="62e92102d6fd1701a6e904da6ab58ae8" sha1="91f6f7843a7413126a7b4026104526615f979134" sha256="0820db5f76a45bbbe6323176b70d4a93256ccde925aee91a6bb500fd0fbd859a" serial="NOWE" />
+	</game>
+	<game name="Buck Bumble (Europe) (En,Fr,De,Es,It)" id="0096">
+		<description>Buck Bumble (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="Buck Bumble (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="Buck Bumble (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="e26192ab" md5="a2e4be02876cb0f0d1e925ff95090c96" sha1="1123bfac4ec3730a54900ca83e196065cbb4b6e2" sha256="3ac266d98a84f01174ad7ffbb532f3e3bc041a57ebc8874c0b45bb062899a6db" status="verified" serial="NBLP" />
+	</game>
+	<game name="Buck Bumble (Japan)" id="0097" cloneofid="0096">
+		<description>Buck Bumble (Japan)</description>
+		<rom name="Buck Bumble (Japan).n64" />
+		<rom name="Buck Bumble (Japan).z64" size="12582912" crc="2ed81a65" md5="aee981977d8f069003574cd10a268d47" sha1="38007f846a454ad09d2090f0ef86e9762a46ccf7" sha256="9b4be33fe5adbc911e69546bcb0149c380f00f02c669539411a8cf1d78714ff4" serial="NBLJ" />
+	</game>
+	<game name="Buck Bumble (USA)" id="0098" cloneofid="0096">
+		<description>Buck Bumble (USA)</description>
+		<rom name="Buck Bumble (USA).n64" />
+		<rom name="Buck Bumble (USA).z64" size="12582912" crc="8ec937db" md5="41417fce2b37eaae787c5a845a0015c4" sha1="01d9497ea0e1f68ae285b8c7a57439b42b7d9a56" sha256="d21e3d1c2ec4d7f025cfaa119553be9a5fa87a9fd6625ef1ef44dc1d4b0aa54b" serial="NBLE" />
+	</game>
+	<game name="Bug's Life, A (Europe)" id="0099">
+		<description>Bug's Life, A (Europe)</description>
+		<rom name="Bug's Life, A (Europe).n64" />
+		<rom name="Bug's Life, A (Europe).z64" size="12582912" crc="791881d4" md5="ed3e962653a1cd56aab175deee6ee52a" sha1="2922c2281faa4106295830c617289292df4c377a" sha256="2c67a977be8c159298d3e1e93e1f2d390994037d73ac786705943ee3dcd9ee53" serial="NBYP" />
+	</game>
+	<game name="Bug's Life, A (France)" id="0100" cloneofid="0099">
+		<description>Bug's Life, A (France)</description>
+		<rom name="Bug's Life, A (France).n64" />
+		<rom name="Bug's Life, A (France).z64" size="12582912" crc="e5429094" md5="d2860d4fbd0ec4b2711a6ef8d78f9866" sha1="4970ecc65e8de25990a241b0d2ffbe274cb1619a" sha256="ca95b985145db27f39d08166829df792a08fb83192368aa4acf9174efa53b12d" serial="NBYF" />
+	</game>
+	<game name="Bug's Life, A (Germany)" id="0101" cloneofid="0099">
+		<description>Bug's Life, A (Germany)</description>
+		<rom name="Bug's Life, A (Germany).n64" />
+		<rom name="Bug's Life, A (Germany).z64" size="12582912" crc="15a32836" md5="cbef54768670f4b5602ccbc90150007a" sha1="daa7114a8d16c3e636b2808d4f256e07954f05dd" sha256="296969309890de4f1b0b62ca6f8b0ad29742a26817794e33d6ee4846676b137b" serial="NBYD" />
+	</game>
+	<game name="Bug's Life, A (Italy)" id="0102" cloneofid="0099">
+		<description>Bug's Life, A (Italy)</description>
+		<rom name="Bug's Life, A (Italy).n64" />
+		<rom name="Bug's Life, A (Italy).z64" size="12582912" crc="2d118764" md5="e3609fd12369c464e832c6d2a4d20790" sha1="46f9c5d7eb822b19be6910b992949def27e46887" sha256="9e1fe3d012dbe9814e4ef36dab7c18c1a84edf9bdfb7df4d04cea2134e5f3853" serial="NBYI" />
+	</game>
+	<game name="Bug's Life, A (USA)" id="0103" cloneofid="0099">
+		<description>Bug's Life, A (USA)</description>
+		<rom name="Bug's Life, A (USA).n64" />
+		<rom name="Bug's Life, A (USA).z64" size="12582912" crc="cf2ea0b6" md5="7fd6bffb80f920e01ef869829d485ea3" sha1="697c1e895fc840826fcb6a6f37411a2af6d6f47c" sha256="a9a3ad10d2660e0fa8c1c23c6a75f900ee2882569917abab6e258f3bd333a3e4" serial="NBYE" />
+	</game>
+	<game name="Bust-A-Move '99 (USA)" id="0104" cloneofid="0107">
+		<description>Bust-A-Move '99 (USA)</description>
+		<rom name="Bust-A-Move '99 (USA).n64" />
+		<rom name="Bust-A-Move '99 (USA).z64" size="8388608" crc="c285fc69" md5="8567382d3cd5bc0406b7b4c780f621dc" sha1="8d874677cfbfa88c5e52bc13327d518be3b756ba" sha256="2932dae8bcce7cb86bbc15c5f1cca96ba5838c486398d445b248276f1203b501" serial="NB3E" />
+	</game>
+	<game name="Bust-A-Move 2 - Arcade Edition (Europe)" id="0105">
+		<description>Bust-A-Move 2 - Arcade Edition (Europe)</description>
+		<rom name="Bust-A-Move 2 - Arcade Edition (Europe).n64" />
+		<rom name="Bust-A-Move 2 - Arcade Edition (Europe).z64" size="8388608" crc="04731bab" md5="094f639a9ba63b2136d2887c8d72bca0" sha1="f92a1b19c522ba6cf20a9d7883321e6e283da32f" sha256="4536d1d05d0f8cfe84926d758e538ecbf5264debdea9dd87292141a2edbd32d0" status="verified" serial="NBUP" />
+	</game>
+	<game name="Bust-A-Move 2 - Arcade Edition (USA)" id="0106" cloneofid="0105">
+		<description>Bust-A-Move 2 - Arcade Edition (USA)</description>
+		<rom name="Bust-A-Move 2 - Arcade Edition (USA).n64" />
+		<rom name="Bust-A-Move 2 - Arcade Edition (USA).z64" size="8388608" crc="9f54cd2d" md5="8897a39e34aee4d3f807af255c6617d6" sha1="8f1aad51e733958d1a9a7a0cb7516fc7a293ca7b" sha256="fb92418bf3673d128807a13a16afc4b3c75f8c04944eea128435d69a1bdf13e9" serial="NBUE" />
+	</game>
+	<game name="Bust-A-Move 3 DX (Europe)" id="0107">
+		<description>Bust-A-Move 3 DX (Europe)</description>
+		<rom name="Bust-A-Move 3 DX (Europe).n64" />
+		<rom name="Bust-A-Move 3 DX (Europe).z64" size="8388608" crc="95595889" md5="3ea21256ddc4157c3231ae5cc9c4652a" sha1="2bd376c3db3080d0a2328ef4052e59c3df71797e" sha256="b8847b703aff8ff887d58b482067fc8dece91856503685b20249c25066c4657c" status="verified" serial="NB3P" />
+	</game>
+	<game name="Bust-A-Move 3 DX (USA) (Beta) (1998-08-28)" id="1189" cloneofid="0107">
+		<category>Games</category>
+		<rom name="Bust-A-Move 3 DX (USA) (Beta) (1998-08-28).n64" />
+		<category>Preproduction</category>
+		<description>Bust-A-Move 3 DX (USA) (Beta) (1998-08-28)</description>
+		<rom name="Bust-A-Move 3 DX (USA) (Beta) (1998-08-28).z64" size="8388608" crc="0ee608d2" md5="d74f0b8738eb1b46248ff286df7615d3" sha1="a0f53d92c8ab70aae0d8605c1cf8f2092a81d720" sha256="253edfb7b9ae7b5de846669978dc949ab2b239982b66792df02d50e86e4897e0" serial="NB3E" />
+	</game>
+	<game name="California Speed (USA)" id="0108">
+		<description>California Speed (USA)</description>
+		<rom name="California Speed (USA).n64" />
+		<rom name="California Speed (USA).z64" size="16777216" crc="6f6262cb" md5="965ad2fa317f0644e49a89a3219719cb" sha1="bd4c070a71ef58499587cb811fb7490b88dd7c0b" sha256="32d083c6570a92614f7ed8221b136ca45eb3d06ca98d8a8342e0a366563ba791" status="verified" serial="NCLE" />
+	</game>
+	<game name="California Speed (Europe) (Proto)" id="0910" cloneofid="0108">
+		<description>California Speed (Europe) (Proto)</description>
+		<rom name="California Speed (Europe) (Proto).n64" />
+		<rom name="California Speed (Europe) (Proto).z64" size="16777216" crc="d913b95f" md5="29b79bf5812e5f9e5ecef073d59f8915" sha1="b0ca8a5c8cbf2d18a91ac1b9df82907613bef479" sha256="42461fe5caba754c5a669220cb8352a4907a32c0e1f93accdd1a23e2e44892ec" serial="NCLP" />
+	</game>
+	<game name="Carmageddon 64 (Europe) (En,Fr,De,Es)" id="0109" cloneofid="0110">
+		<description>Carmageddon 64 (Europe) (En,Fr,De,Es)</description>
+		<rom name="Carmageddon 64 (Europe) (En,Fr,De,Es).n64" />
+		<rom name="Carmageddon 64 (Europe) (En,Fr,De,Es).z64" size="16777216" crc="8569f1a0" md5="ca21467bde6b355e7a15b8f1ada7b24d" sha1="2ab7ea2a9bc05ecf3cac026e2aff7acc9d3202e5" sha256="ac47515585ced9013e6a261d4da8216936f68119a1ea084fe5d6c395fa6abee7" serial="NCDX" />
+	</game>
+	<game name="Carmageddon 64 (Europe) (En,Fr,Es,It)" id="0110">
+		<description>Carmageddon 64 (Europe) (En,Fr,Es,It)</description>
+		<rom name="Carmageddon 64 (Europe) (En,Fr,Es,It).n64" />
+		<rom name="Carmageddon 64 (Europe) (En,Fr,Es,It).z64" size="16777216" crc="8036f999" md5="59eb5646fa079bcbd7a340d7a10196dd" sha1="a26831c07ecc57dbf5846db847a30d9f735297c2" sha256="9cba33550c919fbeeef732b2b4345f309b7e95c9f8d0384a38fe44ba185b1d29" status="verified" serial="NCDY" />
+	</game>
+	<game name="Carmageddon 64 (USA)" id="0111" cloneofid="0110">
+		<description>Carmageddon 64 (USA)</description>
+		<rom name="Carmageddon 64 (USA).n64" />
+		<rom name="Carmageddon 64 (USA).z64" size="16777216" crc="10c6a0a1" md5="31bb57c1fad0d47dc2353c1950b11886" sha1="dc7495093fb9a668b0c851b87c037a4cdf2ddc65" sha256="533a15b5da737fcbb2ae062d1cf2fc7552d64d7ac67293a76c70ebcdd354b01e" serial="NCDE" />
+	</game>
+	<game name="Carnivale - Cenzo's Adventure (USA) (Proto) (2000-07-21)" id="1086">
+		<description>Carnivale - Cenzo's Adventure (USA) (Proto) (2000-07-21)</description>
+		<rom name="Carnivale - Cenzo's Adventure (USA) (Proto) (2000-07-21).n64" />
+		<rom name="Carnivale - Cenzo's Adventure (USA) (Proto) (2000-07-21).z64" size="16777216" crc="cf3a966b" md5="62a20938ea563ba5e79fb3799993d17b" sha1="2efd826bc0907e970ac90c77b3482fa6127addde" sha256="bb85e7dc83d645755967e70ac3e557afc31217474805884f4a31d4f750060b0d" />
+	</game>
+	<game name="Castlevania (Europe) (En,Fr,De)" id="0112">
+		<description>Castlevania (Europe) (En,Fr,De)</description>
+		<rom name="Castlevania (Europe) (En,Fr,De).n64" />
+		<rom name="Castlevania (Europe) (En,Fr,De).z64" size="12582912" crc="d9d76235" md5="57146b6cd8ee7d96b01a811f98a1ac61" sha1="e0da571cddcb8d069b36c2df254334f7c532133e" sha256="902f060c7787ffdf83f547203eb1182c737714a2bec5f42c409f05b26ecdb9dc" status="verified" serial="ND3P" />
+	</game>
+	<game name="Castlevania (USA)" id="0113" cloneofid="0112">
+		<description>Castlevania (USA)</description>
+		<rom name="Castlevania (USA).n64" />
+		<rom name="Castlevania (USA).z64" size="12582912" crc="8b0d3c00" md5="1cc5cf3b4d29d8c3ade957648b529dc1" sha1="989a28782ed6b0bc489a1bbbd7bec355d8f2707e" sha256="0237b439a3adcc2e6c1b24b4ff1b24d2f0d8f04a2d0cc29b8b67cb075f1903c5" serial="ND3E" />
+	</game>
+	<game name="Castlevania (USA) (Rev 2)" id="0114" cloneofid="0112">
+		<description>Castlevania (USA) (Rev 2)</description>
+		<rom name="Castlevania (USA) (Rev 2).n64" />
+		<rom name="Castlevania (USA) (Rev 2).z64" size="12582912" crc="83032d97" md5="06b58673f7d31c56f8fe8186e86f6bd6" sha1="ba23d0fb480b9885f0d847f7f3d67b249177c8c4" sha256="0f53f12e85bcf5799c8c8e9e71957e20c434f8f5823ab95bd1f54c33c16e7b1c" status="verified" serial="ND3E" />
+	</game>
+	<game name="Castlevania (USA) (Rev 1)" id="0943" cloneofid="0112">
+		<description>Castlevania (USA) (Rev 1)</description>
+		<rom name="Castlevania (USA) (Rev 1).n64" />
+		<rom name="Castlevania (USA) (Rev 1).z64" size="12582912" crc="274d3493" md5="ce71d1ce0a2b6d597f72cb4fc08f5844" sha1="349a031320c1fe16a99801c1bab48a7aa8deac8e" sha256="d7ac93315463b968eb0b628d9047c96b72666c93b72752ab729764a3aca59eee" serial="ND3E" />
+	</game>
+	<game name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)" id="0115">
+		<description>Castlevania - Legacy of Darkness (Europe) (En,Fr,De)</description>
+		<rom name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De).n64" />
+		<rom name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De).z64" size="16777216" crc="12ab9b45" md5="78d5f8a98a5ed21d0817856bcd2ad750" sha1="0c6817082dd322477c63f3c91a99c1f34af0065c" sha256="e78c172c1d554d1c94865969cec9b87a2149c92ec69ebc52b73a46648b5b2395" status="verified" serial="ND4P" />
+	</game>
+	<game name="Castlevania - Legacy of Darkness (USA)" id="0116" cloneofid="0115">
+		<description>Castlevania - Legacy of Darkness (USA)</description>
+		<rom name="Castlevania - Legacy of Darkness (USA).n64" />
+		<rom name="Castlevania - Legacy of Darkness (USA).z64" size="16777216" crc="ab13028c" md5="25258460f98f567497b24844abe3a05b" sha1="879ead98f197fd05edda867655da5b1ce25aa5b8" sha256="89e15df6042defddc48c61f7408f99d06fffdb845e2422cf8b5ba8e73d4d70fb" serial="ND4E" />
+	</game>
+	<game name="Centre Court Tennis (Europe)" id="0117">
+		<description>Centre Court Tennis (Europe)</description>
+		<rom name="Centre Court Tennis (Europe).n64" />
+		<rom name="Centre Court Tennis (Europe).z64" size="12582912" crc="b1d26f39" md5="31fb88048076ace4bd4205c5f40414ab" sha1="c6f1251b4b7841220f670d8a0af844b34c5cfada" sha256="872ada665b49641f97b3b6e7bb1ebbc09487d6b5fb6ab92a1e5802f5c3e669fb" status="verified" serial="NTSP" />
+	</game>
+	<game name="Chameleon Twist (Europe)" id="0118">
+		<description>Chameleon Twist (Europe)</description>
+		<rom name="Chameleon Twist (Europe).n64" />
+		<rom name="Chameleon Twist (Europe).z64" size="12582912" crc="587dd983" md5="1cd90b13b7fd6afdcb838f801d807826" sha1="197556f41756c82edb6ba7767f0d181290c1b2c2" sha256="b804e8fe18937ddcc781aa8746feefeaec90dcf55dd42f08e78445891ca5f301" status="verified" serial="NCTP" />
+	</game>
+	<game name="Chameleon Twist (Japan)" id="0119" cloneofid="0118">
+		<description>Chameleon Twist (Japan)</description>
+		<rom name="Chameleon Twist (Japan).n64" />
+		<rom name="Chameleon Twist (Japan).z64" size="12582912" crc="6395c475" md5="c0eb519122d63a944a122437ec1b98ee" sha1="a1faf5c4ca961ab2c029c84ecfa556755e7f70c8" sha256="0e336471285028ba12528a5b6182f95e069e15d12d752b5cbc48368160afed8a" serial="NCTJ" />
+	</game>
+	<game name="Chameleon Twist (USA)" id="0120" cloneofid="0118">
+		<description>Chameleon Twist (USA)</description>
+		<rom name="Chameleon Twist (USA).n64" />
+		<rom name="Chameleon Twist (USA).z64" size="12582912" crc="7fe024c9" md5="397be52d4fb7df1e26c6275e05425571" sha1="173875d2a98161228efb56841484e12446a43156" sha256="3fbf3b4fd1abf27cde4f100e646e43d99c24afe0120a77fd66fe80b15ae0a5b8" serial="NCTE" />
+	</game>
+	<game name="Chameleon Twist (USA) (Rev 1)" id="0942" cloneofid="0118">
+		<description>Chameleon Twist (USA) (Rev 1)</description>
+		<rom name="Chameleon Twist (USA) (Rev 1).n64" />
+		<rom name="Chameleon Twist (USA) (Rev 1).z64" size="12582912" crc="7ff42fd0" md5="d8a88acfcd89df7a59d9a1b050fda740" sha1="4ca6d563131b4809fe1748335182816a024999d4" sha256="8ca37d6dc7f3fbd78211d4ed2274cf9c8ac315f81dafa4e2d636e771fdff36c5" status="verified" serial="NCTE" />
+	</game>
+	<game name="Chameleon Twist 2 (Europe)" id="0121">
+		<description>Chameleon Twist 2 (Europe)</description>
+		<rom name="Chameleon Twist 2 (Europe).n64" />
+		<rom name="Chameleon Twist 2 (Europe).z64" size="8388608" crc="3b53519f" md5="45d1d039ab7926adc748de640afd986a" sha1="bbca485ee38e07da78f44e5de653311b8edc18f2" sha256="ae74febfcef8c41c3ce8b633720252b8b067273ecb8e60c7ed13601326b484b2" status="verified" serial="N2VP" />
+	</game>
+	<game name="Chameleon Twist 2 (Japan)" id="0122" cloneofid="0121">
+		<description>Chameleon Twist 2 (Japan)</description>
+		<rom name="Chameleon Twist 2 (Japan).n64" />
+		<rom name="Chameleon Twist 2 (Japan).z64" size="12582912" crc="08287cc8" md5="740ad4db03952bbe997db09947a41e62" sha1="b60d0347e7b765195fb27c3ee50a806ea9977dca" sha256="5b9a8acbee9f677e134232c3b2270848922771072e35a1a2c067bc8e3378758b" serial="NV2J" />
+	</game>
+	<game name="Chameleon Twist 2 (USA)" id="0123" cloneofid="0121">
+		<description>Chameleon Twist 2 (USA)</description>
+		<rom name="Chameleon Twist 2 (USA).n64" />
+		<rom name="Chameleon Twist 2 (USA).z64" size="8388608" crc="cdf26d67" md5="00327e0b5df6dce6decc31353f33a3d3" sha1="9fa379d66b218228da3cbf386c91d857c677f489" sha256="43ecfea060ac708446769c2049b9a75beb34be4d0f0aa89dba49c839ccac8ee4" serial="N2VE" />
+	</game>
+	<game name="Charlie Blast's Territory (Europe)" id="0124">
+		<description>Charlie Blast's Territory (Europe)</description>
+		<rom name="Charlie Blast's Territory (Europe).n64" />
+		<rom name="Charlie Blast's Territory (Europe).z64" size="4194304" crc="82c1d9e1" md5="dd53e1f83e8789d23df6af942ffef236" sha1="9a0eb87ba72c1ef4dcb8b80029f29cdeea91fe49" sha256="ee5608476461947552c8969c217d9eb34065115ce86769f0b00c0f7817c298d9" status="verified" serial="NCBP" />
+	</game>
+	<game name="Charlie Blast's Territory (USA)" id="0125" cloneofid="0124">
+		<description>Charlie Blast's Territory (USA)</description>
+		<rom name="Charlie Blast's Territory (USA).n64" />
+		<rom name="Charlie Blast's Territory (USA).z64" size="4194304" crc="531f98b5" md5="747e76d50dc3c06fd35e146129706a60" sha1="30cd3d202ae7f79a1e775c701d84370e2aff498a" sha256="7a201d5cc030a921425aa1583edcecdf4394a258819be46c3a0d557c8d1fd7e5" serial="NCBE" />
+	</game>
+	<game name="Chopper Attack (Europe)" id="0126">
+		<description>Chopper Attack (Europe)</description>
+		<rom name="Chopper Attack (Europe).n64" />
+		<rom name="Chopper Attack (Europe).z64" size="8388608" crc="c1dcd7ab" md5="8f6bed633be214cf039dbdac356231ce" sha1="9688c388384edea0141fc66b20d6d0e5fe2d668f" sha256="7f6f4b79dbc80843edc1f9ac67c5e936febcf2d70f93b7434d2698ad8e00b8e2" status="verified" serial="NCHP" />
+	</game>
+	<game name="Chopper Attack (USA)" id="0127" cloneofid="0126">
+		<description>Chopper Attack (USA)</description>
+		<rom name="Chopper Attack (USA).n64" />
+		<rom name="Chopper Attack (USA).z64" size="8388608" crc="aa5d76a9" md5="c37e8afb4f3ecc86d01ce7388ca59347" sha1="1e3f1c94c806b2699c4e0e941190d468435b9f60" sha256="669fd3b75a5fb3db077f76d1cc74fc3396698d208945511567823165e2515f4d" serial="NCHE" />
+	</game>
+	<game name="Choro Q 64 (Japan)" id="0128" cloneofid="0542">
+		<description>Choro Q 64 (Japan)</description>
+		<rom name="Choro Q 64 (Japan).n64" />
+		<rom name="Choro Q 64 (Japan).z64" size="8388608" crc="231f9284" md5="8287a908e36e79b2d3af0bd22c43ecd9" sha1="288cdbabe30349b70ddd68931e697af03e0d2ee8" sha256="e54dd88e65c6a14b7d591118c18d1c69551de334dbebba43d70a96162d63ba32" serial="NCRJ" />
+	</game>
+	<game name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)" id="0129">
+		<description>Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)</description>
+		<rom name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan).n64" />
+		<rom name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan).z64" size="12582912" crc="5c565ad6" md5="9081370141079031ebbdbca56fc8c7d8" sha1="4532621d98b25d07e2f19aa106ff4db547104160" sha256="e017605014c4565f88eb58caba5bad7b038693a0db08f2e67dbd4e854bf2bcf1" serial="NCGJ" />
+	</game>
+	<game name="Chou Kuukan Nighter Pro Yakyuu King (Japan)" id="0130">
+		<description>Chou Kuukan Nighter Pro Yakyuu King (Japan)</description>
+		<rom name="Chou Kuukan Nighter Pro Yakyuu King (Japan).n64" />
+		<rom name="Chou Kuukan Nighter Pro Yakyuu King (Japan).z64" size="8388608" crc="5f75634e" md5="78838c202c4ff5a460586451ee9182aa" sha1="a08dd769f3b885dc27f4cd14022613d1baa52b84" sha256="a8267610ebf5832a222de6689a8364ce60b981bc327fbe83bf3871f9e6275255" status="verified" serial="NPKJ" />
+	</game>
+	<game name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)" id="0131">
+		<description>Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)</description>
+		<rom name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).n64" />
+		<rom name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).z64" size="16777216" crc="479643e2" md5="97eab4dc83da0ad2890de2aaaa5d109a" sha1="b8c62befe0a2bd7bcd6efb5f78b34b923b325aac" sha256="aa02595a3f33ed848d59d06523b2ad0ccad294506827369e3e4c4f826a7a59df" serial="NP2J" />
+	</game>
+	<game name="Chou Snobo Kids (Japan)" id="0132" cloneofid="0670">
+		<description>Chou Snobo Kids (Japan)</description>
+		<rom name="Chou Snobo Kids (Japan).n64" />
+		<rom name="Chou Snobo Kids (Japan).z64" size="16777216" crc="dd4e84e4" md5="9181b35a758ef17d1e2dc595df55ee3c" sha1="a411b2fc46d6953b32897f99ffc5146f385dfd5b" sha256="223416525fe25ef4f74ab829bcc4208c1c3591aa19760c9a4e9cefff17170e4d" serial="NK2J" />
+	</game>
+	<game name="City-Tour GP - Zen-Nihon GT Senshuken (Japan)" id="0133" cloneofid="0270">
+		<description>City-Tour GP - Zen-Nihon GT Senshuken (Japan)</description>
+		<rom name="City-Tour GP - Zen-Nihon GT Senshuken (Japan).n64" />
+		<rom name="City-Tour GP - Zen-Nihon GT Senshuken (Japan).z64" size="16777216" crc="e272bdf6" md5="2a0bf5a9a136d57af01d199b16899634" sha1="2b543707f5bdba52a49d71755615d6cf38e23e76" sha256="8229117b9a8f1d9bfb96e9cc05e5dcd3ad4432d63b5f418c621f953ba554026a" serial="NGTJ" />
+	</game>
+	<game name="Clay Fighter - Sculptor's Cut (USA)" id="0134">
+		<description>Clay Fighter - Sculptor's Cut (USA)</description>
+		<rom name="Clay Fighter - Sculptor's Cut (USA).n64" />
+		<rom name="Clay Fighter - Sculptor's Cut (USA).z64" size="16777216" crc="434de656" md5="30e7e083b978408d5b7760d0ce4dc61d" sha1="28697fba130ded056bf7c497deaa3e154cce8022" sha256="9ccebc317b7ee892be3bdc0d1c8ae46687995908ed51ebd58d6855e5e25abd7f" serial="NC2E" />
+	</game>
+	<game name="Clay Fighter 63 1-3 (Europe)" id="0135">
+		<description>Clay Fighter 63 1-3 (Europe)</description>
+		<rom name="Clay Fighter 63 1-3 (Europe).n64" />
+		<rom name="Clay Fighter 63 1-3 (Europe).z64" size="12582912" crc="82263e5d" md5="41965b533f3dd95663361d9df68b0c1f" sha1="fec40ef7d8b973c5937ade10423d0cf1b5a18e3c" sha256="bcab31d4590161691f0eb0ca79cdfbdfd145b647ea78ab1b34b9a7ea4b42f5f6" status="verified" serial="NCFP" />
+	</game>
+	<game name="Clay Fighter 63 1-3 (USA)" id="0136" cloneofid="0135">
+		<description>Clay Fighter 63 1-3 (USA)</description>
+		<rom name="Clay Fighter 63 1-3 (USA).n64" />
+		<rom name="Clay Fighter 63 1-3 (USA).z64" size="12582912" crc="3fa647dd" md5="3207bf22e305c488109b09a03706f36f" sha1="036873ab0d3107b2d9b3225a180f67daf0899365" sha256="357f26c6cd72559c5c05e8c2df46369624630dbcb1c02b3b6f3338f6ac79af07" status="verified" serial="NCFE" />
+	</game>
+	<game name="Clay Fighter 63 1-3 (USA) (Beta)" id="0137" cloneofid="0135">
+		<description>Clay Fighter 63 1-3 (USA) (Beta)</description>
+		<rom name="Clay Fighter 63 1-3 (USA) (Beta).n64" />
+		<rom name="Clay Fighter 63 1-3 (USA) (Beta).z64" size="12582912" crc="18f4166a" md5="cbbeaff5a9074d1a5507cf46cd683d36" sha1="3307f73b8bd0795d3c7036d77fc4a78efebc4ef0" sha256="95fce9f0de21241ec59c96eff75e6445f88a01b667e45a124089a299fca251c7" serial="NCFE" />
+	</game>
+	<game name="Command &amp; Conquer (Europe) (En,Fr)" id="0138">
+		<description>Command &amp; Conquer (Europe) (En,Fr)</description>
+		<rom name="Command &amp; Conquer (Europe) (En,Fr).n64" />
+		<rom name="Command &amp; Conquer (Europe) (En,Fr).z64" size="33554432" crc="f3da8a26" md5="42da4c7d040f9e7cd046a42ec3e68027" sha1="0d5211e211e7fc063c63c3e8235b62bc288ce305" sha256="55ad032b303c0006da8d2efe732af32ea2cd7c1f3d2b2b0bcab3c71201229cb7" status="verified" serial="NCCP" />
+	</game>
+	<game name="Command &amp; Conquer (Germany)" id="0139" cloneofid="0138">
+		<description>Command &amp; Conquer (Germany)</description>
+		<rom name="Command &amp; Conquer (Germany).n64" />
+		<rom name="Command &amp; Conquer (Germany).z64" size="33554432" crc="6cd0fc99" md5="1a9195662c89dcbea88bcfa99b096cde" sha1="725083ece68d5deb9724d3fa3f2a65f0291b2d5d" sha256="2c43a3277d7b3664ec4aad9e3db65a65d82da229bbf6808802cdf9fe1a39ab72" serial="NCCD" />
+	</game>
+	<game name="Command &amp; Conquer (USA)" id="0140" cloneofid="0138">
+		<description>Command &amp; Conquer (USA)</description>
+		<rom name="Command &amp; Conquer (USA).n64" />
+		<rom name="Command &amp; Conquer (USA).z64" size="33554432" crc="3e9069ef" md5="b436f4717ac585b0d847756468fd6393" sha1="b559e86d98de598b1d25583ca082faa4b7c62641" sha256="cd9113ba6ca54912c08378eef084e1bbb47f0609a8543702e1c07f89d053f908" status="verified" serial="NCCE" />
+	</game>
+	<game name="Conker's Bad Fur Day (Europe)" id="0141">
+		<description>Conker's Bad Fur Day (Europe)</description>
+		<rom name="Conker's Bad Fur Day (Europe).n64" />
+		<rom name="Conker's Bad Fur Day (Europe).z64" size="67108864" crc="4667cfe9" md5="05194d49c14e52055df72a54d40791e1" sha1="ee7bc6656fd1e1d9ffb3d19add759f28b88df710" sha256="8717054d8edcf1bb9fb4607c7ac8fe4d6fb855fe6506f7e5dcba62e414558178" status="verified" serial="NFUP" />
+	</game>
+	<game name="Conker's Bad Fur Day (USA)" id="0142" cloneofid="0141">
+		<description>Conker's Bad Fur Day (USA)</description>
+		<rom name="Conker's Bad Fur Day (USA).n64" />
+		<rom name="Conker's Bad Fur Day (USA).z64" size="67108864" crc="ce8cc172" md5="00e2920665f2329b95797a7eaabc2390" sha1="4cbadd3c4e0729dec46af64ad018050eada4f47a" sha256="32e6a8b970ec12ac5f782344945aa0c98a193832eefb687529d03bab6948714b" status="verified" serial="NFUE" />
+	</game>
+	<game name="Conker's Bad Fur Day (USA) (Beta) (2000-08-26) (ECTS 2000)" id="0948" cloneofid="0141">
+		<description>Conker's Bad Fur Day (USA) (Beta) (2000-08-26) (ECTS 2000)</description>
+		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-08-26) (ECTS 2000).n64" />
+		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-08-26) (ECTS 2000).z64" size="67108864" crc="e1cda95a" md5="13ecbaeef7111d5343d73a80e03e353a" sha1="06597dc935651f8995bfacc30fde6e621d44c3e1" sha256="dabfed4967a67709730f5e5b1bdc27c3d9d75480a9c89c464a6409deacf57acf" serial="NFUE" />
+	</game>
+	<game name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25)" id="0990" cloneofid="0141">
+		<description>Conker's Bad Fur Day (USA) (Beta) (2000-10-25)</description>
+		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25).n64" />
+		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25).z64" size="67108864" crc="4f73408c" md5="70e9eb9bf2f7bc76ca38ce450ba01c2e" sha1="3b99222ee76f6277a963142cd807b3df25d5174f" sha256="46aed7f7b022c4bed93503b648097c4a741a465a8b61d1964921270126a3316d" serial="NFUE" />
+	</game>
+	<game name="Controller Kensa-ki NUS-yo N Cassette (Japan) (Test Program)" id="1070">
+		<description>Controller Kensa-ki NUS-yo N Cassette (Japan) (Test Program)</description>
+		<rom name="Controller Kensa-ki NUS-yo N Cassette (Japan) (Test Program).n64" />
+		<rom name="Controller Kensa-ki NUS-yo N Cassette (Japan) (Test Program).z64" size="8388608" crc="e5828a7f" md5="ae76e243e554510f41f7d9afa05a4978" sha1="fbb6cccecb5d503fbf2079deb0fe5eb69ec62610" sha256="69e616893d731d55a64fdcf16ebf02dbf1219ca75c87e5fcf2b33065e0da4df1" />
+	</game>
+	<game name="Cruis'n Exotica (USA)" id="0143">
+		<description>Cruis'n Exotica (USA)</description>
+		<rom name="Cruis'n Exotica (USA).n64" />
+		<rom name="Cruis'n Exotica (USA).z64" size="16777216" crc="867a2ced" md5="db7a03b77d44db81b8a3fcdfc4b72d8c" sha1="428f53a060103fd88ebfbdcc032a99caea901e17" sha256="d26ecb1b3a3dc965acc1063cc243ab573bf5ffca310e96aff2f6d2265a49f0b1" status="verified" serial="NXOE" />
+	</game>
+	<game name="Cruis'n USA (Europe)" id="0144">
+		<description>Cruis'n USA (Europe)</description>
+		<rom name="Cruis'n USA (Europe).n64" />
+		<rom name="Cruis'n USA (Europe).z64" size="8388608" crc="8935a8d9" md5="69cd5ba6bc9310b9e37ccb1bc6bd16ad" sha1="404ab549cd148ea07f40d66c0b896a343741bbf6" sha256="25fd3ca587edc8316080f28814b7a22fddce2338ef22ac23ed61dbc87b4d8473" status="verified" serial="NCUP" />
+	</game>
+	<game name="Cruis'n USA (USA)" id="0145" cloneofid="0144">
+		<description>Cruis'n USA (USA)</description>
+		<rom name="Cruis'n USA (USA).n64" />
+		<rom name="Cruis'n USA (USA).z64" size="8388608" crc="5238b727" md5="00a3e885f8d899646228a21d946b2102" sha1="aefe77a5518fe74519908b6cbc97cb81b8570897" sha256="2eee547273101e02bb96d0ef3db5e400f0506fba77397719d33b1072617c0558" serial="NCUE" />
+	</game>
+	<game name="Cruis'n USA (USA) (Rev 1)" id="0146" cloneofid="0144">
+		<description>Cruis'n USA (USA) (Rev 1)</description>
+		<rom name="Cruis'n USA (USA) (Rev 1).n64" />
+		<rom name="Cruis'n USA (USA) (Rev 1).z64" size="8388608" crc="4655ba2d" md5="45fc88e2ba6711f25f0de988e719df29" sha1="71bb3d8850b6a4a294aeca2abad1f936e4f85f0f" sha256="9c7cf76974a0219575ff0fc007f9fb2ccd9c1971b7571e3c6269a946f095df5b" serial="NCUE" />
+	</game>
+	<game name="Cruis'n USA (USA) (Rev 2)" id="0147" cloneofid="0144">
+		<description>Cruis'n USA (USA) (Rev 2)</description>
+		<rom name="Cruis'n USA (USA) (Rev 2).n64" />
+		<rom name="Cruis'n USA (USA) (Rev 2).z64" size="8388608" crc="c3b52701" md5="2838a9018ad2bcb8b7f6161c746a1b71" sha1="54a875ee0b482036fa401a6bc2b242699f0259f7" sha256="86db95f334c54fd900db7dce9a2f5880e933cc3650e4e4ebfc2def0f4bcd59c6" status="verified" serial="NCUE" />
+	</game>
+	<game name="Cruis'n USA (USA) (Wii Virtual Console)" id="0991" cloneofid="0144">
+		<description>Cruis'n USA (USA) (Wii Virtual Console)</description>
+		<rom name="Cruis'n USA (USA) (Wii Virtual Console).n64" />
+		<rom name="Cruis'n USA (USA) (Wii Virtual Console).z64" size="8388608" crc="8fc564f9" md5="41ca21bd737e16ba81168982b74276f1" sha1="273f1d6ddd48f92af49f37e88405f318a340c2cd" sha256="0a0dac296e92ee45248598db422828bf52a2dcd81f1b379b707377b14290eedc" serial="NCUE" />
+	</game>
+	<game name="Cruis'n World (Europe)" id="0148" cloneofid="1022">
+		<description>Cruis'n World (Europe)</description>
+		<rom name="Cruis'n World (Europe).n64" />
+		<rom name="Cruis'n World (Europe).z64" size="12582912" crc="e46ce079" md5="af950a1b6c460d7fc3e78375d35047ef" sha1="ee508f14c936265d101c9699b5ae1a722b3e7d9e" sha256="775d164c1e2448dc71b50061ece0fb00aae17f357db97604b47af8f126addb9e" status="verified" serial="NCWP" />
+	</game>
+	<game name="Cruis'n World (USA)" id="0149" cloneofid="1022">
+		<description>Cruis'n World (USA)</description>
+		<rom name="Cruis'n World (USA).n64" />
+		<rom name="Cruis'n World (USA).z64" size="12582912" crc="a123769f" md5="aada4cbd938e58a447b399a1d46f03e6" sha1="6da1a6a2bda687d50e798d80c342948ad1738202" sha256="5320594232f0c492a672464832425351bd06497c95fb243745e2493bc5df9c2c" status="verified" serial="NCWE" />
+	</game>
+	<game name="Cruis'n World (Europe) (Rev 1)" id="1022">
+		<description>Cruis'n World (Europe) (Rev 1)</description>
+		<rom name="Cruis'n World (Europe) (Rev 1).n64" />
+		<rom name="Cruis'n World (Europe) (Rev 1).z64" size="12582912" crc="ebaed1f9" md5="20db5e4ddb0cd5b04c4bf09cdc95592f" sha1="362078633d549d3270b3b3b6b0e0d0243321d9ae" sha256="a73a35fac126d7058c84fbdd2566cc542bd875e9e31fd3cabf33a7ef6536efd6" serial="NCWP" />
+	</game>
+	<game name="Custom Robo (Japan)" id="0150">
+		<description>Custom Robo (Japan)</description>
+		<rom name="Custom Robo (Japan).n64" />
+		<rom name="Custom Robo (Japan).z64" size="16777216" crc="f2fae693" md5="a06d2e83cf2628915e8847f609474661" sha1="49de08f08400a477485c4798d6cd81d95842c806" sha256="9b66c00a983ceccccf17727731173d7c7eeef9f7c13faf44ae89e5d2b9f656c1" status="verified" serial="NCXJ" />
+	</game>
+	<game name="Custom Robo V2 (Japan)" id="0151">
+		<description>Custom Robo V2 (Japan)</description>
+		<rom name="Custom Robo V2 (Japan).n64" />
+		<rom name="Custom Robo V2 (Japan).z64" size="16777216" crc="c8201454" md5="115118dd5e0f02d82ba1bf070a7b78f1" sha1="f9515c2482af8df791339536f60260509c424f6a" sha256="60acf8dc7361f155ec8c987f75c6988ca1b0ccd36baefaffd67c24af6d21ace1" status="verified" serial="NCZJ" />
+	</game>
+	<game name="CyberTiger (Europe)" id="0152">
+		<description>CyberTiger (Europe)</description>
+		<rom name="CyberTiger (Europe).n64" />
+		<rom name="CyberTiger (Europe).z64" size="16777216" crc="7319d9af" md5="8c4a4cd472d610cda5459b3a92f21d30" sha1="ae220ac1cd6d892098937dc639c925f9ef158759" sha256="868dbb42eb29614da40e298532f4ae86c4905de8c54b73059e41d2aae42a9fc5" status="verified" serial="NT4P" />
+	</game>
+	<game name="CyberTiger (USA)" id="0153" cloneofid="0152">
+		<description>CyberTiger (USA)</description>
+		<rom name="CyberTiger (USA).n64" />
+		<rom name="CyberTiger (USA).z64" size="16777216" crc="10cc5f15" md5="88072f30d4f9cf384b2b3a0300649218" sha1="14e0635ccc2a80c77fd0a888a2e7977c55c6e129" sha256="cb05fdd1aaed4b8db33094d065e87d6ef123db45516816e6f2565cf09e28f395" serial="NT4E" />
+	</game>
+	<game name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)" id="0154">
+		<description>Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)</description>
+		<rom name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<rom name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="c61f6bb9" md5="1408fcf68b60d845f090107ef355a7e5" sha1="5499b5284c04cee98186e68198d6bfe73fee0cdb" sha256="296938fb1192d721944e2036b988262af9c556cf432ff9353623495f7e297bb9" status="verified" serial="NDUP" />
+	</game>
+	<game name="Dance Dance Revolution - Disney Dancing Museum (Japan)" id="0155">
+		<description>Dance Dance Revolution - Disney Dancing Museum (Japan)</description>
+		<rom name="Dance Dance Revolution - Disney Dancing Museum (Japan).n64" />
+		<rom name="Dance Dance Revolution - Disney Dancing Museum (Japan).z64" size="33554432" crc="43ee0117" md5="0b86fa9259e2b751111a1701091644b1" sha1="9ada4f62d209fb35c52103f2253ddcc137f90c5d" sha256="6faae1c2878a411a5cb1a3fcfef5456a3aa010b448a25b476d759365247ecd77" status="verified" serial="NDFJ" />
+	</game>
+	<game name="Dark Rift (Europe)" id="0156">
+		<description>Dark Rift (Europe)</description>
+		<rom name="Dark Rift (Europe).n64" />
+		<rom name="Dark Rift (Europe).z64" size="8388608" crc="d2a19c71" md5="4242fde5b74f22aaf5746459e126121f" sha1="18b02fc18411acd770bf3f25b2707669dac2ec5d" sha256="3c528bd0671c72d1a65ae022617b481d1b7bdfad1109f5fa3c300290e3f7cd35" status="verified" serial="NDKP" />
+	</game>
+	<game name="Dark Rift (USA)" id="0157" cloneofid="0156">
+		<description>Dark Rift (USA)</description>
+		<rom name="Dark Rift (USA).n64" />
+		<rom name="Dark Rift (USA).z64" size="8388608" crc="83fd222f" md5="ecb170ebbfda0e932c07524040bcc36c" sha1="3254442626ca2f2ac74400dc1c6a306f5d1b6ceb" sha256="e9eca077b22369b958dbde8d1a540ad77516d8e0a8e14e4bd982007d291dbae2" serial="NDKE" />
+	</game>
+	<game name="Deadly Arts (USA)" id="0158" cloneofid="0251">
+		<description>Deadly Arts (USA)</description>
+		<rom name="Deadly Arts (USA).n64" />
+		<rom name="Deadly Arts (USA).z64" size="12582912" crc="3db8130e" md5="a2a4a0318dab366a595336b6f80ff3ab" sha1="aa8566669575e3fea05daf5688d4fe05df735cd9" sha256="80ba81827277bc1f171a00c4669406a3ef51d419f3aa0d510b9b567b43531a2c" serial="NGAE" />
+	</game>
+	<game name="Defi au Tetris Magique (France)" id="0159" cloneofid="0397">
 		<description>Defi au Tetris Magique (France)</description>
 		<rom name="Defi au Tetris Magique (France).n64" />
-		<release name="Defi au Tetris Magique (France)" region="FRA" />
-		<rom name="Defi au Tetris Magique (France).z64" size="16777216" crc="e7ef60e8" md5="c644e318b33c4ebd94695c0c3e1e80ff" sha1="e5c79cf80ae1c19d2cb7136600ec8bd2cceae934" />
+		<rom name="Defi au Tetris Magique (France).z64" size="16777216" crc="e7ef60e8" md5="c644e318b33c4ebd94695c0c3e1e80ff" sha1="e5c79cf80ae1c19d2cb7136600ec8bd2cceae934" sha256="7d58b339526d2068f3801c213bca2c1443cab3897d553f3f2595ce2f94b9c857" serial="NMTF" />
 	</game>
-	<game name="Magical Tetris Challenge (Germany)" cloneof="Magical Tetris Challenge (Europe)">
+	<game name="Densha de Go! 64 (Japan)" id="0160">
+		<description>Densha de Go! 64 (Japan)</description>
+		<rom name="Densha de Go! 64 (Japan).n64" />
+		<rom name="Densha de Go! 64 (Japan).z64" size="33554432" crc="7bfc71e0" md5="772fa166e5db51effc77fb8d832ac4d2" sha1="5b99d3af55dfd04a5acc11b9d25a3330c1e45708" sha256="91b32c77c070fc87c194e7945b3a835d6e7c96519e0b0dd8efd29a1c8ab07f5d" serial="ND6J" />
+	</game>
+	<game name="Derby Stallion 64 (Japan)" id="0161">
+		<description>Derby Stallion 64 (Japan)</description>
+		<rom name="Derby Stallion 64 (Japan).n64" />
+		<rom name="Derby Stallion 64 (Japan).z64" size="33554432" crc="a9417994" md5="7f57463856540104b21a5289312b626f" sha1="9a2b7dfa38fbf9cd07ff676c0e484d7b97db606b" sha256="2649337accba282f74bf0ae62a5103d5c9ac09bd1a27da84179722c51b3ad576" serial="NDAJ" />
+	</game>
+	<game name="Derby Stallion 64 (Japan) (Beta) [b]" id="0162" cloneofid="0161">
+		<description>Derby Stallion 64 (Japan) (Beta) [b]</description>
+		<rom name="Derby Stallion 64 (Japan) (Beta) [b].n64" />
+		<rom name="Derby Stallion 64 (Japan) (Beta) [b].z64" size="33554432" crc="8ec950a9" md5="1051e1402ee110f3c5e372c9e1c5b338" sha1="bd03f18c456d5db90475dcf1aae2237c82d7446a" sha256="57b9f9fc8b93f38ad222d5503d8f310f053b103f482016e344cc3cf9133c2448" status="baddump" />
+	</game>
+	<game name="Destruction Derby 64 (Europe) (En,Fr,De)" id="0163">
+		<description>Destruction Derby 64 (Europe) (En,Fr,De)</description>
+		<rom name="Destruction Derby 64 (Europe) (En,Fr,De).n64" />
+		<rom name="Destruction Derby 64 (Europe) (En,Fr,De).z64" size="16777216" crc="7ad9e429" md5="bda717ecc8434f12f313342485828b58" sha1="eed379520c7fc7d08ebe5a076683bd56f3a0a04f" sha256="14d3584daec049d12ba802aa6139a2960a9e0400e04c3cdd7ec971ca25498f10" status="verified" serial="NDEP" />
+	</game>
+	<game name="Destruction Derby 64 (USA)" id="0164" cloneofid="0163">
+		<description>Destruction Derby 64 (USA)</description>
+		<rom name="Destruction Derby 64 (USA).n64" />
+		<rom name="Destruction Derby 64 (USA).z64" size="16777216" crc="38f1b5d9" md5="7fccb47498eec06e96ae9372247d1e90" sha1="a2c0799e13566d1b723299592cfcac9387f25fa7" sha256="91abc085eaf245fc3987442a18dfe00585af615fab61e2306b870e7ff4b9e19c" serial="NDEE" />
+	</game>
+	<game name="Destruction Derby 64 (USA) (Beta) (1998-07-31)" id="1103" cloneofid="0163">
+		<category>Games</category>
+		<rom name="Destruction Derby 64 (USA) (Beta) (1998-07-31).n64" />
+		<description>Destruction Derby 64 (USA) (Beta) (1998-07-31)</description>
+		<rom name="Destruction Derby 64 (USA) (Beta) (1998-07-31).z64" size="16777216" crc="a0ff0874" md5="749ac5bc4e7f2b17274f6966ddbf6872" sha1="6c20de318bd6c96409858be3c09e14ce01b829a9" sha256="eead2f3ed135e51794131ddef086264c337879458974a4bad223bdf4c037df0c" serial="!none" />
+	</game>
+	<game name="Dezaemon 3D (Japan)" id="0165">
+		<description>Dezaemon 3D (Japan)</description>
+		<rom name="Dezaemon 3D (Japan).n64" />
+		<rom name="Dezaemon 3D (Japan).z64" size="16777216" crc="9e978488" md5="54be265e7b2c28ab92bf1a4130acb5a2" sha1="1c10a85a2b6a782e6302b19c2387e2d58983a8d4" sha256="f20163baf3adea0883da4b900b4e74e5c500f1d64b3ccd8b970860f811e11e36" serial="CDZJ" />
+	</game>
+	<game name="Diddy Kong Racing (Europe) (En,Fr,De)" id="0166" cloneofid="0167">
+		<description>Diddy Kong Racing (Europe) (En,Fr,De)</description>
+		<rom name="Diddy Kong Racing (Europe) (En,Fr,De).n64" />
+		<rom name="Diddy Kong Racing (Europe) (En,Fr,De).z64" size="12582912" crc="4a13323c" md5="0f0b7b78b345fbf2581d834cb4a81245" sha1="dd5d64dd140cb7aa28404fa35abdcaba33c29260" sha256="11578b1dcb8a93a817300b2c43908e937fdf8b2219cd48de88c62a3607e1e88d" status="verified" serial="NDYP" />
+	</game>
+	<game name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)" id="0167">
+		<description>Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)</description>
+		<rom name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1).n64" />
+		<rom name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1).z64" size="12582912" crc="b1e87639" md5="6b2bafe540e0af052a78e85b992be999" sha1="b7f628073237b3d211d40406aa0884ff8fdd70d5" sha256="584d59412b3a8c675f5569516a0406128028929e31544490a4dbc3ab16a038b9" serial="NDYP" />
+	</game>
+	<game name="Diddy Kong Racing (Japan)" id="0168" cloneofid="0167">
+		<description>Diddy Kong Racing (Japan)</description>
+		<rom name="Diddy Kong Racing (Japan).n64" />
+		<rom name="Diddy Kong Racing (Japan).z64" size="12582912" crc="b566fb94" md5="10747662a55241b9234cd114c940504f" sha1="23ba3d302025153d111416e751027cef11213a19" sha256="d81a6fafde1f9a5d22c930b5ce4e30845beb42503240bc57454edf967ebc55e4" status="verified" serial="NDYJ" />
+	</game>
+	<game name="Diddy Kong Racing (USA) (En,Fr)" id="0169" cloneofid="0167">
+		<description>Diddy Kong Racing (USA) (En,Fr)</description>
+		<rom name="Diddy Kong Racing (USA) (En,Fr).n64" />
+		<rom name="Diddy Kong Racing (USA) (En,Fr).z64" size="12582912" crc="eb759206" md5="4f0e07f0eeac7e5d7ce3a75461888d03" sha1="0cb115d8716dbbc2922fda38e533b9fe63bb9670" sha256="dcf54c82a58f6b38603b5865e90c3baabfe553a4d141a1ea2b282170a2e98876" status="verified" serial="NDYE" />
+	</game>
+	<game name="Diddy Kong Racing (USA) (En,Fr) (Rev 1)" id="0170" cloneofid="0167">
+		<description>Diddy Kong Racing (USA) (En,Fr) (Rev 1)</description>
+		<rom name="Diddy Kong Racing (USA) (En,Fr) (Rev 1).n64" />
+		<rom name="Diddy Kong Racing (USA) (En,Fr) (Rev 1).z64" size="12582912" crc="5acca298" md5="b31f8cca50f31acc9b999ed5b779d6ed" sha1="6d96743d46f8c0cd0edb0ec5600b003c89b93755" sha256="7de1a8fb2a9558cfc3d9ad4497df698c1e89cf7095ac1531557df2af40ba8bcf" status="verified" serial="NDYE" />
+	</game>
+	<game name="Die Hard 64 (USA) (Proto) (Level 1)" id="1011">
+		<description>Die Hard 64 (USA) (Proto) (Level 1)</description>
+		<rom name="Die Hard 64 (USA) (Proto) (Level 1).n64" />
+		<rom name="Die Hard 64 (USA) (Proto) (Level 1).z64" size="33554432" crc="5e826037" md5="820929ebbe6fd332ac1720f94b745a8b" sha1="bc384f588c47e7a4c69ca5afd21189919050ae46" sha256="f81a4c5da33ade66b936c7388e4094ed9877206c03fe23602d61d6ca7915adc1" />
+	</game>
+	<game name="Die Hard 64 (USA) (Proto) (Level 2)" id="1012" cloneofid="1011">
+		<description>Die Hard 64 (USA) (Proto) (Level 2)</description>
+		<rom name="Die Hard 64 (USA) (Proto) (Level 2).n64" />
+		<rom name="Die Hard 64 (USA) (Proto) (Level 2).z64" size="33554432" crc="d1d593cf" md5="3d1e03b097f2124f8f713013d8219291" sha1="25282d4cb5c41affa4149e8bbb215f48e65bad8e" sha256="7530f3c4329230e28a25d759c0a4e0bc14839e32d9ab785fe4dcbe6f54535075" />
+	</game>
+	<game name="Die Hard 64 (USA) (Proto) (Level 3)" id="1013" cloneofid="1011">
+		<description>Die Hard 64 (USA) (Proto) (Level 3)</description>
+		<rom name="Die Hard 64 (USA) (Proto) (Level 3).n64" />
+		<rom name="Die Hard 64 (USA) (Proto) (Level 3).z64" size="33554432" crc="70943925" md5="1b28c4ca21648d318bc6dd3ef27bb1fa" sha1="0971545144930f221a4350e98866c8cd1ee22af5" sha256="d94310dd15e3c62c631ed12e56f539b9080de036f0ac3b901bb062a19f3433df" />
+	</game>
+	<game name="Dinosaur Planet (USA) (Proto) (2000-12-01)" id="1053">
+		<description>Dinosaur Planet (USA) (Proto) (2000-12-01)</description>
+		<rom name="Dinosaur Planet (USA) (Proto) (2000-12-01).n64" />
+		<rom name="Dinosaur Planet (USA) (Proto) (2000-12-01).z64" size="67108864" crc="a7daf9fa" md5="49f7bb346ade39d1915c22e090ffd748" sha1="cb9760b49198f7b754593a01c8ed642211caacde" sha256="22830780902f51aea442825c574b88d404ccf30d726219e4b000edc64bcc60a6" serial="NDPE" />
+	</game>
+	<game name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)" id="0171" cloneofid="0172">
+		<description>Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)</description>
+		<rom name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).n64" />
+		<rom name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).z64" size="33554432" crc="0075d32b" md5="56bcdfc8f0b41bf60e6a54bc60144251" sha1="f992a60c6e28ba818900e008faab01739715ae74" sha256="16948956781b76c13206444a14549adfaa39f4fe9242c6014a9a0ae024fcbe54" status="verified" serial="NDQE" />
+	</game>
+	<game name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)" id="0172">
+		<description>Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="e6220482" md5="00dd77d3d4186d0a91e2e99eb75c2da8" sha1="7d95bc1c2e07adcec437a389e31c884adb6a8fd2" sha256="f74318c58ef60f72df354c3b6c647763f09b2c1545ecd8ded7c95e1ca962a8fd" serial="NDQP" />
+	</game>
+	<game name="Donkey Kong 64 (Europe) (En,Fr,De,Es)" id="0173">
+		<description>Donkey Kong 64 (Europe) (En,Fr,De,Es)</description>
+		<rom name="Donkey Kong 64 (Europe) (En,Fr,De,Es).n64" />
+		<rom name="Donkey Kong 64 (Europe) (En,Fr,De,Es).z64" size="33554432" crc="a28c71c6" md5="118e9ce360b97a6f8dab2c9f30660bf5" sha1="f96af883845308106600d84e0618c1a066dc6676" sha256="f704ddc06dda5bee065dd89adcf86aa58bd817684e190094cd0776c0cabba9df" status="verified" serial="NDOP" />
+	</game>
+	<game name="Donkey Kong 64 (Japan)" id="0174" cloneofid="0173">
+		<description>Donkey Kong 64 (Japan)</description>
+		<rom name="Donkey Kong 64 (Japan).n64" />
+		<rom name="Donkey Kong 64 (Japan).z64" size="33554432" crc="919f7e74" md5="5b677f4bf93d6578252fcad2c8ceb637" sha1="f0ad2b2bbf04d574ed7afbb1bb6a4f0511dcd87d" sha256="8a6a5b48b0a4d5d31fa59608e65bafe787b8664fbc9dbaecbcce16e41e8934cd" status="verified" serial="NDOJ" />
+	</game>
+	<game name="Donkey Kong 64 (USA)" id="0175" cloneofid="0173">
+		<description>Donkey Kong 64 (USA)</description>
+		<rom name="Donkey Kong 64 (USA).n64" />
+		<rom name="Donkey Kong 64 (USA).z64" size="33554432" crc="d44b4fc6" md5="9ec41abf2519fc386cadd0731f6e868c" sha1="cf806ff2603640a748fca5026ded28802f1f4a50" sha256="b6347d9f1f75d38a88d829b4f80b1acf0d93344170a5fbe9546c484dae416ce3" status="verified" serial="NDOE" />
+	</game>
+	<game name="Donkey Kong 64 (USA) (Demo) (Kiosk)" id="0176" cloneofid="0173">
+		<description>Donkey Kong 64 (USA) (Demo) (Kiosk)</description>
+		<rom name="Donkey Kong 64 (USA) (Demo) (Kiosk).n64" />
+		<rom name="Donkey Kong 64 (USA) (Demo) (Kiosk).z64" size="33554432" crc="c83dfa15" md5="98a5836e3a5da7bd0b5819e7498acea2" sha1="b4717e602f07ca9be0d4822813c658cd8b99f993" sha256="c07b247b60272e17f5f0fe4971b971ea9b492b5f107e92eb65810cf4a6d6ff14" serial="NDPE" />
+	</game>
+	<game name="Donkey Kong 64 (USA) (LodgeNet)" id="1137" cloneofid="0173">
+		<category>Games</category>
+		<rom name="Donkey Kong 64 (USA) (LodgeNet).n64" />
+		<description>Donkey Kong 64 (USA) (LodgeNet)</description>
+		<rom name="Donkey Kong 64 (USA) (LodgeNet).i64" size="64" crc="2e760dba" md5="979da0a9f45244939eb9ad5a9a674efa" sha1="3ec335744c43823df3bff3dc5936f6c0611e5891" />
+		<rom name="Donkey Kong 64 (USA) (LodgeNet).z64" size="33554432" crc="acba2248" md5="aac2d7fca4080078ec8a3a067285e142" sha1="f39476827ccf7f03707de5d79949559a4dac390b" />
+	</game>
+	<game name="Doom 64 (USA) (Beta) (1996-12-10)" id="1123" cloneofid="0177">
+		<category>Games</category>
+		<rom name="Doom 64 (USA) (Beta) (1996-12-10).n64" />
+		<category>Preproduction</category>
+		<description>Doom 64 (USA) (Beta) (1996-12-10)</description>
+		<rom name="Doom 64 (USA) (Beta) (1996-12-10).z64" size="16777216" crc="68f7655e" md5="31a8efffe1be68bb1186efa89d9c8896" sha1="398c9c1fe34be41e47ab69c659fd093813692574" sha256="4b3931c14d548fedf98fcd28681ec45695dec415d39fd4a6d58a877e1c6dd2a2" />
+	</game>
+	<game name="Doom 64 (Europe)" id="0177">
+		<description>Doom 64 (Europe)</description>
+		<rom name="Doom 64 (Europe).n64" />
+		<rom name="Doom 64 (Europe).z64" size="8388608" crc="d985c356" md5="190ccca6526dc4a1f611e3b40f5131c0" sha1="b63060f69bb4e1547da1d762e740d19393977055" sha256="e8460f2fa7e55172a296a1e30354cbb868be924a454ff883d1a6601c66b9610f" status="verified" serial="NDMP" />
+	</game>
+	<game name="Doom 64 (Japan)" id="0178" cloneofid="0177">
+		<description>Doom 64 (Japan)</description>
+		<rom name="Doom 64 (Japan).n64" />
+		<rom name="Doom 64 (Japan).z64" size="8388608" crc="c8f3af5b" md5="06f15ef2228c1b1147c41dccaa07d9de" sha1="6b0d65e62626a92aa59ee4bff3f02715f6247692" sha256="19ad4130f8b259f24761d5c873e2ce468315cc5f7bce07e7f44db21241cef4a9" status="verified" serial="NDMJ" />
+	</game>
+	<game name="Doom 64 (USA)" id="0179" cloneofid="0177">
+		<description>Doom 64 (USA)</description>
+		<rom name="Doom 64 (USA).n64" />
+		<rom name="Doom 64 (USA).z64" size="8388608" crc="5cc1ade6" md5="b67748b64a2cc7efd2f3ad4504561e0e" sha1="799a588d73da3fcce8031026a8187da92b91c817" sha256="d3404a7e8ca9d20ba034651932e67aa90c6c475c5f4738f222cd1e3056df935f" serial="NDME" />
+	</game>
+	<game name="Doom 64 (USA) (Rev 1)" id="0180" cloneofid="0177">
+		<description>Doom 64 (USA) (Rev 1)</description>
+		<rom name="Doom 64 (USA) (Rev 1).n64" />
+		<rom name="Doom 64 (USA) (Rev 1).z64" size="8388608" crc="1d3a17b5" md5="1b1378bb9ee819f740550f566745af73" sha1="6fb0ce9c75bbe54b6e1ede337652b0221e5f2aad" sha256="c28eaac9a8a8cc1d30c1b50fbb04622c2ddeb9b14ddcecc6edbaad4a6d067f3f" serial="NDME" />
+	</game>
+	<game name="Doraemon - Nobita to 3tsu no Seireiseki (Japan)" id="0181">
+		<description>Doraemon - Nobita to 3tsu no Seireiseki (Japan)</description>
+		<rom name="Doraemon - Nobita to 3tsu no Seireiseki (Japan).n64" />
+		<rom name="Doraemon - Nobita to 3tsu no Seireiseki (Japan).z64" size="8388608" crc="154e8b33" md5="c2166455e94e89e9e3ab612b4377c443" sha1="bbeb7b7a92a68b17ca72dcb9d7fb16f7b771c4f6" sha256="3a8c50fd245158cfd37bf6fffd496abd7c68b185e4dc2d901c7cc492659d38cc" status="verified" serial="NDRJ" />
+	</game>
+	<game name="Doraemon 2 - Nobita to Hikari no Shinden (Japan)" id="0182">
+		<description>Doraemon 2 - Nobita to Hikari no Shinden (Japan)</description>
+		<rom name="Doraemon 2 - Nobita to Hikari no Shinden (Japan).n64" />
+		<rom name="Doraemon 2 - Nobita to Hikari no Shinden (Japan).z64" size="12582912" crc="0c1a0c38" md5="0580d96a71671c9e6972fdcf5897cc26" sha1="4b187360e1999556662c28b65dd179432ec61f9a" sha256="4503bf20866cb599d88cf1bb5df4dccbd9265c3386c61ce6c9e1968340124c10" status="verified" serial="ND2J" />
+	</game>
+	<game name="Doraemon 3 - Nobita no Machi SOS! (Japan)" id="0183">
+		<description>Doraemon 3 - Nobita no Machi SOS! (Japan)</description>
+		<rom name="Doraemon 3 - Nobita no Machi SOS! (Japan).n64" />
+		<rom name="Doraemon 3 - Nobita no Machi SOS! (Japan).z64" size="16777216" crc="d3b68be4" md5="a4a1d490ba67831775fc381b846e2168" sha1="dd9ba0f6cfc10c3b78401cc55d06ad534f39d5b1" sha256="410f99bdd58795639da272c9be9d1ab8c35b61f24f7c1fb92f7e83e1069a2602" serial="N3DJ" />
+	</game>
+	<game name="Doubutsu Banchou (Japan) (Proto)" id="1064">
+		<description>Doubutsu Banchou (Japan) (Proto)</description>
+		<rom name="Doubutsu Banchou (Japan) (Proto).n64" />
+		<rom name="Doubutsu Banchou (Japan) (Proto).z64" size="33554432" crc="6f8e3e71" md5="6c329dc4cc2fc9a96475e8a30abfe735" sha1="95a0f5f2545dd338ffee85705a360ad161c835c7" sha256="62d3fb29147b3f7021a15f9810f4732e5e79e4ebe8a19242e6957fdf7edae38c" serial="!none" />
+	</game>
+	<game name="Doubutsu no Mori (Japan)" id="0184">
+		<description>Doubutsu no Mori (Japan)</description>
+		<rom name="Doubutsu no Mori (Japan).n64" />
+		<rom name="Doubutsu no Mori (Japan).z64" size="16777216" crc="9503e3f1" md5="a4f7c57c180297b2e7ba5a5feb44fe0b" sha1="e106dff7146f72415337c96deb14f630e1580efb" sha256="d9417be056534fcc0bdff2e6cd5f1135511be7c0a4dace04a96a2649596ce908" status="verified" serial="NAFJ" />
+	</game>
+	<game name="Dr. Mario 64 (USA)" id="0185">
+		<description>Dr. Mario 64 (USA)</description>
+		<rom name="Dr. Mario 64 (USA).n64" />
+		<rom name="Dr. Mario 64 (USA).z64" size="4194304" crc="a4701927" md5="1a7936367413e5d6874abda6d623ad32" sha1="a130d3622ce40e0158db2da4247101f6e92206fc" sha256="bb2c0dec0a8287ad256929563d0509801c2f239df883c1cf52cab05b23bd77b6" serial="NN6E" />
+	</game>
+	<game name="Dr. Mario 64 (USA) (LodgeNet)" id="1138" cloneofid="0185">
+		<category>Games</category>
+		<rom name="Dr. Mario 64 (USA) (LodgeNet).n64" />
+		<description>Dr. Mario 64 (USA) (LodgeNet)</description>
+		<rom name="Dr. Mario 64 (USA) (LodgeNet).i64" size="64" crc="8f5aa504" md5="cace2cabdbd5874f28b5a1310c9a481a" sha1="87ab08a44a9df500650223a00fa067b5fa616e08" />
+		<rom name="Dr. Mario 64 (USA) (LodgeNet).z64" size="4194304" crc="dd5190ee" md5="697db27690b4f031cf91f28bc445a29f" sha1="e63b10abfaa37aa8c7f37643d6d4e82fadb511fe" />
+	</game>
+	<game name="Dragon Sword 64 (Europe) (Proto)" id="0912" cloneofid="1009">
+		<description>Dragon Sword 64 (Europe) (Proto)</description>
+		<rom name="Dragon Sword 64 (Europe) (Proto).n64" />
+		<rom name="Dragon Sword 64 (Europe) (Proto).z64" size="33554432" crc="55ded416" md5="4d901e4e15f931fd09e803343017ebfe" sha1="e7827a1d0f3e7d222ecab414c260d185f9ef9749" sha256="8a498dc20583268d9d2406b36ab4765fe7e87fb25f4548d167ce2cf0a41707ad" serial="MGVP" />
+	</game>
+	<game name="Dragon Sword 64 (USA) (Proto) (1999-08-25)" id="1009">
+		<description>Dragon Sword 64 (USA) (Proto) (1999-08-25)</description>
+		<rom name="Dragon Sword 64 (USA) (Proto) (1999-08-25).n64" />
+		<rom name="Dragon Sword 64 (USA) (Proto) (1999-08-25).z64" size="33554432" crc="2296b50d" md5="942fc6737765ac718799a7f66202216c" sha1="4478a6405f61014478bbc35cee3a00ee1515d8ce" sha256="b833036594701d8973a436a876313cb661e373f2127280760735b3e3c10f832b" />
+	</game>
+	<game name="Dual Heroes (Europe)" id="0186">
+		<description>Dual Heroes (Europe)</description>
+		<rom name="Dual Heroes (Europe).n64" />
+		<rom name="Dual Heroes (Europe).z64" size="12582912" crc="5a7e226b" md5="f120fadb52b414eb4fb7d13092ac3cdb" sha1="061b7956c3aadddc6fdc11aab885f95a71b7f463" sha256="292ffc02db47118a4b94a5581394c2edf41d16f0f1d42e9cbfae73dad78f0b2f" status="verified" serial="NDHP" />
+	</game>
+	<game name="Dual Heroes (Japan)" id="0187" cloneofid="0186">
+		<description>Dual Heroes (Japan)</description>
+		<rom name="Dual Heroes (Japan).n64" />
+		<rom name="Dual Heroes (Japan).z64" size="12582912" crc="20f23dde" md5="e7652ed5ceceb5b1bc14495c58546d1c" sha1="cfd5992bcc3e0d90966d8a6fc6e0813e75473b14" sha256="2d390313b93fbc838ddda8225901f994d5953191853ed3f7549f48720767930c" serial="NDHJ" />
+	</game>
+	<game name="Dual Heroes (USA)" id="0188" cloneofid="0186">
+		<description>Dual Heroes (USA)</description>
+		<rom name="Dual Heroes (USA).n64" />
+		<rom name="Dual Heroes (USA).z64" size="12582912" crc="d09f4da8" md5="923d65e69f51858c697e0e5759cd038b" sha1="8fd879ce53e211d33a689015a78cff3fdd39db09" sha256="5715846bd3bf7da5c296e10384b7ff4ff6e94ee315856c4ad275d5c2ed9bd712" serial="NDHE" />
+	</game>
+	<game name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)" id="0189" cloneofid="0154">
+		<description>Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)</description>
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es).n64" />
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es).z64" size="16777216" crc="3177a905" md5="02192b4b3797983bbe5e452336584208" sha1="2c840e2991d6a2af63c4efe830240fc49d93fc9a" sha256="2bbfe0cfc6aff7b623ae53673b8f91e9008cc5749fe07920712e0d0f9abe3fc5" serial="NDUE" />
+	</game>
+	<game name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta 2) (2000-03-07)" id="1060" cloneofid="0154">
+		<category>Games</category>
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta 2) (2000-03-07).n64" />
+		<category>Preproduction</category>
+		<description>Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta 2) (2000-03-07)</description>
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta 2) (2000-03-07).z64" size="33554432" crc="1e48d155" md5="08ce7620b31851cbb05d386fe22c7109" sha1="145e0cb7f3a0e866945631dcf633d31b26c7e6bc" sha256="d40569054d74b28b3d57e6e17446665d79f6bd59368d3e3cc263355fdb3278f7" serial="!none" />
+	</game>
+	<game name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta 1)" id="1185" cloneofid="0154">
+		<category>Games</category>
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta 1).n64" />
+		<category>Preproduction</category>
+		<description>Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta 1)</description>
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta 1).z64" size="16777216" crc="f2012442" md5="95816b46a52b7b5a6acee19288b01384" sha1="53febb3e7511f581f15cdf3d6ff65e1527ad3348" sha256="bac2d18a2dc57499c9637ef6351df0963bdb8200afdfc9be68df9989758599f9" serial="!none" />
+	</game>
+	<game name="Duke Nukem - Zero Hour (USA) (Beta)" id="1104" cloneofid="0191">
+		<category>Games</category>
+		<rom name="Duke Nukem - Zero Hour (USA) (Beta).n64" />
+		<description>Duke Nukem - Zero Hour (USA) (Beta)</description>
+		<rom name="Duke Nukem - Zero Hour (USA) (Beta).z64" size="33554432" crc="21e4de3a" md5="73bbd95cd877d6c9c923547da1ba76bd" sha1="0fe108c66384dcfebb395f767ac5fa6a842d07f0" sha256="9a679928314ef211c9bf1f5e28e680133d73cd7d0cab0768122be4673cb3e66c" serial="NDZE" />
+	</game>
+	<game name="Duke Nukem - Zero Hour (Europe)" id="0191">
+		<description>Duke Nukem - Zero Hour (Europe)</description>
+		<rom name="Duke Nukem - Zero Hour (Europe).n64" />
+		<rom name="Duke Nukem - Zero Hour (Europe).z64" size="33554432" crc="ea82f037" md5="86e98aaca0d90bf744da090539ba4ad8" sha1="c18ad90fb889f95773fef48c204ce06cff9e6be3" sha256="4efcba37b79d2c1beeed9c3aa169346df763760996927aeee4cd1f2385f8b997" serial="NDZP" />
+	</game>
+	<game name="Duke Nukem - Zero Hour (France)" id="0192" cloneofid="0191">
+		<description>Duke Nukem - Zero Hour (France)</description>
+		<rom name="Duke Nukem - Zero Hour (France).n64" />
+		<rom name="Duke Nukem - Zero Hour (France).z64" size="33554432" crc="7ecdfb28" md5="e2b73feb0843874ea831a2e0076fcb72" sha1="e69a4dda8cca88d4c149f2b00640da0ff04fa9c8" sha256="7fbfe76673e54b681ddeefcfc2c59a4910459af335cc9de22a2335f46abf4972" serial="NDZF" />
+	</game>
+	<game name="Duke Nukem - Zero Hour (USA)" id="0193" cloneofid="0191">
+		<description>Duke Nukem - Zero Hour (USA)</description>
+		<rom name="Duke Nukem - Zero Hour (USA).n64" />
+		<rom name="Duke Nukem - Zero Hour (USA).z64" size="33554432" crc="9a3258d7" md5="026789d47db5fe202a76f89797b33ac7" sha1="de4db292cc6cf5dd1dd1d3c9700cf8e5c3078410" sha256="5ba016567c53b0d111eb175347c6eee603c31783cd2bb3fea97f31b5ff74190f" serial="NDZE" />
+	</game>
+	<game name="Duke Nukem 64 (Europe)" id="0194">
+		<description>Duke Nukem 64 (Europe)</description>
+		<rom name="Duke Nukem 64 (Europe).n64" />
+		<rom name="Duke Nukem 64 (Europe).z64" size="8388608" crc="3275adb0" md5="8657cba95c409b74c1f5632cbc36643f" sha1="6cc06f6097f90228bd7d7784fa7d20ba17e82eef" sha256="8aaa9ccee878cee7b9084b721ee0314a2136a5b87f6e394a9c46ab79b5dbc823" status="verified" serial="NDNP" />
+	</game>
+	<game name="Duke Nukem 64 (France)" id="0195" cloneofid="0194">
+		<description>Duke Nukem 64 (France)</description>
+		<rom name="Duke Nukem 64 (France).n64" />
+		<rom name="Duke Nukem 64 (France).z64" size="8388608" crc="b9c9f07a" md5="e2e79c7167bdb26e176d220904739c91" sha1="2c48706c4280a51e52691331543606e4170a19a9" sha256="f51460caf18b6457befb79a62e2930537dceaa409e1dc8a2407226af04671a92" status="verified" serial="NDNF" />
+	</game>
+	<game name="Duke Nukem 64 (USA)" id="0196" cloneofid="0194">
+		<description>Duke Nukem 64 (USA)</description>
+		<rom name="Duke Nukem 64 (USA).n64" />
+		<rom name="Duke Nukem 64 (USA).z64" size="8388608" crc="dbfd5a53" md5="c7f1a43764a26da2e43f2a36a5f76e4c" sha1="98d6778004becc672eba0a5e887f6e3f3d1b5c15" sha256="5885913d626849190469a7e0e8ad90729b490d1715f70fe73ef047d24f20964b" status="verified" serial="NDNE" />
+	</game>
+	<game name="Duke Nukem 64 (Europe) (Beta)" id="0947" cloneofid="0194">
+		<description>Duke Nukem 64 (Europe) (Beta)</description>
+		<rom name="Duke Nukem 64 (Europe) (Beta).n64" />
+		<rom name="Duke Nukem 64 (Europe) (Beta).z64" size="8388608" crc="4a82d036" md5="bb2472b3f8a41fbf3aec3ccef7ea8c78" sha1="bd6ed4a342290eab3d99be392986e085e91315ac" sha256="0609bc62b79f42132e56f439dcd1db6564a6ef07f294f5e6c67ffb0fe7cb3329" serial="NMSE" />
+	</game>
+	<game name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)" id="0197">
+		<description>Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="61a56330" md5="bf2df4b86faa2181a7acfe2643fa2293" sha1="f02c1afd18c1cbe309472cbe5b3b3f04b22db7ee" sha256="4beb08c33592bb98339c9e0d3df3d5511ea8ca064864be744fd07e29c76345e5" status="verified" serial="NJMP" />
+	</game>
+	<game name="Earthworm Jim 3D (USA)" id="0198" cloneofid="0197">
+		<description>Earthworm Jim 3D (USA)</description>
+		<rom name="Earthworm Jim 3D (USA).n64" />
+		<rom name="Earthworm Jim 3D (USA).z64" size="16777216" crc="9e6579c5" md5="980dfb38ad9a883119de135f45b7db36" sha1="eab14f23640cd6148d4888902cdcc00dd6111bf9" sha256="fb21478839ba3f73b200a6b305d3d888fc38bf841e85454d68e4e5c8987c9890" serial="NJME" />
+	</game>
+	<game name="ECW Hardcore Revolution (Europe)" id="0199">
+		<description>ECW Hardcore Revolution (Europe)</description>
+		<rom name="ECW Hardcore Revolution (Europe).n64" />
+		<rom name="ECW Hardcore Revolution (Europe).z64" size="33554432" crc="be8feead" md5="1830ede2557e8685e6f76d05cc65076a" sha1="226cad0c48e9e0d1dc928298518ca8b2d6eae5ed" sha256="4902bdb739cea1eb5722a120bf046776eb2bb11bbd9a455f181555f9ea528e48" status="verified" serial="NWIP" />
+	</game>
+	<game name="ECW Hardcore Revolution (USA)" id="0200" cloneofid="0199">
+		<description>ECW Hardcore Revolution (USA)</description>
+		<rom name="ECW Hardcore Revolution (USA).n64" />
+		<rom name="ECW Hardcore Revolution (USA).z64" size="33554432" crc="36d368ef" md5="8eebb16b7a4d39ae8bc8cccbc41f0a01" sha1="d460dc1eb24ef3e1e27c6b125c8c8d8324a64125" sha256="c12c0f6579d9e49762658c73a58bf5b9a82fab154e29952039b7f8d231869d13" serial="NWIE" />
+	</game>
+	<game name="ECW Hardcore Revolution (Germany)" id="1023" cloneofid="0199">
+		<description>ECW Hardcore Revolution (Germany)</description>
+		<rom name="ECW Hardcore Revolution (Germany).n64" />
+		<rom name="ECW Hardcore Revolution (Germany).z64" size="33554432" crc="e9cf3d9f" md5="5d1e41aa28169e71b4919fa08f1acd9b" sha1="cdabb42be0755d186ad6cae6427fb7c0a12b2e7b" sha256="7da42aca9cd1daa7310aab8221085de14779d6d38fefe3dd2b0e09e2f37bb852" serial="NWID" />
+	</game>
+	<game name="ECW Hardcore Revolution (USA) (Beta)" id="1085" cloneofid="0199">
+		<description>ECW Hardcore Revolution (USA) (Beta)</description>
+		<rom name="ECW Hardcore Revolution (USA) (Beta).n64" />
+		<rom name="ECW Hardcore Revolution (USA) (Beta).z64" size="134217728" crc="0a239818" md5="bc8c8ebe227a75e23fdc339d06aade19" sha1="cf4130295df9a7360339a477f1f670d755c45059" sha256="245a8859d079dd5425cc3847186e9fb8ee5d0a3a18ecd388749c74d77c839950" />
+	</game>
+	<game name="EEPROM &amp; SRAM Erase Program (USA) (v1.2) (LodgeNet)" id="1135">
+		<category>Applications</category>
+		<rom name="EEPROM &amp; SRAM Erase Program (USA) (v1.2) (LodgeNet).n64" />
+		<description>EEPROM &amp; SRAM Erase Program (USA) (v1.2) (LodgeNet)</description>
+		<rom name="EEPROM &amp; SRAM Erase Program (USA) (v1.2) (LodgeNet).i64" size="64" crc="8e89a3c6" md5="846efe679f0cb17621c22d25c2a800cd" sha1="9bc23e80b0737b0f9401f8512113f8284414538b" />
+		<rom name="EEPROM &amp; SRAM Erase Program (USA) (v1.2) (LodgeNet).z64" size="1179648" crc="2d5bc167" md5="b4e13ec6150e4e84a25cec4e879b25b5" sha1="bcb439e41a997ee459a0b792cbbfe4a765894d67" />
+	</game>
+	<game name="Eikou no Saint Andrews (Japan)" id="0201">
+		<description>Eikou no Saint Andrews (Japan)</description>
+		<rom name="Eikou no Saint Andrews (Japan).n64" />
+		<rom name="Eikou no Saint Andrews (Japan).z64" size="8388608" crc="1699d2d6" md5="935dd85ad198bbde92161cdce47cbfb3" sha1="5686b49ac9a60ebfc1d1abf6214f7bc06849abf4" sha256="4d7292884c27dc329499dab22a116bbe0d07b62b4b169138c89d7493b09a2bfa" serial="NSTJ" />
+	</game>
+	<game name="Eltale Monsters (Japan)" id="0204" cloneofid="0285">
+		<description>Eltale Monsters (Japan)</description>
+		<rom name="Eltale Monsters (Japan).n64" />
+		<rom name="Eltale Monsters (Japan).z64" size="16777216" crc="24d937bf" md5="9b456acb96291fc8b55232a08ae03346" sha1="4161b5c100ec82b0241b20ca8f81366e23564ccb" sha256="dd05763200fcff84c29f23c74ea057381e95c64c4677f82fbefabed3d64ab54f" serial="NETJ" />
+	</game>
+	<game name="Excitebike 64 (Europe)" id="0205">
+		<description>Excitebike 64 (Europe)</description>
+		<rom name="Excitebike 64 (Europe).n64" />
+		<rom name="Excitebike 64 (Europe).z64" size="16777216" crc="0b881e60" md5="8fa253fd69b73df9a831ef2f731491f2" sha1="5abfb6024f935ef5fe0067f39fd594c50697c749" sha256="a28143f7dc16e905ca4da25665875a2b0d5489bcc7310ce4465637537ab096d0" status="verified" serial="NMXP" />
+	</game>
+	<game name="Excitebike 64 (Japan)" id="0206" cloneofid="0205">
+		<description>Excitebike 64 (Japan)</description>
+		<rom name="Excitebike 64 (Japan).n64" />
+		<rom name="Excitebike 64 (Japan).z64" size="16777216" crc="03bfd065" md5="bf15a61aff71c93bf5e05243f57bca1d" sha1="e2c8d01fc66c0a575e79cb338678f1fd065226d6" sha256="a2227d626690256f6d1242d5fe7c9bbbf8fa5aec2d803a0a138e1e09dd26b635" serial="NMXJ" />
+	</game>
+	<game name="Excitebike 64 (USA)" id="0207" cloneofid="0205">
+		<description>Excitebike 64 (USA)</description>
+		<rom name="Excitebike 64 (USA).n64" />
+		<rom name="Excitebike 64 (USA).z64" size="16777216" crc="fc459192" md5="7200d1c1cf489fafff767729f215e6e6" sha1="a847dd011e98204ad198cadeb6c80dda10d9a40e" sha256="2909229be3cdaac1b5ead544648b970a23e8ea83c2c3a7f891ce121fefe918cc" serial="NMXE" />
+	</game>
+	<game name="Excitebike 64 (USA) (Demo) (Kiosk)" id="0208" cloneofid="0205">
+		<description>Excitebike 64 (USA) (Demo) (Kiosk)</description>
+		<rom name="Excitebike 64 (USA) (Demo) (Kiosk).n64" />
+		<rom name="Excitebike 64 (USA) (Demo) (Kiosk).z64" size="16777216" crc="be6298b0" md5="e0018c33346714b63a55c0e040f23dea" sha1="daaf564815e9eef3fc163b9546b5880ee256274b" sha256="cd056cc339b30b77d9a7afa99bc7f9203d655ba9e34ee4048cc0b36982458263" serial="NNXE" />
+	</game>
+	<game name="Excitebike 64 (USA) (Rev 1)" id="0939" cloneofid="0205">
+		<description>Excitebike 64 (USA) (Rev 1)</description>
+		<rom name="Excitebike 64 (USA) (Rev 1).n64" />
+		<rom name="Excitebike 64 (USA) (Rev 1).z64" size="16777216" crc="143926ce" md5="21954e4e404d9e87dbdb87dd309f3e94" sha1="c2fac422af135409c1b38569b309f9d452c81c35" sha256="7f72526876c87423c757ffa2246eb689e4079de473c7a9f599699e6892dfe7ed" status="verified" serial="NMXE" />
+	</game>
+	<game name="Excitebike 64 (USA) (LodgeNet)" id="1139" cloneofid="0205">
+		<category>Games</category>
+		<rom name="Excitebike 64 (USA) (LodgeNet).n64" />
+		<description>Excitebike 64 (USA) (LodgeNet)</description>
+		<rom name="Excitebike 64 (USA) (LodgeNet).i64" size="64" crc="ddd8f443" md5="e88fbfe05d2c46635722f22eb9422dc7" sha1="f78929fd62668cd0f0b7146b1e55f4430cb1f997" />
+		<rom name="Excitebike 64 (USA) (LodgeNet).z64" size="16777216" crc="a1895884" md5="bc34b1aabd1109593abf9cf017573201" sha1="3a043dc4c8b1351ca56c3ab9bb061bd7fa99c312" />
+	</game>
+	<game name="Extreme-G (Europe) (En,Fr,De,Es,It)" id="0209">
+		<description>Extreme-G (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="Extreme-G (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="Extreme-G (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="0b71b1ea" md5="3b2ca0da0810c95b31df8c1fb8811be2" sha1="e7120856ecc9a7f29c21f45130eca0eca8a7bfec" sha256="45cfbf079b7c5777ee47f3b86c643eeeb406acb2a84c95ec4ab2b5e2d754107b" status="verified" serial="NEGP" />
+	</game>
+	<game name="Extreme-G (Japan)" id="0210" cloneofid="0209">
+		<description>Extreme-G (Japan)</description>
+		<rom name="Extreme-G (Japan).n64" />
+		<rom name="Extreme-G (Japan).z64" size="8388608" crc="750dc9a7" md5="a7cd65e5a4a8838d1cd452ba66e74df6" sha1="d9d6f7cc456b530fd3233ef2d8d6b9f845cee043" sha256="a4784b478525cef90be5576a1acfde1ca23bac254535952811f22385d5e03601" serial="NEGJ" />
+	</game>
+	<game name="Extreme-G (USA)" id="0211" cloneofid="0209">
+		<description>Extreme-G (USA)</description>
+		<rom name="Extreme-G (USA).n64" />
+		<rom name="Extreme-G (USA).z64" size="8388608" crc="04cb74ec" md5="3e660d3f991c0529e90bfec0244db31a" sha1="eb9b273431970a6124319a8fd125f0b2cacd8966" sha256="9e67bc574e40ef273759d587972655003d5213e625bfa68d3071dc9782d2071c" serial="NEGE" />
+	</game>
+	<game name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)" id="0212">
+		<description>Extreme-G XG2 (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="1a57f416" md5="bb7f98e657fb4b5fcc7dc04bd72e2d2b" sha1="ca6db450d29a6cc0d4a6fbb3468a1ed725cef51e" sha256="de1deae125b6f17048cb240132dbfe918b8fec61fe2ed1fe8e5a2e03995211b3" status="verified" serial="NG2P" />
+	</game>
+	<game name="Extreme-G XG2 (Japan)" id="0213" cloneofid="0212">
+		<description>Extreme-G XG2 (Japan)</description>
+		<rom name="Extreme-G XG2 (Japan).n64" />
+		<rom name="Extreme-G XG2 (Japan).z64" size="12582912" crc="7c8a36da" md5="f17884a2c16fb6fd11a74d65b1388b4a" sha1="94efb5d7247a075a9cc782d39b5e8af56d5f434f" sha256="5004c79552feb976b72aec4fa3e3eba2e19f7e7b6233be58acee9f7b7fb75cbe" serial="NG2J" />
+	</game>
+	<game name="Extreme-G XG2 (USA)" id="0214" cloneofid="0212">
+		<description>Extreme-G XG2 (USA)</description>
+		<rom name="Extreme-G XG2 (USA).n64" />
+		<rom name="Extreme-G XG2 (USA).z64" size="12582912" crc="81a4c28b" md5="44fe06ba3686c02a7988f27600a533da" sha1="ed0a50086ef9a89f5b445c20ab6f365165959630" sha256="0b5d9904cf45a92396396308506da0ae258afe44a902c96e50d0ff4969c67500" status="verified" serial="NG2E" />
+	</game>
+	<game name="F-1 World Grand Prix (Europe)" id="0215">
+		<description>F-1 World Grand Prix (Europe)</description>
+		<rom name="F-1 World Grand Prix (Europe).n64" />
+		<rom name="F-1 World Grand Prix (Europe).z64" size="12582912" crc="1f4e651a" md5="fac450eaff8fa46a1414db02e6eeab9f" sha1="d812098662c4f8f73deb06d140e46a7754ce3b42" sha256="bc965dee76361aed01d5d745ae1060e010d6d6f118421a6cd6959015767872a6" serial="NFWP" />
+	</game>
+	<game name="F-1 World Grand Prix (France)" id="0216" cloneofid="0215">
+		<description>F-1 World Grand Prix (France)</description>
+		<rom name="F-1 World Grand Prix (France).n64" />
+		<rom name="F-1 World Grand Prix (France).z64" size="12582912" crc="57cd299d" md5="35f6c42d5a9284688284c24250f4d6be" sha1="dd68b3624f2f8a0f821a391b690ecc5bb4fef2fd" sha256="673a8da8fc0dadf665d54f2cfcf319f8f876941dc0f691d956c6e7afebb4e346" status="verified" serial="NFWF" />
+	</game>
+	<game name="F-1 World Grand Prix (Germany)" id="0217" cloneofid="0215">
+		<description>F-1 World Grand Prix (Germany)</description>
+		<rom name="F-1 World Grand Prix (Germany).n64" />
+		<rom name="F-1 World Grand Prix (Germany).z64" size="12582912" crc="0f1984dc" md5="a8c78454c70bd73375aaf69c4078d5da" sha1="2ae85db9d6e9f3b85e4478577d5eb049ec4040c9" sha256="b64f5b9a3c4afc1907aa71f81edd7df91222a961bd346e0ef57bba6d25900fb4" serial="NFWD" />
+	</game>
+	<game name="F-1 World Grand Prix (Japan)" id="0218" cloneofid="0215">
+		<description>F-1 World Grand Prix (Japan)</description>
+		<rom name="F-1 World Grand Prix (Japan).n64" />
+		<rom name="F-1 World Grand Prix (Japan).z64" size="12582912" crc="f7bacbc3" md5="f248f0aae609111ba9dff9fd7afbc485" sha1="595bfa62ec34f7884ff46137c92771cde4d8d6fe" sha256="756bfcd4f823a5306520ad48d14d43b94392e5a8c922653328165b109f1be147" serial="NFWJ" />
+	</game>
+	<game name="F-1 World Grand Prix (USA)" id="0219" cloneofid="0215">
+		<description>F-1 World Grand Prix (USA)</description>
+		<rom name="F-1 World Grand Prix (USA).n64" />
+		<rom name="F-1 World Grand Prix (USA).z64" size="12582912" crc="7dc9ef2c" md5="a81b1de864df3f4bb0903760be673f21" sha1="dd17545adc8fe2af2a713ab48c5f71801222edaf" sha256="b5470d259dfebcdf7910257479ff47792bcc83e82f6c70131d4363d7ecb6e7a0" status="verified" serial="NFWE" />
+	</game>
+	<game name="F-1 World Grand Prix (Europe) (Beta)" id="0889" cloneofid="0215">
+		<description>F-1 World Grand Prix (Europe) (Beta)</description>
+		<rom name="F-1 World Grand Prix (Europe) (Beta).n64" />
+		<rom name="F-1 World Grand Prix (Europe) (Beta).z64" size="12582912" crc="bebbc6c8" md5="9fbe3363da6c146ef2e29605bca834ff" sha1="63bd69c382eca5e569eddf7456f6435a7dce484f" sha256="94c0cfff085a9e1768d840d9b48f226d6a6c12692e629bf0bb0b1b5f7d955b27" serial="NFWP" />
+	</game>
+	<game name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es)" id="0220">
+		<description>F-1 World Grand Prix II (Europe) (En,Fr,De,Es)</description>
+		<rom name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es).n64" />
+		<rom name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es).z64" size="12582912" crc="803d33df" md5="bc0fd2468ac7769a37c3c58cd5699585" sha1="53ed343a757b8a14814732393d02b3d780bccab5" sha256="84ad927e250a746b24ab6a9c35264a008d7c27c216da37e5ec1dd46c4c5f699f" status="verified" serial="NF2P" />
+	</game>
+	<game name="F-Zero X (Europe)" id="0221">
+		<description>F-Zero X (Europe)</description>
+		<rom name="F-Zero X (Europe).n64" />
+		<rom name="F-Zero X (Europe).z64" size="16777216" crc="2d6f7e8b" md5="ee79a8fe287b5dcaea584439363342fc" sha1="af9038bcb543a2b4faaab876dbdab4663859e092" sha256="1fb61b96aba61ed061201d1267c2dca6532abb12420dc951648b4b06f1eeb181" status="verified" serial="NFZP" />
+	</game>
+	<game name="F-Zero X (Japan)" id="0222" cloneofid="0221">
+		<description>F-Zero X (Japan)</description>
+		<rom name="F-Zero X (Japan).n64" />
+		<rom name="F-Zero X (Japan).z64" size="16777216" crc="6b1cef83" md5="58d200d43620007314304f4e6c9e6528" sha1="a418b0151521b76691fa03f8658c8b567c69498b" sha256="fa28ed5fd250ee7a948919a28720b8d02bd2b5dd59c5c629e04dde8875bd90d5" status="verified" serial="CFZJ" />
+	</game>
+	<game name="F-Zero X (USA)" id="0223" cloneofid="0221">
+		<description>F-Zero X (USA)</description>
+		<rom name="F-Zero X (USA).n64" />
+		<rom name="F-Zero X (USA).z64" size="16777216" crc="0b561fba" md5="753437d0d8ada1d12f3f9cf0f0a5171f" sha1="5f658e88ffa9de23cba6986a8fd3d3a90d7b4340" sha256="2be0f861c30752bbdfa727753a454108bc973c27ad814744f191b1278c1f482d" serial="CFZE" />
+	</game>
+	<game name="F-Zero X (USA) (Beta) (The Legend of Zelda - Ocarina of Time leftover data)" id="1049">
+		<description>F-Zero X (USA) (Beta) (The Legend of Zelda - Ocarina of Time leftover data)</description>
+		<rom name="F-Zero X (USA) (Beta) (The Legend of Zelda - Ocarina of Time leftover data).n64" />
+		<rom name="F-Zero X (USA) (Beta) (The Legend of Zelda - Ocarina of Time leftover data).z64" size="33554432" crc="68fe1cec" md5="95bf2153aaad6faff3fb42fecd2f0200" sha1="6aa870ec53602650638b50d7c89cac026be481f0" sha256="8cef0e399c0524052b758109abe894c709a72540a42c4a2118064a5cddf01b6d" serial="CFZE" />
+	</game>
+	<game name="F-Zero X (USA) (LodgeNet)" id="1140" cloneofid="0221">
+		<category>Games</category>
+		<rom name="F-Zero X (USA) (LodgeNet).n64" />
+		<description>F-Zero X (USA) (LodgeNet)</description>
+		<rom name="F-Zero X (USA) (LodgeNet).i64" size="64" crc="0ca548dc" md5="4da397a94cab50677ed16699ad21d376" sha1="4b7077c638883195ec8a0b94f5e96391c2fc68ab" />
+		<rom name="F-Zero X (USA) (LodgeNet).z64" size="16777216" crc="1c753f3f" md5="036ec306fc0a6bc3afd967ede4cf4a6f" sha1="2a7cd80ce10a654f3844c602268d66cdbe78230d" />
+	</game>
+	<game name="F1 Pole Position 64 (Europe) (En,Fr,De)" id="0224">
+		<description>F1 Pole Position 64 (Europe) (En,Fr,De)</description>
+		<rom name="F1 Pole Position 64 (Europe) (En,Fr,De).n64" />
+		<rom name="F1 Pole Position 64 (Europe) (En,Fr,De).z64" size="8388608" crc="ed750623" md5="a6bd93ea576cdf8569f68171452f7e8a" sha1="685feb2e8615d5d50944093eb0552858d3e12583" sha256="25e201e65a7d8cd656846b51a39a3cf56a8c5cd4ecb6b577091f61de201ec59d" status="verified" serial="NHGP" />
+	</game>
+	<game name="F1 Pole Position 64 (USA) (En,Fr,De)" id="0225" cloneofid="0224">
+		<description>F1 Pole Position 64 (USA) (En,Fr,De)</description>
+		<rom name="F1 Pole Position 64 (USA) (En,Fr,De).n64" />
+		<rom name="F1 Pole Position 64 (USA) (En,Fr,De).z64" size="8388608" crc="30a24d89" md5="049db657f4223d949f56e9dc5b6a9180" sha1="6e6bdaefc9980f066cd2abc5fa7f29f2353ca8b1" sha256="c41c9679fee76a32aefa4e35e54eff2a90edd3e501c339c18496eb915c7b1736" serial="NHGE" />
+	</game>
+	<game name="F1 Racing Championship (Europe) (En,Fr,De,Es,It)" id="0226">
+		<description>F1 Racing Championship (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="F1 Racing Championship (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="F1 Racing Championship (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="2da744f5" md5="9581fc6ceac86dc8a2aee4053043e422" sha1="3bce20f58ef9f377299858b7f2dabd0a02d2e9b9" sha256="51b765ae7cfdd67ed58a92b5c2181c6c5a6949884df0775b53f72c243f0b6919" status="verified" serial="NFRP" />
+	</game>
+	<game name="F1 Racing Championship (Brazil) (En,Fr)" id="0914" cloneofid="0226">
+		<description>F1 Racing Championship (Brazil) (En,Fr)</description>
+		<rom name="F1 Racing Championship (Brazil) (En,Fr).n64" />
+		<rom name="F1 Racing Championship (Brazil) (En,Fr).z64" size="16777216" crc="c05b9184" md5="44d5f87127053a21db120bd108b7ac0c" sha1="4c95cee963c9f8b477c41c03afccb3362a14e7ce" serial="NFRE" />
+	</game>
+	<game name="F1 Racing Championship (USA) (Beta)" id="1079" cloneofid="0226">
+		<description>F1 Racing Championship (USA) (Beta)</description>
+		<rom name="F1 Racing Championship (USA) (Beta).n64" />
+		<rom name="F1 Racing Championship (USA) (Beta).z64" size="33554432" crc="5a55b4c2" md5="40246128052b0aa0fffc7a06a72930f2" sha1="499dd70cb9d85f6e0c65af0e07c08fc1c0919638" sha256="2fe66b2acd642d8557250df6c5c8b92d58e76997ea09acdca9ccba8387c305a2" serial="NMGE" />
+	</game>
+	<game name="Famista 64 (Japan)" id="0227">
+		<description>Famista 64 (Japan)</description>
+		<rom name="Famista 64 (Japan).n64" />
+		<rom name="Famista 64 (Japan).z64" size="12582912" crc="9fb0e6c9" md5="d99b1a3f6d72defd76f3620959b94944" sha1="f4acb365c8a0dffdf2e93a726fd5e805ab857c56" serial="NFSJ" />
+	</game>
+	<game name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)" id="0228">
+		<description>FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)</description>
+		<rom name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).n64" />
+		<rom name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).z64" size="12582912" crc="137cb3cc" md5="26b18d35984528ae2f90adbb2f2642f7" sha1="676b4d14ad74ccc92ee4b19aa9130ddce42e0e9c" sha256="baee4f4a6b528eab242f09885c518af282fb02175c622812ecb82d58c79d8849" status="verified" serial="N8IP" />
+	</game>
+	<game name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)" id="0229" cloneofid="0228">
+		<description>FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)</description>
+		<rom name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).n64" />
+		<rom name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).z64" size="12582912" crc="28b1221c" md5="2c6d146a8473511cfcfbbe8518f49d71" sha1="148d6424d2135afefecde74092701c491027c23e" serial="N8IE" />
+	</game>
+	<game name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)" id="0230" cloneofid="0228">
+		<description>FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)</description>
+		<rom name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).n64" />
+		<rom name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).z64" size="12582912" crc="ae346df6" md5="3611779f29997267622cbc80e2d087cc" sha1="d8a0c9ef8ff258d061a639e7572d0d9e3038a895" serial="N8IJ" />
+	</game>
+	<game name="FIFA 64 (Europe) (En,Fr,De)" id="0233">
+		<description>FIFA 64 (Europe) (En,Fr,De)</description>
+		<rom name="FIFA 64 (Europe) (En,Fr,De).n64" />
+		<rom name="FIFA 64 (Europe) (En,Fr,De).z64" size="8388608" crc="ae2583fb" md5="9a7006212947ee7648ee1d13162e55e0" sha1="eacdf23e27ec1e0639042bf03804222851e4f151" sha256="f00e3398a860839631b1e06ad26454029bf0d35b3fa27703fdbe58dc1e89051f" status="verified" serial="N7IP" />
+	</game>
+	<game name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)" id="0231">
+		<description>FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)</description>
+		<rom name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" />
+		<rom name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).z64" size="16777216" crc="6eae1e6e" md5="6432c622c05ea9cd3217e280ac2ce37c" sha1="07400c53aef501887f73ef6a45ce04fe2f170fb0" sha256="9598ee62390f249f02bd595c8610e5f81a21f71b7d1162f7d1014012ce799db0" status="verified" serial="N9FP" />
+	</game>
+	<game name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)" id="0232" cloneofid="0231">
+		<description>FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)</description>
+		<rom name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" />
+		<rom name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).z64" size="16777216" crc="6b2473a9" md5="148de3073727b9fd156f10afadd46864" sha1="735062e593715f128d3aad435de0e7a899aed127" serial="N9FE" />
+	</game>
+	<game name="FIFA Soccer 64 (USA) (En,Fr,De)" id="0234" cloneofid="0233">
+		<description>FIFA Soccer 64 (USA) (En,Fr,De)</description>
+		<rom name="FIFA Soccer 64 (USA) (En,Fr,De).n64" />
+		<rom name="FIFA Soccer 64 (USA) (En,Fr,De).z64" size="8388608" crc="57de7cab" md5="cc7c58a032aaba19e72ccbfa6b3eeff6" sha1="603c5bf64497dca86c4eb802f97f1c32e75a68a8" serial="N7IE" />
+	</game>
+	<game name="Fighter Destiny 2 (USA)" id="0235">
+		<description>Fighter Destiny 2 (USA)</description>
+		<rom name="Fighter Destiny 2 (USA).n64" />
+		<rom name="Fighter Destiny 2 (USA).z64" size="16777216" crc="bb2563c6" md5="04dd2a319f4f5c22569b612cfdf9f00c" sha1="1dc12cfd908f56debcad6cf582bfdfc23a3ad725" serial="NFGE" />
+	</game>
+	<game name="Fighters Destiny (Europe)" id="0236">
+		<description>Fighters Destiny (Europe)</description>
+		<rom name="Fighters Destiny (Europe).n64" />
+		<rom name="Fighters Destiny (Europe).z64" size="12582912" crc="c9225511" md5="ef5cb24ce3fe4e0f850901205437b574" sha1="2763731085a9d86d357d8fef775c2d21d3c9f2b4" serial="NKAP" />
+	</game>
+	<game name="Fighters Destiny (France)" id="0237" cloneofid="0236">
+		<description>Fighters Destiny (France)</description>
+		<rom name="Fighters Destiny (France).n64" />
+		<rom name="Fighters Destiny (France).z64" size="12582912" crc="b3a034d6" md5="02689be7b904b76ee083489579e6df89" sha1="f183f2b7e8d8fbea7ed239fc8ea6c902234bba41" sha256="2e2bb4113ad0f987fb51b13250c015eec6fe8def0244d98be33b8675c82b0649" status="verified" serial="NKAF" />
+	</game>
+	<game name="Fighters Destiny (Germany)" id="0238" cloneofid="0236">
+		<description>Fighters Destiny (Germany)</description>
+		<rom name="Fighters Destiny (Germany).n64" />
+		<rom name="Fighters Destiny (Germany).z64" size="12582912" crc="5052168c" md5="1cf379aca2397222af9f3dc5d8e3c444" sha1="aef7792324c262c956e91ee01f57bed0c36bd825" serial="NKAD" />
+	</game>
+	<game name="Fighters Destiny (USA)" id="0239" cloneofid="0236">
+		<description>Fighters Destiny (USA)</description>
+		<rom name="Fighters Destiny (USA).n64" />
+		<rom name="Fighters Destiny (USA).z64" size="12582912" crc="f45ea789" md5="d61d97a7658c419a25a9bac96b0a3df8" sha1="f87e1677602e38bac962424042e289ec58ec37b2" serial="NKAE" />
+	</game>
+	<game name="Fighting Cup (Japan)" id="0240" cloneofid="0236">
+		<description>Fighting Cup (Japan)</description>
+		<rom name="Fighting Cup (Japan).n64" />
+		<rom name="Fighting Cup (Japan).z64" size="12582912" crc="8a1c261e" md5="722c3a74a90305d6079a37994cebf5b2" sha1="011bdbaa1bc6d6a5540a749cf1a90bf6a35fd94b" serial="NKAJ" />
+	</game>
+	<game name="Fighting Force 64 (Europe)" id="0241">
+		<description>Fighting Force 64 (Europe)</description>
+		<rom name="Fighting Force 64 (Europe).n64" />
+		<rom name="Fighting Force 64 (Europe).z64" size="16777216" crc="4052c176" md5="0035e8205336982e362402aaea37d147" sha1="705d2b553fab526c908e46c048be3a3338ae2a86" sha256="5747731470434e1b4613d81288f8a7743b41e61c7349acf673eea92685c75c43" status="verified" serial="NFFP" />
+	</game>
+	<game name="Fighting Force 64 (USA)" id="0242" cloneofid="0241">
+		<description>Fighting Force 64 (USA)</description>
+		<rom name="Fighting Force 64 (USA).n64" />
+		<rom name="Fighting Force 64 (USA).z64" size="16777216" crc="8456841e" md5="e7008d17fd71d9c2bda1362c885388b2" sha1="6b4e78201ad5c5d0bd932652f233d9732316cdc2" sha256="951b6e3ae20fa5eed054f55e9c345b7eaa913930b330cd87e0ade373233bc417" serial="NFFE" />
+	</game>
+	<game name="Flying Dragon (Europe)" id="0243">
+		<description>Flying Dragon (Europe)</description>
+		<rom name="Flying Dragon (Europe).n64" />
+		<rom name="Flying Dragon (Europe).z64" size="12582912" crc="c3066e59" md5="add115aad0ab7d33bfd243936d809178" sha1="3f4462d85d5b5ddc6edaeef45b682eeff7f4b144" sha256="a67ca1d9a3297429524dfde1bc9cd27d7b9b727c4aa336510211b6d2ef070e0e" status="verified" serial="NFDP" />
+	</game>
+	<game name="Flying Dragon (USA)" id="0244" cloneofid="0243">
+		<description>Flying Dragon (USA)</description>
+		<rom name="Flying Dragon (USA).n64" />
+		<rom name="Flying Dragon (USA).z64" size="12582912" crc="91bc9aeb" md5="272b359d8f8ac48acbf053c262f422e4" sha1="5472fe1dcaaacaecba8d1bed8eab4a2146e58665" serial="NFDE" />
+	</game>
+	<game name="Forsaken (Europe) (En,Fr,Es,It)" id="0245">
+		<description>Forsaken (Europe) (En,Fr,Es,It)</description>
+		<rom name="Forsaken (Europe) (En,Fr,Es,It).n64" />
+		<rom name="Forsaken (Europe) (En,Fr,Es,It).z64" size="8388608" crc="5ed736d9" md5="8286ded701dfa22436d311bd5b93bd29" sha1="ac24c6e48fcd03c32aef484188ba842b619ff613" sha256="a94eb83c9e68906d1cfb320bb3d07c74b74f6fa1ac9c57d291e5801cc15e9289" status="verified" serial="NFOP" />
+	</game>
+	<game name="Forsaken (Germany)" id="0246" cloneofid="0245">
+		<description>Forsaken (Germany)</description>
+		<rom name="Forsaken (Germany).n64" />
+		<rom name="Forsaken (Germany).z64" size="8388608" crc="9793abc2" md5="74650f7154e0b2dd7c364f511b0d6a77" sha1="f1be08780d117c44fc10a0dba792d6c5be7d4093" serial="NFOD" />
+	</game>
+	<game name="Forsaken 64 (USA)" id="0247" cloneofid="0245">
+		<description>Forsaken 64 (USA)</description>
+		<rom name="Forsaken 64 (USA).n64" />
+		<rom name="Forsaken 64 (USA).z64" size="8388608" crc="76c4333d" md5="5cdee5503a57d14533c66b35a5848899" sha1="7c670b224acfa960df902c866febb679806cb3fb" serial="NFOE" />
+	</game>
+	<game name="Fox Sports College Hoops '99 (USA)" id="0248">
+		<description>Fox Sports College Hoops '99 (USA)</description>
+		<rom name="Fox Sports College Hoops '99 (USA).n64" />
+		<rom name="Fox Sports College Hoops '99 (USA).z64" size="12582912" crc="67eaf0f3" md5="360dc6be6d06dca12e53c077ac0d2571" sha1="a8ce01a7d6d01be19ffb87cb54cc069494efb596" serial="NF9E" />
+	</game>
+	<game name="Freak Boy (Unknown) (Proto)" id="1040">
+		<description>Freak Boy (Unknown) (Proto)</description>
+		<rom name="Freak Boy (Unknown) (Proto).n64" />
+		<rom name="Freak Boy (Unknown) (Proto).z64" size="16777216" crc="40632bec" md5="19d8cc329244f73f9a0e0750e3688d58" sha1="9326914cd8271e220d6289837f8780f63f98ef30" sha256="e22a3dcc9d4b735698c93ae2ca85572550f303521908fa4c4ef3c74921777223" />
+	</game>
+	<game name="Frogger 2 (USA) (Proto 2)" id="0249">
+		<description>Frogger 2 (USA) (Proto 2)</description>
+		<rom name="Frogger 2 (USA) (Proto 2).n64" />
+		<rom name="Frogger 2 (USA) (Proto 2).z64" size="33554432" crc="a8f81f39" md5="27f61a55e27ea7f1ede4ca11966acc7c" sha1="412d60ec37b71621368fe1885272f74385a7c5a3" serial="NGVE" />
+	</game>
+	<game name="Frogger 2 (USA) (Proto 1)" id="1035" cloneofid="0249">
+		<description>Frogger 2 (USA) (Proto 1)</description>
+		<rom name="Frogger 2 (USA) (Proto 1).n64" />
+		<rom name="Frogger 2 (USA) (Proto 1).z64" size="33554432" crc="8d62268e" md5="097189b4c9bf6775e4685951b6e66f24" sha1="637cafe4abdc3fc0ef0703e3a47ea6a633b16fa3" serial="NGVE" />
+	</game>
+	<game name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)" id="0250">
+		<description>Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)</description>
+		<rom name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).n64" />
+		<rom name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).z64" size="33554432" crc="2aa6d2a1" md5="bbcde4966bee5602a80d9b8c1011dfa6" sha1="f97b070a1fa6ab3d190b36d6b68a2ef182d35233" serial="NSIJ" />
+	</game>
+	<game name="G.A.S.P!! Fighters' NEXTream (Europe)" id="0251">
+		<description>G.A.S.P!! Fighters' NEXTream (Europe)</description>
+		<rom name="G.A.S.P!! Fighters' NEXTream (Europe).n64" />
+		<rom name="G.A.S.P!! Fighters' NEXTream (Europe).z64" size="12582912" crc="5aa63b04" md5="316c59dae45c20250a0419a937e7d65b" sha1="b069f2c0b6ab4fbd486861c4d3aaf8a149ab4529" sha256="dcb4b7c2c53b1505e12db2136af1dea4877ba1be446d4524c2bca18dbe65acd3" status="verified" serial="NGAP" />
+	</game>
+	<game name="G.A.S.P!! Fighters' NEXTream (Japan)" id="0252" cloneofid="0251">
+		<description>G.A.S.P!! Fighters' NEXTream (Japan)</description>
+		<rom name="G.A.S.P!! Fighters' NEXTream (Japan).n64" />
+		<rom name="G.A.S.P!! Fighters' NEXTream (Japan).z64" size="12582912" crc="6ead2d89" md5="6c73558de5a1eee6597d7264f9a11b0c" sha1="86693e6c1623708438ebf23ab0e78dd6ea8c8fa7" serial="NGAJ" />
+	</game>
+	<game name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)" id="0253" cloneofid="0465">
+		<description>Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)</description>
+		<rom name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).n64" />
+		<rom name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).z64" size="16777216" crc="08c41e0e" md5="96ca36d474e82c270a129d775c63167a" sha1="2ab71b71665a688d40832e16d897548ece9f0dd4" serial="NG6J" />
+	</game>
+	<game name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)" id="0254" cloneofid="0466">
+		<description>Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)</description>
+		<rom name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).n64" />
+		<rom name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).z64" size="16777216" crc="2e91efc9" md5="9b929e0bf8d63e62820f2fa6257cc5cf" sha1="9843ee979b5f6c80f5eda85df0baed9ae7c4e73b" serial="NG5J" />
+	</game>
+	<game name="Ganbare! Nippon! Olympics 2000 (Japan)" id="0255" cloneofid="0318">
+		<description>Ganbare! Nippon! Olympics 2000 (Japan)</description>
+		<rom name="Ganbare! Nippon! Olympics 2000 (Japan).n64" />
+		<rom name="Ganbare! Nippon! Olympics 2000 (Japan).z64" size="12582912" crc="73133cd2" md5="8d8f3a8393f3f5489b3b144369565594" sha1="f683446894a704df016b90cc3409ecdb70cba0aa" serial="N3HJ" />
+	</game>
+	<game name="Gauntlet Legends (Europe)" id="0256">
+		<description>Gauntlet Legends (Europe)</description>
+		<rom name="Gauntlet Legends (Europe).n64" />
+		<rom name="Gauntlet Legends (Europe).z64" size="16777216" crc="b7b3a489" md5="28c2108a375f7731e719333a09439d2f" sha1="29f19e0405dca66c7383fb94104a22758a9d06dd" sha256="344a04c993618acdbf01f8bc7283874d77ebcc78c534a49f3ac2e38ca61e38a9" status="verified" serial="NGXP" />
+	</game>
+	<game name="Gauntlet Legends (Japan)" id="0257" cloneofid="0256">
+		<description>Gauntlet Legends (Japan)</description>
+		<rom name="Gauntlet Legends (Japan).n64" />
+		<rom name="Gauntlet Legends (Japan).z64" size="16777216" crc="8d133db0" md5="3b2615d754a61e45b1034d555d830a78" sha1="8389b01e5872053f1f39bc586db9fa012d46c5fa" serial="NGDJ" />
+	</game>
+	<game name="Gauntlet Legends (USA)" id="0258" cloneofid="0256">
+		<description>Gauntlet Legends (USA)</description>
+		<rom name="Gauntlet Legends (USA).n64" />
+		<rom name="Gauntlet Legends (USA).z64" size="16777216" crc="64765e82" md5="9cb963e8b71f18568f78ec1af120362e" sha1="0489dcce749c6a5102681d288ed0616a4b94e99d" serial="NGXE" />
+	</game>
+	<game name="Gauntlet Legends (USA) (LodgeNet)" id="1141" cloneofid="0256">
+		<category>Games</category>
+		<rom name="Gauntlet Legends (USA) (LodgeNet).n64" />
+		<description>Gauntlet Legends (USA) (LodgeNet)</description>
+		<rom name="Gauntlet Legends (USA) (LodgeNet).i64" size="64" crc="195f583f" md5="b003d72f2dbc9701f842f4d5b9c2f392" sha1="9ab84f08b4d54ccf627080e657afa3f1893fec92" />
+		<rom name="Gauntlet Legends (USA) (LodgeNet).z64" size="16777216" crc="1f030279" md5="85ba92b8c4a20ff41b73623a1e794c8b" sha1="45a8d42e17993d1009c858d1847b311197b04f8c" />
+	</game>
+	<game name="Getter Love!! - Cho Renai Party Game Tanjou (Japan)" id="0259">
+		<description>Getter Love!! - Cho Renai Party Game Tanjou (Japan)</description>
+		<rom name="Getter Love!! - Cho Renai Party Game Tanjou (Japan).n64" />
+		<rom name="Getter Love!! - Cho Renai Party Game Tanjou (Japan).z64" size="12582912" crc="724ecae7" md5="5270d98f9e67dc7ef354ece109c2a18f" sha1="942d161abf00b612486388eee98a2c51fc990147" sha256="d66a9b152d32d96fa1360e23437cfd30da7451e444945984387209fceb3a8ff1" status="verified" serial="NGLJ" />
+	</game>
+	<game name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)" id="0260">
+		<description>Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)</description>
+		<rom name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).n64" />
+		<rom name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).z64" size="33554432" crc="6bc4a056" md5="9f0492a34d7a2d7c4e9f29dc1848a04a" sha1="54653ba26a12521ccd886212fffdf2f6427c2fea" serial="NX3P" />
+	</game>
+	<game name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" id="0261" cloneofid="0260">
+		<description>Gex 3 - Deep Cover Gecko (Europe) (Fr,De)</description>
+		<rom name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De).n64" />
+		<rom name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De).z64" size="33554432" crc="a43cb8e4" md5="43b9a7a5ccb6ea3f4860f9f80d73669d" sha1="4bcd958526d9145acf4e3ee7ee484e62dc1bb4ba" sha256="ca8e4d82ce229b6ca4d58328f874379c3e95171b35c6af5695515c31bef10866" status="verified" serial="NX3X" />
+	</game>
+	<game name="Gex 3 - Deep Cover Gecko (USA)" id="0262" cloneofid="0260">
+		<description>Gex 3 - Deep Cover Gecko (USA)</description>
+		<rom name="Gex 3 - Deep Cover Gecko (USA).n64" />
+		<rom name="Gex 3 - Deep Cover Gecko (USA).z64" size="33554432" crc="87a7d099" md5="6770ddec84eb21a5e0d0f55dfd52a01a" sha1="467bc88942e02d542e1a4705dcab98ab7281819f" serial="NX3E" />
+	</game>
+	<game name="Gex 64 - Enter the Gecko (Europe)" id="0263">
+		<description>Gex 64 - Enter the Gecko (Europe)</description>
+		<rom name="Gex 64 - Enter the Gecko (Europe).n64" />
+		<rom name="Gex 64 - Enter the Gecko (Europe).z64" size="16777216" crc="a7c92bea" md5="5bba457e286d250101ce274e0e58080d" sha1="c5318e2660fed61782bb170e780b89305aa8c3dc" sha256="c2febf6820928ed6ab87e11847da6c29ee125344427ccbbeb4f66030f63748ff" status="verified" serial="NX2P" />
+	</game>
+	<game name="Gex 64 - Enter the Gecko (USA)" id="0264" cloneofid="0263">
+		<description>Gex 64 - Enter the Gecko (USA)</description>
+		<rom name="Gex 64 - Enter the Gecko (USA).n64" />
+		<rom name="Gex 64 - Enter the Gecko (USA).z64" size="16777216" crc="c545ce80" md5="47f9d900c97ece154bb40a9c6dccd3fd" sha1="16042cd0dfa5439ca436f1bf05ebfb7e9f730cda" serial="NX2E" />
+	</game>
+	<game name="Glover (USA) (1998-09-04) (Beta)" id="1050" cloneofid="0265">
+		<description>Glover (USA) (1998-09-04) (Beta)</description>
+		<rom name="Glover (USA) (1998-09-04) (Beta).n64" />
+		<rom name="Glover (USA) (1998-09-04) (Beta).z64" size="25165824" crc="5e091e8f" md5="9cc14c73eb1202c3d19633ee05ad5fc4" sha1="3da3074fe998dbc6c47791a5b6dcbb5143b0fad8" sha256="7bfbdce623cdfdffcebdfc95db1317ab46de8d3189e13c790d1def46b2ff6710" serial="NGVE" />
+	</game>
+	<game name="Glover (Europe) (En,Fr,De)" id="0265">
+		<description>Glover (Europe) (En,Fr,De)</description>
+		<rom name="Glover (Europe) (En,Fr,De).n64" />
+		<rom name="Glover (Europe) (En,Fr,De).z64" size="8388608" crc="90eceb4a" md5="2f2163c53db135792331df00398b3f87" sha1="a5209925761c4ef08e5d446a55bc957505308a31" sha256="3b4537794a4b89920fe6fb0739388e4545e4a7ccd57f3b4ed65d8b26859cc7ab" status="verified" serial="NGVP" />
+	</game>
+	<game name="Glover (USA)" id="0266" cloneofid="0265">
+		<description>Glover (USA)</description>
+		<rom name="Glover (USA).n64" />
+		<rom name="Glover (USA).z64" size="8388608" crc="f874571c" md5="87aa5740dff79291ee97832da1f86205" sha1="270be17b3c8da9b88a7b99c2a545b0bce16837f4" sha256="363c84be17c7c11e97df6069ee8f3b205cb190f60e0c02ca223892ff7f47367a" serial="NGVE" />
+	</game>
+	<game name="Glover (USA) (1998-07-16) (Beta) [b]" id="0925" cloneofid="0265">
+		<description>Glover (USA) (1998-07-16) (Beta) [b]</description>
+		<rom name="Glover (USA) (1998-07-16) (Beta) [b].n64" />
+		<rom name="Glover (USA) (1998-07-16) (Beta) [b].z64" size="67108864" crc="7a866221" md5="43c3375bbd6496b6c51d08ec193bc8ed" sha1="a60bb3856218b554beee25d30dcf05e6d0308f52" status="baddump" />
+	</game>
+	<game name="Glover 2 (USA) (Proto 2)" id="0917">
+		<description>Glover 2 (USA) (Proto 2)</description>
+		<rom name="Glover 2 (USA) (Proto 2).n64" />
+		<rom name="Glover 2 (USA) (Proto 2).z64" size="8388608" crc="29966555" md5="d06713b543022414a1a09261f0be42a6" sha1="5e644f7436b2cc0ff07335863e7e2c254d8438a8" sha256="a099f381d12f3b92c52ca28a4e42cfd8c57c56d27bf7a7c74606bb99db914951" />
+	</game>
+	<game name="Glover 2 (USA) (Proto 1)" id="0940" cloneofid="0917">
+		<description>Glover 2 (USA) (Proto 1)</description>
+		<rom name="Glover 2 (USA) (Proto 1).n64" />
+		<rom name="Glover 2 (USA) (Proto 1).z64" size="8388608" crc="1a526dcd" md5="f59e3a7ed3454124680f3a16d38fc42f" sha1="7e6dff67a4dcc1831467aaed16f346f1b5f3fb03" sha256="dad6ce070cbe50be06634c6fb2d306530159c00ae628361926b60439125e3feb" serial="NGVE" />
+	</game>
+	<game name="Goemon - Mononoke Sugoroku (Japan)" id="0267">
+		<description>Goemon - Mononoke Sugoroku (Japan)</description>
+		<rom name="Goemon - Mononoke Sugoroku (Japan).n64" />
+		<rom name="Goemon - Mononoke Sugoroku (Japan).z64" size="16777216" crc="965c4575" md5="2bde49f2855030de342976c9a95b81b3" sha1="accc27a72e9bd8bcac011009a08df7f7aae3b2fe" serial="NGPJ" />
+	</game>
+	<game name="Goemon's Great Adventure (USA)" id="0268" cloneofid="0465">
+		<description>Goemon's Great Adventure (USA)</description>
+		<rom name="Goemon's Great Adventure (USA).n64" />
+		<rom name="Goemon's Great Adventure (USA).z64" size="16777216" crc="52d418e1" md5="29bc5c1a24d3979d376ad421000ac9cb" sha1="9f9e860816f9e2a68bb5f4f56086e0c7450c64d7" serial="NGME" />
+	</game>
+	<game name="Golden Nugget 64 (USA)" id="0269">
+		<description>Golden Nugget 64 (USA)</description>
+		<rom name="Golden Nugget 64 (USA).n64" />
+		<rom name="Golden Nugget 64 (USA).z64" size="8388608" crc="70594d3c" md5="231bac1afb3de138072c2d697783059b" sha1="1c0b0e11804585a17fe1f8776cf5744963d5e2d7" sha256="85bda93bf603585340170183811856116dde707641e541e1ff2943c2bf2772ce" status="verified" serial="NGNE" />
+	</game>
+	<game name="GoldenEye 007 (Europe)" id="0001">
+		<description>GoldenEye 007 (Europe)</description>
+		<rom name="GoldenEye 007 (Europe).n64" />
+		<rom name="GoldenEye 007 (Europe).z64" size="12582912" crc="9ec14aeb" md5="cff69b70a8ad674a0efe5558765855c9" sha1="167c3c433dec1f1eb921736f7d53fac8cb45ee31" sha256="40ff3643d3ed0be1b0b88266d298f455c15bd5a6f1a520c9aa2650b5f4b349de" status="verified" serial="NGEP" />
+	</game>
+	<game name="GoldenEye 007 (Japan)" id="0002" cloneofid="0001">
+		<description>GoldenEye 007 (Japan)</description>
+		<rom name="GoldenEye 007 (Japan).n64" />
+		<rom name="GoldenEye 007 (Japan).z64" size="12582912" crc="a6be19dd" md5="1880da358f875c0740d4a6731e110109" sha1="2a5dade32f7fad6c73c659d2026994632c1b3174" serial="NGEJ" />
+	</game>
+	<game name="GoldenEye 007 (USA)" id="0003" cloneofid="0001">
+		<description>GoldenEye 007 (USA)</description>
+		<rom name="GoldenEye 007 (USA).n64" />
+		<rom name="GoldenEye 007 (USA).z64" size="12582912" crc="b6330846" md5="70c525880240c1e838b8b1be35666c3b" sha1="abe01e4aeb033b6c0836819f549c791b26cfde83" sha256="2cdcec8a9f0cb6e36337f3ee39d8ad105dc8afa6ba1c02d466e8f5b771f9a162" status="verified" serial="NGEE" />
+	</game>
+	<game name="GoldenEye 007 (USA, Europe) (Switch Online)" id="1127" cloneofid="0001">
+		<description>GoldenEye 007 (USA, Europe) (Switch Online)</description>
+		<rom name="GoldenEye 007 (USA, Europe) (Switch Online).n64" />
+		<rom name="GoldenEye 007 (USA, Europe) (Switch Online).z64" size="12582912" crc="e3f2b41e" md5="ea0e3e6aefa58738a12906298373218b" sha1="84accdc54ffaecee312ce6945bfe722ed97e654c" sha256="57dc56aa4b8c66a85d6f83c3068960850dd81f8eaea309e1a7602cb969499fbc" serial="NGEE" />
+	</game>
+	<game name="GoldenEye 007 (Japan) (Switch Online)" id="1193">
+		<category>Games</category>
+		<rom name="GoldenEye 007 (Japan) (Switch Online).n64" />
+		<description>GoldenEye 007 (Japan) (Switch Online)</description>
+		<rom name="GoldenEye 007 (Japan) (Switch Online).z64" size="12582912" crc="92dd6dd5" md5="d41f3ef8f65cedfa0d262d25fa968bba" sha1="a5f4fbf0ed959edd61762940a20c042e6a02a070" sha256="272f656be04c38aa4e7b00bad8a6ea302b98f6a9c19e79773eef0f8ed6ebccf7" serial="NGEJ" />
+	</game>
+	<game name="GT 64 - Championship Edition (Europe) (En,Fr,De)" id="0270">
+		<description>GT 64 - Championship Edition (Europe) (En,Fr,De)</description>
+		<rom name="GT 64 - Championship Edition (Europe) (En,Fr,De).n64" />
+		<rom name="GT 64 - Championship Edition (Europe) (En,Fr,De).z64" size="12582912" crc="6dfb4747" md5="628aa3cd492559b705488f634797e045" sha1="a4d0d694f521cef69f64acaee3eb420a64f28e4d" sha256="928e0763465ddce8109720e529d22cf34fc9567ac965ebe03917e83871e52f28" status="verified" serial="NGCP" />
+	</game>
+	<game name="GT 64 - Championship Edition (USA)" id="0271" cloneofid="0270">
+		<description>GT 64 - Championship Edition (USA)</description>
+		<rom name="GT 64 - Championship Edition (USA).n64" />
+		<rom name="GT 64 - Championship Edition (USA).z64" size="12582912" crc="bc627da7" md5="fe81aa381719fada693d803bae7d5eb9" sha1="b941246af78748f4e081f496dac0a9e2056d3d8d" serial="NGCE" />
+	</game>
+	<game name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25)" id="1037" cloneofid="0270">
+		<description>GT 64 - Championship Edition (USA) (Beta) (1998-05-25)</description>
+		<rom name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25).n64" />
+		<rom name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25).z64" size="16777216" crc="191bf504" md5="4690cab33d0bc10b62d62cecdcaa50a1" sha1="6b58306825ef85a3a128dd5bc0bc0c21f517b3a2" serial="NGCE" />
+	</game>
+	<game name="Hamster Monogatari 64 (Japan)" id="0272">
+		<description>Hamster Monogatari 64 (Japan)</description>
+		<rom name="Hamster Monogatari 64 (Japan).n64" />
+		<rom name="Hamster Monogatari 64 (Japan).z64" size="12582912" crc="c1d98b78" md5="3d4c7b11076bafa4620bcc154c0eeef3" sha1="436627174830fb9941bd4f25efa6fa1024498a97" serial="NHSJ" />
+	</game>
+	<game name="Harukanaru Augusta - Masters '98 (Japan)" id="0273">
+		<description>Harukanaru Augusta - Masters '98 (Japan)</description>
+		<rom name="Harukanaru Augusta - Masters '98 (Japan).n64" />
+		<rom name="Harukanaru Augusta - Masters '98 (Japan).z64" size="16777216" crc="51228f0c" md5="a02a4fb4b93e9847348440652cef8d4d" sha1="08af498bca98c79e3fa18c9c860091d5eb952e6e" serial="NM9J" />
+	</game>
+	<game name="Harvest Moon 64 (USA)" id="0274">
+		<description>Harvest Moon 64 (USA)</description>
+		<rom name="Harvest Moon 64 (USA).n64" />
+		<rom name="Harvest Moon 64 (USA).z64" size="16777216" crc="decdc0ad" md5="6da848a70d83ece130d274124760928e" sha1="90631460f1876a14849df0541d534012b410a34c" sha256="15c570120bfaa97b4580762f5ee5939a56ba054e696925ea81ccfa55a022d2a6" serial="NYWE" />
+	</game>
+	<game name="Heiwa Pachinko World 64 (Japan)" id="0275">
+		<description>Heiwa Pachinko World 64 (Japan)</description>
+		<rom name="Heiwa Pachinko World 64 (Japan).n64" />
+		<rom name="Heiwa Pachinko World 64 (Japan).z64" size="8388608" crc="99a427fa" md5="5e8539e037eea88c5a2746f60e431c8d" sha1="d48a484febaac3bd146130434921861890503b29" serial="NHPJ" />
+	</game>
+	<game name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)" id="0276">
+		<description>Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)</description>
+		<rom name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<rom name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="b1954b08" md5="1546877fd85c00a83515005727e5fda5" sha1="d2e26f4aecf488f87e1ab36395280385b060d229" status="verified" serial="NHCP" />
+	</game>
+	<game name="Hercules - The Legendary Journeys (USA)" id="0277" cloneofid="0276">
+		<description>Hercules - The Legendary Journeys (USA)</description>
+		<rom name="Hercules - The Legendary Journeys (USA).n64" />
+		<rom name="Hercules - The Legendary Journeys (USA).z64" size="16777216" crc="4948892b" md5="6bbd8c42f6ef8f5b9541d6f4db657dd7" sha1="5c3c4345be505763fc51a9e3713f5787e4044646" sha256="8c7d23b9d9a349561f922c90aa128d85abf5ccafc696a2bcd36a434738bf72bc" serial="NHCE" />
+	</game>
+	<game name="Hercules - The Legendary Journeys (USA) (Beta 1)" id="1073" cloneofid="0276">
+		<category>Games</category>
+		<rom name="Hercules - The Legendary Journeys (USA) (Beta 1).n64" />
+		<category>Preproduction</category>
+		<description>Hercules - The Legendary Journeys (USA) (Beta 1)</description>
+		<rom name="Hercules - The Legendary Journeys (USA) (Beta 1).z64" size="16777216" crc="87eba0cb" md5="5f1304c94e1b355398abd8141657382d" sha1="cd42f8a8cafd1adb54b971485bd3c5b35393b361" sha256="39f54f55d0a54a8c71597d9950de2422aba9e3a42a40ecf32a2a39359612c40c" />
+	</game>
+	<game name="Hercules - The Legendary Journeys (USA) (Beta 2)" id="1132" cloneofid="0276">
+		<category>Games</category>
+		<rom name="Hercules - The Legendary Journeys (USA) (Beta 2).n64" />
+		<category>Preproduction</category>
+		<description>Hercules - The Legendary Journeys (USA) (Beta 2)</description>
+		<rom name="Hercules - The Legendary Journeys (USA) (Beta 2).z64" size="16777216" crc="cf3a5e8f" md5="fa1bb2483dae322f2b336878b3b95229" sha1="9d1b39b7706d9cd0e98af1c9d5e57aa9d5f7e0a5" sha256="ca4603878ff685bef382b4184155179f6812cbe02c98b10569a3156970ffc0b0" serial="NHCE" />
+	</game>
+	<game name="Hexen (Europe)" id="0278">
+		<description>Hexen (Europe)</description>
+		<rom name="Hexen (Europe).n64" />
+		<rom name="Hexen (Europe).z64" size="8388608" crc="5369efb4" md5="2080262a251d270f9ce819887f2104a7" sha1="1a929ae2a7930cf4b762fa28a9d20338c5fed847" serial="NHXP" />
+	</game>
+	<game name="Hexen (France)" id="0279" cloneofid="0278">
+		<description>Hexen (France)</description>
+		<rom name="Hexen (France).n64" />
+		<rom name="Hexen (France).z64" size="8388608" crc="e373fa31" md5="a5921c00111200257284ce0aba0904ca" sha1="476d3b340ba2a1b1acc1d0cc97ac6e25a5136ca2" sha256="d2dd8eacd6697d0ae9a5bea2d45ed6182eedc3bb7e4f71a9b8330d4fdd9304f7" status="verified" serial="NHXF" />
+	</game>
+	<game name="Hexen (Germany)" id="0280" cloneofid="0278">
+		<description>Hexen (Germany)</description>
+		<rom name="Hexen (Germany).n64" />
+		<rom name="Hexen (Germany).z64" size="8388608" crc="e4821c4b" md5="08cbb141dec604e4dad2787f237d57a2" sha1="8d10ca2860d72c3c1adb409485936c4ba3f18396" serial="NHXD" />
+	</game>
+	<game name="Hexen (Japan)" id="0281" cloneofid="0278">
+		<description>Hexen (Japan)</description>
+		<rom name="Hexen (Japan).n64" />
+		<rom name="Hexen (Japan).z64" size="8388608" crc="571da09a" md5="672152cf4dcb5d0a19662c11eff71452" sha1="3e3e2b012bbb873338b0573f6e11426e38f8b5cd" serial="NHXJ" />
+	</game>
+	<game name="Hexen (USA)" id="0282" cloneofid="0278">
+		<description>Hexen (USA)</description>
+		<rom name="Hexen (USA).n64" />
+		<rom name="Hexen (USA).z64" size="8388608" crc="1d35e110" md5="eb98f1b8c6898af7417f6882946da9b3" sha1="a602839132f6cca71f175fb72039897705ba4661" serial="NHXE" />
+	</game>
+	<game name="Hey You, Pikachu! (USA)" id="0283">
+		<description>Hey You, Pikachu! (USA)</description>
+		<rom name="Hey You, Pikachu! (USA).n64" />
+		<rom name="Hey You, Pikachu! (USA).z64" size="16777216" crc="b18b2734" md5="1280c78f286fc1c437a4905ee42c47f1" sha1="da1a1e47a86720f9d54fb2d2d247480041bda824" sha256="9a255c6d36177283f1a72e3b2d57750b70f6c0f13c361fd60ae8545ab04aca43" status="verified" serial="NPGE" />
+	</game>
+	<game name="Hiryuu no Ken Twin (Japan)" id="0284" cloneofid="0243">
+		<description>Hiryuu no Ken Twin (Japan)</description>
+		<rom name="Hiryuu no Ken Twin (Japan).n64" />
+		<rom name="Hiryuu no Ken Twin (Japan).z64" size="12582912" crc="ba6a687e" md5="73084495f3209c54900525436bbbc531" sha1="c7a76b061c383600378e52a39dada8d2be58325b" status="verified" serial="NHKJ" />
+	</game>
+	<game name="Holy Magic Century (Europe)" id="0285">
+		<description>Holy Magic Century (Europe)</description>
+		<rom name="Holy Magic Century (Europe).n64" />
+		<rom name="Holy Magic Century (Europe).z64" size="16777216" crc="84ff9890" md5="80cc112f62e9a8581a1bb6a1d1e1488b" sha1="139607eba03326fbe9d899663c56e64042d51e84" serial="NETP" />
+	</game>
+	<game name="Holy Magic Century (France)" id="0286" cloneofid="0285">
+		<description>Holy Magic Century (France)</description>
+		<rom name="Holy Magic Century (France).n64" />
+		<rom name="Holy Magic Century (France).z64" size="16777216" crc="284170ed" md5="988f5abd96259196343659e913666820" sha1="610bf1f4a5cbeb2d6dc3ae1dafc5b3b818f69c26" sha256="6e861b0b50149ba9ccb751d06002728cac0610fc3147f0060369c6691f84b3ca" serial="NETF" />
+	</game>
+	<game name="Holy Magic Century (Germany)" id="0287" cloneofid="0285">
+		<description>Holy Magic Century (Germany)</description>
+		<rom name="Holy Magic Century (Germany).n64" />
+		<rom name="Holy Magic Century (Germany).z64" size="16777216" crc="d1934cf6" md5="ab676c3e9d26a77450ddb4aacd1a3861" sha1="ac5457fff3fcc8d6acffb60fa9a99846d36facf8" serial="NETD" />
+	</game>
+	<game name="Hoshi no Kirby 64 (Japan)" id="0288" cloneofid="0360">
+		<description>Hoshi no Kirby 64 (Japan)</description>
+		<rom name="Hoshi no Kirby 64 (Japan).n64" />
+		<rom name="Hoshi no Kirby 64 (Japan).z64" size="33554432" crc="ae7cb69d" md5="b1a67aebc2be89a800e5eb60c0dfa968" sha1="b9882992907a102bd33373585acc90b9c7eb1ba4" serial="NK4J" />
+	</game>
+	<game name="Hoshi no Kirby 64 (Japan) (Rev 1)" id="0289" cloneofid="0360">
+		<description>Hoshi no Kirby 64 (Japan) (Rev 1)</description>
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 1).n64" />
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 1).z64" size="33554432" crc="a263c1b9" md5="ffdb4456f799722bcfe430632c3986ae" sha1="2502ceb1afba83c90f3e7f98b283f667b85d4150" serial="NK4J" />
+	</game>
+	<game name="Hoshi no Kirby 64 (Japan) (Rev 2)" id="0290" cloneofid="0360">
+		<description>Hoshi no Kirby 64 (Japan) (Rev 2)</description>
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 2).n64" />
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 2).z64" size="33554432" crc="f4589aa8" md5="3ec0471e2cbee17471ddbf80c56606d5" sha1="c177f4e37eff98ef2d18fb1e94cd253fd366a218" serial="NK4J" />
+	</game>
+	<game name="Hoshi no Kirby 64 (Japan) (Rev 3)" id="0291" cloneofid="0360">
+		<description>Hoshi no Kirby 64 (Japan) (Rev 3)</description>
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 3).n64" />
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 3).z64" size="33554432" crc="6d5e1332" md5="35e039f8e79843917d02be06d00c457b" sha1="03257c820b7705400c32bde1bcc3161c55814605" sha256="81eba9acfb169db372a8c4f151f191ed434b64c0c505cf064f0dec9d4ac0ecb7" status="verified" serial="NK4J" />
+	</game>
+	<game name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De)" id="0292">
+		<description>Hot Wheels - Turbo Racing (Europe) (En,Fr,De)</description>
+		<rom name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De).n64" />
+		<rom name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De).z64" size="16777216" crc="850633a7" md5="ef34da35ef8a0734843cb182c19feb26" sha1="fbcfd6d466931e5cb71fe880c52ea692c3f84d75" sha256="7beda0bb4ef2435aa097094c8622950d4bd34e786bdb6ae30ecd5f390875089f" status="verified" serial="NHWP" />
+	</game>
+	<game name="Hot Wheels - Turbo Racing (USA)" id="0293" cloneofid="0292">
+		<description>Hot Wheels - Turbo Racing (USA)</description>
+		<rom name="Hot Wheels - Turbo Racing (USA).n64" />
+		<rom name="Hot Wheels - Turbo Racing (USA).z64" size="12582912" crc="a5c92148" md5="4311a1aef1898678331f7e3486055307" sha1="94913a07e49005ffd43dfdfa16ff5862bdb93748" sha256="cdedbe26e64ee9a85c214ae85dceb68d14f52d39a01583d8b6a100d206f172a6" serial="NHWE" />
+	</game>
+	<game name="HSV Adventure Racing! (Australia)" id="0294" cloneofid="0071">
+		<description>HSV Adventure Racing! (Australia)</description>
+		<rom name="HSV Adventure Racing! (Australia).n64" />
+		<rom name="HSV Adventure Racing! (Australia).z64" size="16777216" crc="c0ba9440" md5="26f7d8f4640ebdfa823f84e5f89d62bf" sha1="8a9cdc2a7d98c354ba4b31cea644dbd5153880ae" status="verified" serial="NNSX" />
+	</game>
+	<game name="Human Grand Prix - The New Generation (Japan)" id="0295" cloneofid="0224">
+		<description>Human Grand Prix - The New Generation (Japan)</description>
+		<rom name="Human Grand Prix - The New Generation (Japan).n64" />
+		<rom name="Human Grand Prix - The New Generation (Japan).z64" size="8388608" crc="31e102e3" md5="97e706ed9cc6f30708ffdc187c85d59f" sha1="b8dfe78c7abf1e33edad0b5ecec1c9f1f3c8b576" serial="NHGJ" />
+	</game>
+	<game name="Hybrid Heaven (Europe) (En,Fr,De)" id="0296">
+		<description>Hybrid Heaven (Europe) (En,Fr,De)</description>
+		<rom name="Hybrid Heaven (Europe) (En,Fr,De).n64" />
+		<rom name="Hybrid Heaven (Europe) (En,Fr,De).z64" size="16777216" crc="e76627ff" md5="da861c4d9202f661575466450a27c412" sha1="d2210d492bad952b055a4269e45fd89631c32d25" sha256="b8f74146e50eaf17aa7198fc70c27d85ecb4a494951ebef3f7a33352fb0ba7ff" status="verified" serial="NHVP" />
+	</game>
+	<game name="Hybrid Heaven (Japan)" id="0297" cloneofid="0296">
+		<description>Hybrid Heaven (Japan)</description>
+		<rom name="Hybrid Heaven (Japan).n64" />
+		<rom name="Hybrid Heaven (Japan).z64" size="16777216" crc="e769de96" md5="9946eff915fc947a226407ac1f7b35c4" sha1="09f4d3200b0bd4b984a80248af07de3c40b5cc26" serial="NHYJ" />
+	</game>
+	<game name="Hybrid Heaven (USA)" id="0298" cloneofid="0296">
+		<description>Hybrid Heaven (USA)</description>
+		<rom name="Hybrid Heaven (USA).n64" />
+		<rom name="Hybrid Heaven (USA).z64" size="16777216" crc="15b57ef8" md5="c47e95bb32ab132c41d67bd243f9e02a" sha1="16dbc21620b52deab5c5abf8a309ac60adfbee85" serial="NHVE" />
+	</game>
+	<game name="Hydro Thunder (Europe)" id="0299">
+		<description>Hydro Thunder (Europe)</description>
+		<rom name="Hydro Thunder (Europe).n64" />
+		<rom name="Hydro Thunder (Europe).z64" size="33554432" crc="863ab8f3" md5="434bb8de49011573ac38e893224c5623" sha1="0661b1b0e47bc02d9b0d87d1688fd466793c074b" serial="NHTP" />
+	</game>
+	<game name="Hydro Thunder (France)" id="0300" cloneofid="0299">
+		<description>Hydro Thunder (France)</description>
+		<rom name="Hydro Thunder (France).n64" />
+		<rom name="Hydro Thunder (France).z64" size="33554432" crc="010f6242" md5="4b4c85d9dd2d460adafabae8db48b4fa" sha1="03fa91aec0819654f1ad0d12bb81ce3f5d7d08ae" sha256="ba0bd67caa0968b70f18ca0e62fc2c41efd484d906df29d5d296302fe12c6d6f" status="verified" serial="NHTF" />
+	</game>
+	<game name="Hydro Thunder (USA)" id="0301" cloneofid="0299">
+		<description>Hydro Thunder (USA)</description>
+		<rom name="Hydro Thunder (USA).n64" />
+		<rom name="Hydro Thunder (USA).z64" size="33554432" crc="e744456f" md5="54f43e6b68782e98caabea5e7976b2be" sha1="f5d5054f97da0d68857f9824130147ec38ee7a76" sha256="41703c97b3045ab9bd414a3c36e97617c3309a7695233eddf3e5c252936bc20e" serial="NHTE" />
+	</game>
+	<game name="Hydro Thunder (USA) (LodgeNet)" id="1142" cloneofid="0299">
+		<category>Games</category>
+		<rom name="Hydro Thunder (USA) (LodgeNet).n64" />
+		<description>Hydro Thunder (USA) (LodgeNet)</description>
+		<rom name="Hydro Thunder (USA) (LodgeNet).i64" size="64" crc="2e82689d" md5="c8838c1838d8813c4d6978014a6794d1" sha1="d77158239a249f4db34c31d6e2e15b9e3e948fe0" />
+		<rom name="Hydro Thunder (USA) (LodgeNet).z64" size="33554432" crc="1ec49934" md5="3fd29c7f2bc7af39b249d1f13b3e4247" sha1="30794eb5c1c6a22fbb9dd530f22d153163a6ccda" />
+	</game>
+	<game name="Hyper Olympics in Nagano 64 (Japan)" id="0302" cloneofid="0468">
+		<description>Hyper Olympics in Nagano 64 (Japan)</description>
+		<rom name="Hyper Olympics in Nagano 64 (Japan).n64" />
+		<rom name="Hyper Olympics in Nagano 64 (Japan).z64" size="12582912" crc="c1ea5d33" md5="d2f7b3ace75a2ce7a06beac929711d94" sha1="3d0f36371f99c8abc8e835dae4e0913757ee4827" serial="NH5J" />
+	</game>
+	<game name="Ide Yosuke no Mahjong Juku (Japan)" id="0303">
+		<description>Ide Yosuke no Mahjong Juku (Japan)</description>
+		<rom name="Ide Yosuke no Mahjong Juku (Japan).n64" />
+		<rom name="Ide Yosuke no Mahjong Juku (Japan).z64" size="12582912" crc="dbd96deb" md5="92a6ffa1c8d537c7a97c5c613cae05c6" sha1="26e3210f45c78d72eae61cb066d08d6e00c0ea87" sha256="ee36dc5adf5ccaa446e6148d8dc5f4519bdf1c225bf36cee30163a185caaa47c" status="verified" serial="NIMJ" />
+	</game>
+	<game name="Iggy-kun no Bura Bura Poyon (Japan)" id="0306" cloneofid="0304">
+		<description>Iggy-kun no Bura Bura Poyon (Japan)</description>
+		<rom name="Iggy-kun no Bura Bura Poyon (Japan).n64" />
+		<rom name="Iggy-kun no Bura Bura Poyon (Japan).z64" size="4194304" crc="26cc1266" md5="c70b0b680807f2b8c2c3d5dc495fa8c2" sha1="ebb8c0c99d000a366d2dba0d8d184ec18aa82d43" status="verified" serial="NWBJ" />
+	</game>
+	<game name="Iggy's Reckin' Balls (Europe)" id="0304">
+		<description>Iggy's Reckin' Balls (Europe)</description>
+		<rom name="Iggy's Reckin' Balls (Europe).n64" />
+		<rom name="Iggy's Reckin' Balls (Europe).z64" size="4194304" crc="9bf26065" md5="25b297143e9e5ccbb4b80a7fb6af399b" sha1="da3c5ba5849e104383ea4c3df1fbdb8253f184c9" sha256="d4cb09595833b42ae9c8c4ceb3df5c35e0b013409cd57b11bac955e7b42dc5b1" status="verified" serial="NWBP" />
+	</game>
+	<game name="Iggy's Reckin' Balls (USA)" id="0305" cloneofid="0304">
+		<description>Iggy's Reckin' Balls (USA)</description>
+		<rom name="Iggy's Reckin' Balls (USA).n64" />
+		<rom name="Iggy's Reckin' Balls (USA).z64" size="4194304" crc="6a6fbd5d" md5="464211abb602ee1005974d2d835a3bcf" sha1="1a32230e0ef147b3c8c07ece5aec96458286b4af" serial="NWBE" />
+	</game>
+	<game name="Iggy's Reckin' Balls (USA) (Beta)" id="1186" cloneofid="0304">
+		<category>Games</category>
+		<rom name="Iggy's Reckin' Balls (USA) (Beta).n64" />
+		<category>Preproduction</category>
+		<description>Iggy's Reckin' Balls (USA) (Beta)</description>
+		<rom name="Iggy's Reckin' Balls (USA) (Beta).z64" size="4194304" crc="240bdad4" md5="acc2cb075999105e516d727586e9dc60" sha1="997b6d58ed7e1cab4e5bc0f396af1bd88f413f48" sha256="7ee9782bffccc49380c489a0f02d8248440d478f7ad48c215328e28c4025e8bc" serial="NTUE" />
+	</game>
+	<game name="In-Fisherman - Bass Hunter 64 (Europe)" id="0307">
+		<description>In-Fisherman - Bass Hunter 64 (Europe)</description>
+		<rom name="In-Fisherman - Bass Hunter 64 (Europe).n64" />
+		<rom name="In-Fisherman - Bass Hunter 64 (Europe).z64" size="8388608" crc="00da3704" md5="bf3e84cdd01cac05987fd8da5191534b" sha1="d36374be227e972b1c0b6f2cfbb8fdd724aa1074" sha256="ef0be65a822e0cd2c55cac4616e515a4c6bda3ee31b87ada2bf4e0b77a758af1" status="verified" serial="NFHP" />
+	</game>
+	<game name="In-Fisherman - Bass Hunter 64 (USA)" id="0308" cloneofid="0307">
+		<description>In-Fisherman - Bass Hunter 64 (USA)</description>
+		<rom name="In-Fisherman - Bass Hunter 64 (USA).n64" />
+		<rom name="In-Fisherman - Bass Hunter 64 (USA).z64" size="8388608" crc="d8eb5e6e" md5="c605f40bf669e00a5e51baf0d00621ea" sha1="4aa373e23876c89a549c98036f456b564d779217" serial="NFHE" />
+	</game>
+	<game name="Indiana Jones and the Infernal Machine (USA)" id="0309">
+		<description>Indiana Jones and the Infernal Machine (USA)</description>
+		<rom name="Indiana Jones and the Infernal Machine (USA).n64" />
+		<rom name="Indiana Jones and the Infernal Machine (USA).z64" size="33554432" crc="4978eb57" md5="70de1eab508596b6bbefd168b5d07194" sha1="93300d63412d6c7432109b5ad2e4a8b9348e9538" serial="NIJE" />
+	</game>
+	<game name="Indiana Jones and the Infernal Machine (Australia) (Proto)" id="0946" cloneofid="0309">
+		<description>Indiana Jones and the Infernal Machine (Australia) (Proto)</description>
+		<rom name="Indiana Jones and the Infernal Machine (Australia) (Proto).n64" />
+		<rom name="Indiana Jones and the Infernal Machine (Australia) (Proto).z64" size="33554432" crc="337219be" md5="63d7ab29ba3dfc5d5b12c1d9c5832355" sha1="8465af5538c4b636834a8b2cd5a7decadf0e8841" serial="NIJP" />
+	</game>
+	<game name="Indy Racing 2000 (USA)" id="0310">
+		<description>Indy Racing 2000 (USA)</description>
+		<rom name="Indy Racing 2000 (USA).n64" />
+		<rom name="Indy Racing 2000 (USA).z64" size="16777216" crc="a5163f29" md5="a7781d441af55c4ff8afc68ab3a59313" sha1="015bf0e0bc700a80a2606d3578e4a9b7645e99ec" sha256="1a4672323200183efef8df6e9f4ec6bab230f76731407386a72dbebf6d984d08" serial="NICE" />
+	</game>
+	<game name="International Superstar Soccer '98 (Europe)" id="0311">
+		<description>International Superstar Soccer '98 (Europe)</description>
+		<rom name="International Superstar Soccer '98 (Europe).n64" />
+		<rom name="International Superstar Soccer '98 (Europe).z64" size="12582912" crc="bf23945d" md5="34489365b550f32c97337d86d52d8c84" sha1="ccaffee3a793a0c3a5e7c48fbc4a4759ef29153f" sha256="1825595b2b42a01c0cb83a00d71313695d83f705a0afc1deb9b6a6f097b02c0f" status="verified" serial="NWSP" />
+	</game>
+	<game name="International Superstar Soccer '98 (USA)" id="0312" cloneofid="0311">
+		<description>International Superstar Soccer '98 (USA)</description>
+		<rom name="International Superstar Soccer '98 (USA).n64" />
+		<rom name="International Superstar Soccer '98 (USA).z64" size="12582912" crc="b85fa721" md5="7dcc05b98e2fa690b478808ebbad5d1a" sha1="053735184d414e0a1bbd888f3c931252ea1b92fd" serial="NWSE" />
+	</game>
+	<game name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02)" id="1059" cloneofid="0311">
+		<description>International Superstar Soccer '98 (Europe) (Beta) (1998-03-02)</description>
+		<rom name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02).n64" />
+		<rom name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02).z64" size="16777216" crc="a63dcb66" md5="21ea0b80849b084ac3138fde780e5dbb" sha1="2fb15e4517ebe84f4a354e555716105fe69dd993" sha256="7540ee55ab721c657e86a73b4e98174e13d47880c35f003833cfe5b90a5124aa" serial="!none" />
+	</game>
+	<game name="International Superstar Soccer 2000 (Europe) (En,De)" id="0313">
+		<description>International Superstar Soccer 2000 (Europe) (En,De)</description>
+		<rom name="International Superstar Soccer 2000 (Europe) (En,De).n64" />
+		<rom name="International Superstar Soccer 2000 (Europe) (En,De).z64" size="16777216" crc="69572558" md5="9f101b6f6bef4f267deb5c6c37a24b97" sha1="e7078e5f1e899382b1cc145df43ee8cfaa924297" status="verified" serial="NISX" />
+	</game>
+	<game name="International Superstar Soccer 2000 (Europe) (Fr,It)" id="0314" cloneofid="0313">
+		<description>International Superstar Soccer 2000 (Europe) (Fr,It)</description>
+		<rom name="International Superstar Soccer 2000 (Europe) (Fr,It).n64" />
+		<rom name="International Superstar Soccer 2000 (Europe) (Fr,It).z64" size="16777216" crc="8a16a6a9" md5="cc2be97a16744860fae8a94611479c4c" sha1="b0505e13ba0f029ea735378c50b224fd618be302" sha256="0424b77df0ddae3996bb3af88c17311b46addc4f510da1ae0e2197df03d50eda" status="verified" serial="NISY" />
+	</game>
+	<game name="International Superstar Soccer 2000 (USA) (En,Es)" id="0315" cloneofid="0313">
+		<description>International Superstar Soccer 2000 (USA) (En,Es)</description>
+		<rom name="International Superstar Soccer 2000 (USA) (En,Es).n64" />
+		<rom name="International Superstar Soccer 2000 (USA) (En,Es).z64" size="16777216" crc="dcd0538f" md5="23a4ed8d79882594206173b1d476f0e9" sha1="e7bd36c410ce881d8b8dc853cb4b7b7961bf6a62" sha256="e18e87c062a66002c0cbd7e2dd793ef755609e70675d5679df0396d4b6c67850" serial="NISE" />
+	</game>
+	<game name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)" id="1027" cloneofid="0313">
+		<description>International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)</description>
+		<rom name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1).n64" />
+		<rom name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1).z64" size="16777216" crc="4c433fdd" md5="de9498be76134bd066aa714ce2c71a16" sha1="47a993fe1316dfd9e208603370d3dddae05f1d1b" serial="NISE" />
+	</game>
+	<game name="International Superstar Soccer 64 (Europe)" id="0316">
+		<description>International Superstar Soccer 64 (Europe)</description>
+		<rom name="International Superstar Soccer 64 (Europe).n64" />
+		<rom name="International Superstar Soccer 64 (Europe).z64" size="8388608" crc="8c839268" md5="376803f28ca8b2133671783419933ca2" sha1="3b53fd76bb37b923b0fe61e50057ae773a25170a" sha256="87cad89c16530762708eefa49e2c69d5690a406eab8d39554aaceca9efcc4574" status="verified" serial="NJPP" />
+	</game>
+	<game name="International Superstar Soccer 64 (USA)" id="0317" cloneofid="0316">
+		<description>International Superstar Soccer 64 (USA)</description>
+		<rom name="International Superstar Soccer 64 (USA).n64" />
+		<rom name="International Superstar Soccer 64 (USA).z64" size="8388608" crc="0ea249b9" md5="6a345402ae1db5ce1041365e36126bce" sha1="d2c258ee3844be77049e4af5208f8f2bb073a86e" serial="NJPE" />
+	</game>
+	<game name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)" id="0318">
+		<description>International Track &amp; Field - Summer Games (Europe) (En,Fr,De)</description>
+		<rom name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De).n64" />
+		<rom name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De).z64" size="12582912" crc="b3181ee0" md5="970488fb7d9c5c25bd924e6f898b84a0" sha1="b3d5a2128813bd077dd3e161978e3c1717e278e0" sha256="271aaf29620973642eaba225e762c92305f7f10285a21c08ef9d00f55bc8baa6" status="verified" serial="N3HP" />
+	</game>
+	<game name="International Track &amp; Field 2000 (USA)" id="0319" cloneofid="0318">
+		<description>International Track &amp; Field 2000 (USA)</description>
+		<rom name="International Track &amp; Field 2000 (USA).n64" />
+		<rom name="International Track &amp; Field 2000 (USA).z64" size="12582912" crc="da443f0b" md5="35662cfd07fd6af4bab90ca23f7c98e6" sha1="61d7958e61b50fd933faf5d3ae70807fa53818fb" serial="N3HE" />
+	</game>
+	<game name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)" id="0320">
+		<description>Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)</description>
+		<rom name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).n64" />
+		<rom name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).z64" size="16777216" crc="576915d4" md5="13893db9e919c4e7cf0c0b0064ccb554" sha1="c722ba7fd7c44fee474233db3fd251177a83a9ab" serial="NIBJ" />
+	</game>
+	<game name="J.League Dynamite Soccer 64 (Japan)" id="0321">
+		<description>J.League Dynamite Soccer 64 (Japan)</description>
+		<rom name="J.League Dynamite Soccer 64 (Japan).n64" />
+		<rom name="J.League Dynamite Soccer 64 (Japan).z64" size="8388608" crc="dc0b2c8f" md5="1247b093e0fd6ccfd50d15de59301076" sha1="b5618ffde759bcef12a19b336cf940df24f52209" serial="NDSJ" />
+	</game>
+	<game name="J.League Eleven Beat 1997 (Japan)" id="0322">
+		<description>J.League Eleven Beat 1997 (Japan)</description>
+		<rom name="J.League Eleven Beat 1997 (Japan).n64" />
+		<rom name="J.League Eleven Beat 1997 (Japan).z64" size="8388608" crc="7d0eed6a" md5="30e23d3de446e37e5e7fbef6794a6fc9" sha1="0403902145ced0c42252981bc6c8fef2f76ccc08" serial="NJEJ" />
+	</game>
+	<game name="J.League Live 64 (Japan)" id="0323">
+		<description>J.League Live 64 (Japan)</description>
+		<rom name="J.League Live 64 (Japan).n64" />
+		<rom name="J.League Live 64 (Japan).z64" size="8388608" crc="4c536dd7" md5="209db8333eeb526ae9a91209175348ce" sha1="447e573eb019bf4acd48b926c89701e09198ee36" serial="NJLJ" />
+	</game>
+	<game name="J.League Tactics Soccer (Japan)" id="0324" cloneofid="0325">
+		<description>J.League Tactics Soccer (Japan)</description>
+		<rom name="J.League Tactics Soccer (Japan).n64" />
+		<rom name="J.League Tactics Soccer (Japan).z64" size="12582912" crc="976a2d12" md5="800acc7d609ecdb3e09e68cbd05f5fa0" sha1="853cecc41c00f1bbc9972dffb94b78bdb0dfa274" serial="NSJJ" />
+	</game>
+	<game name="J.League Tactics Soccer (Japan) (Rev 1)" id="0325">
+		<description>J.League Tactics Soccer (Japan) (Rev 1)</description>
+		<rom name="J.League Tactics Soccer (Japan) (Rev 1).n64" />
+		<rom name="J.League Tactics Soccer (Japan) (Rev 1).z64" size="12582912" crc="156e705e" md5="793dbf504e20c92f6b73b4e8a25a220c" sha1="9a47293d82c161f1cb146673ac6ad96c1730c624" serial="NSJJ" />
+	</game>
+	<game name="Jangou Simulation Mahjong Dou 64 (Japan)" id="0326">
+		<description>Jangou Simulation Mahjong Dou 64 (Japan)</description>
+		<rom name="Jangou Simulation Mahjong Dou 64 (Japan).n64" />
+		<rom name="Jangou Simulation Mahjong Dou 64 (Japan).z64" size="8388608" crc="d1c1681e" md5="8ee01de7da2e9ad08d7ed913a5ee8632" sha1="f2f96b00709ac81ba8228bb38a8396824c29ce51" serial="NMAJ" />
+	</game>
+	<game name="Jeopardy! (USA)" id="0327">
+		<description>Jeopardy! (USA)</description>
+		<rom name="Jeopardy! (USA).n64" />
+		<rom name="Jeopardy! (USA).z64" size="4194304" crc="e739947c" md5="a45f7200537c0d928a88cbba2dfeb680" sha1="c5bcf3eff6bcdd9e7846ce5fd5db3095db9c58ed" serial="NJOE" />
+	</game>
+	<game name="Jeremy McGrath Supercross 2000 (Europe)" id="0328">
+		<description>Jeremy McGrath Supercross 2000 (Europe)</description>
+		<rom name="Jeremy McGrath Supercross 2000 (Europe).n64" />
+		<rom name="Jeremy McGrath Supercross 2000 (Europe).z64" size="16777216" crc="5bf42ec4" md5="4c5be1bfc1cccff501eba2a685226962" sha1="7804a688c9f7ed39d9c1a33c0339f4317d3918dc" sha256="0aae47e4a9ae696f7bbd6446fc3b620cb1add70ea9d79a2d26f9693c5df0dd88" status="verified" serial="NCOP" />
+	</game>
+	<game name="Jeremy McGrath Supercross 2000 (USA)" id="0329" cloneofid="0328">
+		<description>Jeremy McGrath Supercross 2000 (USA)</description>
+		<rom name="Jeremy McGrath Supercross 2000 (USA).n64" />
+		<rom name="Jeremy McGrath Supercross 2000 (USA).z64" size="16777216" crc="2a5c9a06" md5="8046a4b8abd4353b2ab9696106ccf8d2" sha1="278ad55333b7b75970812ecb9e691111ca3cfc46" serial="NCOE" />
+	</game>
+	<game name="Jeremy McGrath Supercross 2000 (USA) (Beta)" id="1089" cloneofid="0328">
+		<description>Jeremy McGrath Supercross 2000 (USA) (Beta)</description>
+		<rom name="Jeremy McGrath Supercross 2000 (USA) (Beta).n64" />
+		<rom name="Jeremy McGrath Supercross 2000 (USA) (Beta).z64" size="16777216" crc="1af1cc66" md5="ab2c4f7ee5b773f1e63362fe32223385" sha1="417320f3e80072dbe02164a3a1b747387b47c058" sha256="ecfff6f16825c5aabb939b2448f0c138ceebd379d1ca64e0a8ef81d394ff0a37" serial="NTUE" />
+	</game>
+	<game name="Jet Force Gemini (Europe) (En,Fr,De,Es)" id="0330">
+		<description>Jet Force Gemini (Europe) (En,Fr,De,Es)</description>
+		<rom name="Jet Force Gemini (Europe) (En,Fr,De,Es).n64" />
+		<rom name="Jet Force Gemini (Europe) (En,Fr,De,Es).z64" size="33554432" crc="cfbed88c" md5="baaf237e71aa7526c9b2f01c08b68a53" sha1="50651c4e0c46332f7f0b45870263f0a8b9a49602" sha256="0e8dce17d1df452787341e6f137d987048b6ba94459dfdfc1da815e332542d71" status="verified" serial="NJFP" />
+	</game>
+	<game name="Jet Force Gemini (USA)" id="0331" cloneofid="0330">
+		<description>Jet Force Gemini (USA)</description>
+		<rom name="Jet Force Gemini (USA).n64" />
+		<rom name="Jet Force Gemini (USA).z64" size="33554432" crc="6753d5a3" md5="772cc6eab2620d2d3cdc17bbc26c4f68" sha1="493ced9008dbe932d6e91179b68e8630cf23a023" sha256="159dde164c475976a3e527fbb20978431d4765f2c63019b3530c3aa8772595aa" status="verified" serial="NJFE" />
+	</game>
+	<game name="Jet Force Gemini (USA) (Demo) (Kiosk)" id="0332" cloneofid="0330">
+		<description>Jet Force Gemini (USA) (Demo) (Kiosk)</description>
+		<rom name="Jet Force Gemini (USA) (Demo) (Kiosk).n64" />
+		<rom name="Jet Force Gemini (USA) (Demo) (Kiosk).z64" size="33554432" crc="fa061b96" md5="5bbe9ade7171f2e1daaa7c48fad38728" sha1="f00f7c7fb085d0df57dcb649793aced5be4e8562" serial="NJDE" />
+	</game>
+	<game name="Jikkyou G1 Stable (Japan)" id="0333" cloneofid="0894">
+		<description>Jikkyou G1 Stable (Japan)</description>
+		<rom name="Jikkyou G1 Stable (Japan).n64" />
+		<rom name="Jikkyou G1 Stable (Japan).z64" size="16777216" crc="0a796c3e" md5="878d8a26fd02fdb08200464cb6f566ef" sha1="eb7b24bac29df362cab562662ae9a5de7d5fb0c3" serial="NGSJ" />
+	</game>
+	<game name="Jikkyou G1 Stable (Japan) (Rev 1)" id="0894">
+		<description>Jikkyou G1 Stable (Japan) (Rev 1)</description>
+		<rom name="Jikkyou G1 Stable (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou G1 Stable (Japan) (Rev 1).z64" size="16777216" crc="6fc0a31b" md5="482bdd39ad2574b943db780b12a9bdfb" sha1="ad0ebbb4b2ea4dffbfd99c77f9be530a479ef7e1" serial="NGSJ" />
+	</game>
+	<game name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan)" id="0334" cloneofid="0313">
+		<description>Jikkyou J.League 1999 - Perfect Striker 2 (Japan)</description>
+		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan).n64" />
+		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan).z64" size="16777216" crc="2ef647d3" md5="1fb40ee386b58feab6cf29ddb33bcccc" sha1="2967b60aa29954fc684fdf28a0e2c335759695fe" serial="NPSJ" />
+	</game>
+	<game name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)" id="0895" cloneofid="0313">
+		<description>Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)</description>
+		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1).z64" size="16777216" crc="f96c2be1" md5="d9f8b84fd6fd21f0b1d750062ac86efc" sha1="65a69b9e8a0c5c49e1badec27bf65c426ea0cc16" serial="NPSJ" />
+	</game>
+	<game name="Jikkyou J.League Perfect Striker (Japan)" id="0335">
+		<description>Jikkyou J.League Perfect Striker (Japan)</description>
+		<rom name="Jikkyou J.League Perfect Striker (Japan).n64" />
+		<rom name="Jikkyou J.League Perfect Striker (Japan).z64" size="8388608" crc="8ed60dea" md5="58153ac5c4030d1bfd3c15cf57fb02e7" sha1="e1185922648a6b9dec1c820f43a292e480e396cc" status="verified" serial="NJPJ" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan)" id="0342" cloneofid="0899">
+		<description>Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan).z64" size="16777216" crc="6a9e24d7" md5="7fc933a64884a382aa07605ea7204ff5" sha1="b24170ed95734dd12084ca3c82b678fabcbd4279" serial="NPEJ" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)" id="0899">
+		<description>Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1).z64" size="16777216" crc="bc7ef5c1" md5="f13d0803885b73b4a6b35eddd40b9253" sha1="8fc693bc19c362716cfbaa7d1ef513685bec99e0" serial="NPEJ" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 2000 (Japan)" id="0336" cloneofid="0337">
+		<description>Jikkyou Powerful Pro Yakyuu 2000 (Japan)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan).z64" size="16777216" crc="351cde48" md5="23409668a6e6c4ece7b5fb0b7d0e8f2c" sha1="365d6efa2665b816a5e0e2233c890ddcd524c05d" serial="NPAJ" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)" id="0337">
+		<description>Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1).z64" size="16777216" crc="753706ef" md5="b653c963ed8d3a749676810f07cfe4e5" sha1="2b9425be9c6f76eb6594d414299c24e19cf12992" serial="NPAJ" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan)" id="0338" cloneofid="0339">
+		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan).z64" size="12582912" crc="480b953e" md5="fda57f65eb159278223eb9d03267c27f" sha1="7e27a27bad4f98500d7a68ec43ab7bffe5de03e1" serial="NP4J" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)" id="0339">
+		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1).z64" size="12582912" crc="40e3ac61" md5="b454490eb44f0978f009fa41de8c478e" sha1="d11b2860925c3784cbd4ad163111414537c5378a" serial="NP4J" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30)" id="1057" cloneofid="0339">
+		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30).z64" size="16777216" crc="1b8b9a68" md5="ada39573b25804610d8fafaff741b088" sha1="c780866c263f5d9ae8f70bad558b0de6d5795115" sha256="ff573185ac868da487adc666beafb76966691b82e9b8ca3457d113e34d725fb9" serial="!none" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan)" id="0340" cloneofid="0884">
+		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan).z64" size="16777216" crc="feec34f6" md5="e9f989e09e3f1519aefe619889a4f710" sha1="f1bc8d2a6b03ffab7355c4e7b5fa1c393421e9f9" serial="NJ5J" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)" id="0884">
+		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2).z64" size="16777216" crc="c02fd9be" md5="68a27fbab060857c267a639931d2c3d6" sha1="a504c2978d8cfffccbb815cc00d96dc0b7bece3b" status="verified" serial="NJ5J" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1)" id="0896" cloneofid="0884">
+		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1).z64" size="16777216" crc="7994c2fe" md5="6ef19bf8d8d6196390745f1b858ac16a" sha1="a830e30c8272220c5481f294aa5cb5014df05499" serial="NJ5J" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan)" id="0341" cloneofid="0898">
+		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan).z64" size="16777216" crc="1e53a7ba" md5="060d0313e23b660180441fcc7d24d7db" sha1="02924d963d214102cb723b0e54c901968aa51a1f" serial="NP6J" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1)" id="0897" cloneofid="0898">
+		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1).z64" size="16777216" crc="7ab7ebf4" md5="23ee24faba0edfb04b5b0407e174496b" sha1="828002c3f34eb357458a9a9c4fa989ba82927fe9" serial="NP6J" />
+	</game>
+	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)" id="0898">
+		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)</description>
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2).z64" size="16777216" crc="fcc10356" md5="03bd8e5ca2b1b7d74398db4739979282" sha1="2763b83846165221c8b80bc4430f5b55779622e3" serial="NP6J" />
+	</game>
+	<game name="Jikkyou World Soccer - World Cup France '98 (Japan)" id="0343" cloneofid="0311">
+		<description>Jikkyou World Soccer - World Cup France '98 (Japan)</description>
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan).n64" />
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan).z64" size="16777216" crc="5c721850" md5="a05e7db2409deecca36e48e9d931cacb" sha1="bb1c7a8634ba6078843532264a8676f80d5b79fc" serial="NWSJ" />
+	</game>
+	<game name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1)" id="0344" cloneofid="0311">
+		<description>Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1)</description>
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1).z64" size="16777216" crc="68dbcc04" md5="538b54c2aaea73faa3a021d42a3225be" sha1="e9ed8a0ed5b7b20b80f0e140cc4b7261a89143bb" serial="NWSJ" />
+	</game>
+	<game name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)" id="0345" cloneofid="0311">
+		<description>Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)</description>
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2).n64" />
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2).z64" size="16777216" crc="f63f9a5e" md5="2e5fd9303138e8f558bf67bb9e799960" sha1="8ea26072dd7da07c567ebca7c25071739ec563fb" serial="NWSJ" />
+	</game>
+	<game name="Jikkyou World Soccer 3 (Japan)" id="0346" cloneofid="0316">
+		<description>Jikkyou World Soccer 3 (Japan)</description>
+		<rom name="Jikkyou World Soccer 3 (Japan).n64" />
+		<rom name="Jikkyou World Soccer 3 (Japan).z64" size="8388608" crc="3ba9e644" md5="ef0f425689586850a6f5796124b0c85b" sha1="a06528ce7a1c007f3e8dfae199b6e65b3dbc034d" serial="NJ3J" />
+	</game>
+	<game name="Jikuu Senshi Turok (Japan)" id="0347" cloneofid="0777">
+		<description>Jikuu Senshi Turok (Japan)</description>
+		<rom name="Jikuu Senshi Turok (Japan).n64" />
+		<rom name="Jikuu Senshi Turok (Japan).z64" size="8388608" crc="e6bd65d5" md5="7b261247150c431de55ab371e8b46ea8" sha1="726baefd703eb2ca72ec22b4aab8844662f32845" serial="NTUJ" />
+	</game>
+	<game name="Jinsei Game 64 (Japan)" id="0348">
+		<description>Jinsei Game 64 (Japan)</description>
+		<rom name="Jinsei Game 64 (Japan).n64" />
+		<rom name="Jinsei Game 64 (Japan).z64" size="16777216" crc="67a1a22c" md5="68230d510015ff6817ef898c0b8b636c" sha1="8759a3fc272c3f6259bbe2433eb34411705d8634" serial="NJGJ" />
+	</game>
+	<game name="John Romero's Daikatana (Europe) (En,Fr,De)" id="0349">
+		<description>John Romero's Daikatana (Europe) (En,Fr,De)</description>
+		<rom name="John Romero's Daikatana (Europe) (En,Fr,De).n64" />
+		<rom name="John Romero's Daikatana (Europe) (En,Fr,De).z64" size="16777216" crc="f88ac3ce" md5="7ab29c6ad2d8f4007d8213eb3411e0bd" sha1="0278c3f9b2780890c4c2a3ee8a10c550a1eda346" sha256="3bbf87a2fb2479996cd544758b38ac09861b77235fb8f35b31150e481966653b" status="verified" serial="NDWP" />
+	</game>
+	<game name="John Romero's Daikatana (Japan)" id="0350" cloneofid="0349">
+		<description>John Romero's Daikatana (Japan)</description>
+		<rom name="John Romero's Daikatana (Japan).n64" />
+		<rom name="John Romero's Daikatana (Japan).z64" size="16777216" crc="44b80fd7" md5="57d31ea7121dd5a05b547225efa5cfd7" sha1="4ed2ec28997865e301c5693639c2ec717c79a5bc" sha256="d733debf3a38c643127d58e84b086f44948bd630bf6449030db8cea1ca51abf8" status="verified" serial="NDWJ" />
+	</game>
+	<game name="John Romero's Daikatana (USA)" id="0351" cloneofid="0349">
+		<description>John Romero's Daikatana (USA)</description>
+		<rom name="John Romero's Daikatana (USA).n64" />
+		<rom name="John Romero's Daikatana (USA).z64" size="16777216" crc="494950c6" md5="5b4c268422469f50b94779e655f2b798" sha1="08709013d512f3a2bed65b98ab451ec8b839d3b4" serial="NDWE" />
+	</game>
+	<game name="Kakutou Denshou - F-Cup Maniax (Japan)" id="0352" cloneofid="0235">
+		<description>Kakutou Denshou - F-Cup Maniax (Japan)</description>
+		<rom name="Kakutou Denshou - F-Cup Maniax (Japan).n64" />
+		<rom name="Kakutou Denshou - F-Cup Maniax (Japan).z64" size="16777216" crc="db40a155" md5="dff0efe2b35fcde506d21b0c0bd373a5" sha1="f88f541d5913c99a9eac5ca4162e65b8a3828725" serial="NFYJ" />
+	</game>
+	<game name="Ken Griffey Jr.'s Slugfest (USA)" id="0353">
+		<description>Ken Griffey Jr.'s Slugfest (USA)</description>
+		<rom name="Ken Griffey Jr.'s Slugfest (USA).n64" />
+		<rom name="Ken Griffey Jr.'s Slugfest (USA).z64" size="16777216" crc="12d8f3e9" md5="eec0fab75af59e9c23e6de2132de89ff" sha1="ec33cd4d44bba163f89e435c2aefbf7313d8cece" serial="NKJE" />
+	</game>
+	<game name="Killer Instinct Gold (Europe)" id="0354">
+		<description>Killer Instinct Gold (Europe)</description>
+		<rom name="Killer Instinct Gold (Europe).n64" />
+		<rom name="Killer Instinct Gold (Europe).z64" size="12582912" crc="5d0ee5d2" md5="c93d92f10a1a97d2ba87386be7d178fd" sha1="e0ed97c7310b012a5cf81c6f6678a75b8601b47e" sha256="a77af932a359c4cd9f17f38e22ebccb3e11ae3dfd58da2780fbdec780809a4c0" status="verified" serial="NKIP" />
+	</game>
+	<game name="Killer Instinct Gold (USA)" id="0355" cloneofid="0354">
+		<description>Killer Instinct Gold (USA)</description>
+		<rom name="Killer Instinct Gold (USA).n64" />
+		<rom name="Killer Instinct Gold (USA).z64" size="12582912" crc="31c76be7" md5="8e33ad20c31feb61d7230fad28846c5c" sha1="ba52e91b44450c548467044b26951353dc491e04" sha256="660bc99b0023b731348535d160d894700fa4bab5b750dff70bd3ce79596f5793" status="verified" serial="NKIE" />
+	</game>
+	<game name="Killer Instinct Gold (USA) (Rev 1)" id="0356" cloneofid="0354">
+		<description>Killer Instinct Gold (USA) (Rev 1)</description>
+		<rom name="Killer Instinct Gold (USA) (Rev 1).n64" />
+		<rom name="Killer Instinct Gold (USA) (Rev 1).z64" size="12582912" crc="49ef8f2b" md5="4c9b419dc583c0df4ab908adf83bfc65" sha1="bcc599ed0f0b8b75a8068269958a2230ec7cb34c" serial="NKIE" />
+	</game>
+	<game name="Killer Instinct Gold (USA) (Rev 2)" id="0357" cloneofid="0354">
+		<description>Killer Instinct Gold (USA) (Rev 2)</description>
+		<rom name="Killer Instinct Gold (USA) (Rev 2).n64" />
+		<rom name="Killer Instinct Gold (USA) (Rev 2).z64" size="12582912" crc="0b5b5df8" md5="dd0a82fcc10397afb37f12bb7f94e67a" sha1="aaeb492b1e538af65a3544a97240675ef438a04f" sha256="f80cae340efadf5725cd0f75441addb9186be9860267595be2b4a2d317b05f8a" serial="NKIE" />
+	</game>
+	<game name="King Hill 64 - Extreme Snowboarding (Japan)" id="0358" cloneofid="0796">
+		<description>King Hill 64 - Extreme Snowboarding (Japan)</description>
+		<rom name="King Hill 64 - Extreme Snowboarding (Japan).n64" />
+		<rom name="King Hill 64 - Extreme Snowboarding (Japan).z64" size="12582912" crc="f120cc52" md5="cca4e87ec206b5b65aeab9531c0f275b" sha1="10924ab3c8909b18dae64fede304af2a08d7ffe1" serial="NSBJ" />
+	</game>
+	<game name="Kiratto Kaiketsu! 64 Tanteidan (Japan)" id="0359">
+		<description>Kiratto Kaiketsu! 64 Tanteidan (Japan)</description>
+		<rom name="Kiratto Kaiketsu! 64 Tanteidan (Japan).n64" />
+		<rom name="Kiratto Kaiketsu! 64 Tanteidan (Japan).z64" size="12582912" crc="7fdc3784" md5="32257bfffd9b2d680f582e148e9b0611" sha1="5340930ee4a26d8897c8734ee812e769c162be0f" sha256="a0b6a57a5b966870259f163b8e617649f15278c864d6b16ad3c551198684e07d" status="verified" serial="N64J" />
+	</game>
+	<game name="Kirby 64 - The Crystal Shards (Europe)" id="0360">
+		<description>Kirby 64 - The Crystal Shards (Europe)</description>
+		<rom name="Kirby 64 - The Crystal Shards (Europe).n64" />
+		<rom name="Kirby 64 - The Crystal Shards (Europe).z64" size="33554432" crc="5b8b89ef" md5="a44b7a612964a6d6139d0426e569d9c9" sha1="52e8382252ec9b629662153eae6f87ae3675b700" sha256="391a33a74dedffb870aad78c19d1d8c443f4b6963c582066ee77b14b343ba520" status="verified" serial="NK4P" />
+	</game>
+	<game name="Kirby 64 - The Crystal Shards (USA)" id="0361" cloneofid="0360">
+		<description>Kirby 64 - The Crystal Shards (USA)</description>
+		<rom name="Kirby 64 - The Crystal Shards (USA).n64" />
+		<rom name="Kirby 64 - The Crystal Shards (USA).z64" size="33554432" crc="20a1c120" md5="d33e4254336383a17ff4728360562ada" sha1="6cea2d46b929a3bb347b060a77fccc83526fb855" sha256="2f579751d7ad2824dfd8a6141570306bfaeda1cff40139ba231c30b8591d681c" status="verified" serial="NK4E" />
+	</game>
+	<game name="Kirby 64 - The Crystal Shards (USA) (LodgeNet)" id="1143" cloneofid="0360">
+		<category>Games</category>
+		<rom name="Kirby 64 - The Crystal Shards (USA) (LodgeNet).n64" />
+		<description>Kirby 64 - The Crystal Shards (USA) (LodgeNet)</description>
+		<rom name="Kirby 64 - The Crystal Shards (USA) (LodgeNet).i64" size="64" crc="5a049d23" md5="73a0681d3ec74b8edd919c6c204d8054" sha1="265413c4a08f7aead7ca7bd746f3897c74eb0029" />
+		<rom name="Kirby 64 - The Crystal Shards (USA) (LodgeNet).z64" size="33554432" crc="70ba28e4" md5="79748edc4fd32e263c5a18d73b519736" sha1="f615c6e10d1044c944bd4965c5471bb3f1cf5c5b" />
+	</game>
+	<game name="Knife Edge - Nose Gunner (Europe)" id="0362">
+		<description>Knife Edge - Nose Gunner (Europe)</description>
+		<rom name="Knife Edge - Nose Gunner (Europe).n64" />
+		<rom name="Knife Edge - Nose Gunner (Europe).z64" size="8388608" crc="b77783be" md5="d31a94a5685a21a932cc886d64cc9b21" sha1="5359c747e91c9119fde3a7920333a9d0c04d251d" sha256="07578b1e624fce4ad366f1fc5c446e4516592da3a1f072730656ae0c5cdfd103" status="verified" serial="NKEP" />
+	</game>
+	<game name="Knife Edge - Nose Gunner (Japan)" id="0363" cloneofid="0362">
+		<description>Knife Edge - Nose Gunner (Japan)</description>
+		<rom name="Knife Edge - Nose Gunner (Japan).n64" />
+		<rom name="Knife Edge - Nose Gunner (Japan).z64" size="8388608" crc="3bc93017" md5="436ba873e9466aab237d9429348a5f70" sha1="b3242226237a401436d9d7a8d533296333e64240" serial="NKEJ" />
+	</game>
+	<game name="Knife Edge - Nose Gunner (USA)" id="0364" cloneofid="0362">
+		<description>Knife Edge - Nose Gunner (USA)</description>
+		<rom name="Knife Edge - Nose Gunner (USA).n64" />
+		<rom name="Knife Edge - Nose Gunner (USA).z64" size="8388608" crc="255ee1dd" md5="8043d829fcd4f8f72dd81e5c6dde916f" sha1="b247167e37e7f62924be6b0d2362a091fd2352ac" serial="NKEE" />
+	</game>
+	<game name="Knockout Kings 2000 (Europe)" id="0365">
+		<description>Knockout Kings 2000 (Europe)</description>
+		<rom name="Knockout Kings 2000 (Europe).n64" />
+		<rom name="Knockout Kings 2000 (Europe).z64" size="16777216" crc="58ce7d80" md5="e95d73ff55fbb63e79aa9eab14608584" sha1="181d220efaa3e06ac5a7baac4b6a351b762ec384" sha256="9b01ba8aae55151d3445bab551150c884959af7a4897566946b43f7bd6ae394f" status="verified" serial="NKKP" />
+	</game>
+	<game name="Knockout Kings 2000 (USA)" id="0366" cloneofid="0365">
+		<description>Knockout Kings 2000 (USA)</description>
+		<rom name="Knockout Kings 2000 (USA).n64" />
+		<rom name="Knockout Kings 2000 (USA).z64" size="16777216" crc="074690d6" md5="008b473841ce4d9ac050d55f99b4b5d4" sha1="ae7229676da9acb39becb03246969693585b7728" sha256="e34165bdcfcf6dff6322ec6faf23f59ce38d43417573e6eb41233ebf7309e293" serial="NKKE" />
+	</game>
+	<game name="Kobe Bryant in NBA Courtside (Europe)" id="0367">
+		<description>Kobe Bryant in NBA Courtside (Europe)</description>
+		<rom name="Kobe Bryant in NBA Courtside (Europe).n64" />
+		<rom name="Kobe Bryant in NBA Courtside (Europe).z64" size="12582912" crc="1355a826" md5="c6b01c020fdfd2e5c037c5a330b161ad" sha1="6390dc1cd4600ca57069d92f39f108a4cc1b62f1" sha256="260f1a046ba71e42555bdb8a698a437d4a42acce09c10f1c03731c383f890381" status="verified" serial="NNBP" />
+	</game>
+	<game name="Kobe Bryant in NBA Courtside (USA)" id="0368" cloneofid="0367">
+		<description>Kobe Bryant in NBA Courtside (USA)</description>
+		<rom name="Kobe Bryant in NBA Courtside (USA).n64" />
+		<rom name="Kobe Bryant in NBA Courtside (USA).z64" size="12582912" crc="86360bfb" md5="d37c79e4e4eabcb5dc6a07bd76688223" sha1="49346b3124750c14dddf56b9bb2fe38b618f28f2" sha256="7b4970b3e94877b347722bb919ec5b7855bc819a91090388ffd5b62697229a26" serial="NNBE" />
+	</game>
+	<game name="Last Legion UX (Japan)" id="0369">
+		<description>Last Legion UX (Japan)</description>
+		<rom name="Last Legion UX (Japan).n64" />
+		<rom name="Last Legion UX (Japan).z64" size="12582912" crc="9db99881" md5="eb11fc0797ae1107201c4601fee5471a" sha1="dfdf852d0939466ad1f1627f4de29b7288a77589" serial="NLLJ" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)" id="0370" cloneofid="0371">
+		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).z64" size="33554432" crc="9ead1608" md5="13fab67e603b002ceaf0eea84130e973" sha1="c04599cdafee1c84a7af9a71df68f139179ada84" sha256="d64d412d595ca32a248320da56772291b6bac7bcd942752f357c4bba367685e6" status="verified" serial="NZSP" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)" id="0371">
+		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1).z64" size="33554432" crc="e2e6823d" md5="beccfded43a2f159d03555027462a950" sha1="bb4e4757d10727c7584c59c1f2e5f44196e9c293" sha256="f760c811e02b4951873a5919b3a1c84fda68e5042aa5d9f69ee8368ac72b0297" status="verified" serial="NZSP" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (USA)" id="0372" cloneofid="0371">
+		<description>Legend of Zelda, The - Majora's Mask (USA)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (USA).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (USA).z64" size="33554432" crc="b428d8a7" md5="2a0a8acb61538235bc1094d297fb6556" sha1="d6133ace5afaa0882cf214cf88daba39e266c078" sha256="efb1365b3ae362604514c0f9a1a2d11f5dc8688ba5be660a37debf5e3be43f2b" status="verified" serial="NZSE" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk)" id="0373" cloneofid="0371">
+		<description>Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk).z64" size="33554432" crc="dcc110a0" md5="8f281800fba5ddcb1d2b377731fc0215" sha1="2f0744f2422b0421697a74b305cb1ef27041ab11" serial="NDLE" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug)" id="0911" cloneofid="0371">
+		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug).z64" size="67108864" crc="04ea55ea" md5="02f963fa8f95e3a7f0b6c13d81999ba9" sha1="55541662a192c66e34a011d4bf6f4a0ec69899ae" sha256="d56ab6b0e5351e60e57a625388e05b06abf61f74d6a133f714c3611436d15b57" serial="NZSP" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (USA) (GameCube)" id="0928" cloneofid="0371">
+		<description>Legend of Zelda, The - Majora's Mask (USA) (GameCube)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (GameCube).z64" size="33554432" crc="b008458f" md5="ac0751dbc23ab2ec0c3144203aca0003" sha1="9743aa026e9269b339eb0e3044cd5830a440c1fd" sha256="e951a0cd34c137267a6434c62b97947e62486212aab5dd412e17131428c6e5d5" status="verified" serial="NZSE" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube)" id="0933" cloneofid="0371">
+		<description>Legend of Zelda, The - Majora's Mask (Europe) (GameCube)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube).z64" size="33554432" crc="12836e19" md5="dbe9af0db46256e42b5c67902b696549" sha1="a849a65e56d57d4dd98b550524150f898df90a9f" serial="NZSP" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console)" id="0992" cloneofid="0371">
+		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console).z64" size="33554432" crc="a83abf72" md5="609b47b79da21f3df9b31d06c95c09a1" sha1="c487db55c2c3a97ccd39ded13ef9fd9121dae729" serial="NZSP" />
+	</game>
+	<game name="Legend of Zelda, The - Majora's Mask (USA) (LodgeNet)" id="1144" cloneofid="0371">
+		<category>Games</category>
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (LodgeNet).n64" />
+		<description>Legend of Zelda, The - Majora's Mask (USA) (LodgeNet)</description>
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (LodgeNet).i64" size="64" crc="8d23977d" md5="10d4e6f1a66236bf2827f681628a3420" sha1="f882460a888b8db76e8b163fd508d89e7b2e9e00" />
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (LodgeNet).z64" size="33554432" crc="e4b47e08" md5="f6738180b95d46f6355855d1da8dbb0b" sha1="ecabc86f0de743c02ba3fa0c83ab163538b00be9" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Beta)" id="1048" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (USA) (Beta)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Beta).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Beta).z64" size="33554432" crc="6c348aa8" md5="21f7b4a4ff463464bfc23498c1ab9da1" sha1="70537a3144c8813b115252c40065c117cb139dcd" sha256="68bbdd74169510d128e193b93047cad9197e689c33dbbd52ba7414f5b2ffb1ca" serial="CZLE" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube)" id="1062" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube).z64" size="67108864" crc="c188acda" md5="ab1ca59d0039e3b34d82db650b54d7b9" sha1="da19ca4aac723c155d55ae371107b8462044e350" sha256="f2ed79515542faecfdb054cc5228b3f755bfa6c5fd4df52811240cbaaaa979e1" serial="NZLP" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (USA) (LodgeNet)" id="1134" cloneofid="0375">
+		<category>Games</category>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (LodgeNet).n64" />
+		<description>Legend of Zelda, The - Ocarina of Time (USA) (LodgeNet)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (LodgeNet).i64" size="64" crc="0eb0198c" md5="bc24ac3f3a3109139ddbe71b3b482050" sha1="45185a1938db659ee6760117cd4f742aac5e18bf" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (LodgeNet).z64" size="33554432" crc="c4d2ac1d" md5="74072c944a82c34190f412ee96a51b13" sha1="86ff85565e0e4f78d56f50e73df51ba29d36738a" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)" id="0374" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).z64" size="33554432" crc="946fd0f7" md5="e040de91a74b61e3201db0e2323f768a" sha1="328a1f1beba30ce5e178f031662019eb32c5f3b5" sha256="f29d21e10f77c44d933f07ff6d0f593d4267925f1e6834ce55e239b6037549e7" status="verified" serial="NZLP" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)" id="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1).z64" size="33554432" crc="a108f6e3" md5="d714580dd74c2c033f5e1b6dc0aeac77" sha1="cfbb98d392e4a9d39da8285d10cbef3974c2f012" sha256="74f9266fd7fa23cc700b5b46a21fbe99cdc6ea10438bc4b48eeb625763b8611c" status="verified" serial="NZLP" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (USA)" id="0376" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (USA)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA).z64" size="33554432" crc="cd16c529" md5="5bd1fe107bf8106b2ab6650abecd54d6" sha1="ad69c91157f6705e8ab06c79fe08aad47bb57ba7" sha256="c916ab315fbe82a22169bff13d6b866e9fddc907461eb6b0a227b82acdf5b506" status="verified" serial="CZLE" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1)" id="0377" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (USA) (Rev 1)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1).z64" size="33554432" crc="3fd2151e" md5="721fdcc6f5f34be55c43a807f2a16af4" sha1="d3ecb253776cd847a5aa63d859d8c89a2f37b364" status="verified" serial="CZLE" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)" id="0378" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2).z64" size="33554432" crc="32120c23" md5="57a9719ad547c516342e1a15d5c28c3d" sha1="41b3bdc48d98c48529219919015a1af22f5057c2" sha256="49acd3885f13b0730119b78fb970911cc8aba614fe383368015c21565983368d" status="verified" serial="CZLE" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube)" id="0926" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (USA) (GameCube)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube).z64" size="33554432" crc="346de3ae" md5="cd09029edcfb7c097ac01986a0f83d3f" sha1="b82710ba2bd3b4c6ee8aa1a7e9acf787dfc72e9b" sha256="00712c4951c3823978898b6e1b7b084ab9b7a1d09ad3189307ca8556ef53c761" status="verified" serial="CZLE" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube)" id="0929" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (Europe) (GameCube)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube).z64" size="33554432" crc="3fbd519f" md5="2c27b4e000e85fd78dbca551f1b1c965" sha1="0227d7c0074f2d0ac935631990da8ec5914597b4" serial="NZLP" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-21) (GameCube) (Debug)" id="1038" cloneofid="0375">
+		<description>Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-21) (GameCube) (Debug)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-21) (GameCube) (Debug).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-21) (GameCube) (Debug).z64" size="67108864" crc="5d1b2996" md5="3c10b67a76616ae2c162def7528724cf" sha1="cee6bc3c2a634b41728f2af8da54d9bf8cc14099" sha256="94bdeb4ab906db112078a902f4477e9712c4fe803c4efb98c7b97c3f950305ab" serial="NZLP" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube) (Debug)" id="0379" cloneofid="0931">
+		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube) (Debug)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube) (Debug).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube) (Debug).z64" size="67108864" crc="a1d34e08" md5="09ae099051bdf6377d482d1944171dfc" sha1="cfecfdc58d650e71a200c81f033de4e6d617a9f6" sha256="dd30b6f31f764e024d5d79d6bf4c27f077a2ff917ae7d5e73f79e8967f64144e" serial="NZLP" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)" id="0927" cloneofid="0931">
+		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube).z64" size="33554432" crc="c744c4db" md5="da35577fe54579f6a266931cc75f512d" sha1="8b5d13aac69bfbf989861cfdc50b1d840945fc1d" sha256="2a8d9dff460757a0f506a43db9b929510777ef690df620fb4364069a653372a8" serial="CZLE" />
+	</game>
+	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (En,Fr,De) (GameCube)" id="0931">
+		<category>Games</category>
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (En,Fr,De) (GameCube).n64" />
+		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (En,Fr,De) (GameCube)</description>
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (En,Fr,De) (GameCube).z64" size="33554432" crc="832d6449" md5="1618403427e4344a57833043db5ce3c3" sha1="f46239439f59a2a594ef83cf68ef65043b1bffe2" serial="NZLP" />
+	</game>
+	<game name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" id="0380">
+		<description>LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)</description>
+		<rom name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" />
+		<rom name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).z64" size="16777216" crc="c7d9b21c" md5="6310c7173385ed2b06020f3b90158e9e" sha1="6e9c4b097628f0147e9e79393dba6d7b4e59986f" sha256="4709368b2f11fb724e91eaefe3aebc97b04e9c5d664f476d18cb5e48352c4af3" status="verified" serial="NLGP" />
+	</game>
+	<game name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" id="0381" cloneofid="0380">
+		<description>LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)</description>
+		<rom name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" />
+		<rom name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).z64" size="16777216" crc="4d1e1897" md5="26b5eaa13dc5b5e35307fe8c0cf5b6ba" sha1="8decc41869926e20da2eb3da526e6395aa33cece" sha256="dbbfdfde4abf4b0bec60470fe8ed412f2b0a360b9237066b952ef8d53f74c0ce" status="verified" serial="NLGE" />
+	</game>
+	<game name="Let's Smash (Japan)" id="0382" cloneofid="0117">
+		<description>Let's Smash (Japan)</description>
+		<rom name="Let's Smash (Japan).n64" />
+		<rom name="Let's Smash (Japan).z64" size="12582912" crc="455a1770" md5="aee5016e6d60d12ad768e9f6d10adde8" sha1="6fda28a79cec30b6c52c3dbc96b513da16bfa4d0" serial="NTSJ" />
+	</game>
+	<game name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)" id="0383">
+		<description>Lode Runner 3-D (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="7148251d" md5="e62f4fdcc82c244ba9709e40756d9b62" sha1="3b198c0117da808b25fbc4e543d282228bb4780a" sha256="9a0bcf401a512c7d0fbc5686f91599e7d6f61c627c848ba841b3f774181d4292" status="verified" serial="NLRP" />
+	</game>
+	<game name="Lode Runner 3-D (Japan)" id="0384" cloneofid="0383">
+		<description>Lode Runner 3-D (Japan)</description>
+		<rom name="Lode Runner 3-D (Japan).n64" />
+		<rom name="Lode Runner 3-D (Japan).z64" size="8388608" crc="1d4fb466" md5="d2bd8dd8c3be1e8f0b8ae49206dbd7e5" sha1="a115c19e1dea438861437a326124c0e7a482de3b" serial="NLRJ" />
+	</game>
+	<game name="Lode Runner 3-D (USA)" id="0385" cloneofid="0383">
+		<description>Lode Runner 3-D (USA)</description>
+		<rom name="Lode Runner 3-D (USA).n64" />
+		<rom name="Lode Runner 3-D (USA).z64" size="8388608" crc="4ea07453" md5="d038813541589f0b3f1f900f4fd22c9b" sha1="d3a13c0cfdff835fdf87d5dc7c5149fba564877f" serial="NLRE" />
+	</game>
+	<game name="Lylat Wars (Australia) (En,Fr,De)" id="0386" cloneofid="0387">
+		<description>Lylat Wars (Australia) (En,Fr,De)</description>
+		<rom name="Lylat Wars (Australia) (En,Fr,De).n64" />
+		<rom name="Lylat Wars (Australia) (En,Fr,De).z64" size="12582912" crc="9a3425da" md5="7a99628edf0a6602d0c408f31b701435" sha1="47a8ccc11450f9044ca2292b9fc3c58949b9caac" serial="NFXU" />
+	</game>
+	<game name="Lylatwars (Europe) (En,Fr,De)" id="0387">
+		<description>Lylatwars (Europe) (En,Fr,De)</description>
+		<rom name="Lylatwars (Europe) (En,Fr,De).n64" />
+		<rom name="Lylatwars (Europe) (En,Fr,De).z64" size="12582912" crc="50a9c0b1" md5="884ccca35cbeedb8ed288326f9662100" sha1="05b307b8804f992af1a1e2fbafbd588501fdf799" sha256="6604c219c2835446522d03a7a3f3634fb00a27703fd6b7f318d98f003806e3a4" status="verified" serial="NFXP" />
+	</game>
+	<game name="Mace - The Dark Age (Europe)" id="0388">
+		<description>Mace - The Dark Age (Europe)</description>
+		<rom name="Mace - The Dark Age (Europe).n64" />
+		<rom name="Mace - The Dark Age (Europe).z64" size="12582912" crc="57ddede1" md5="523883a766c662e8377cd256755b27b4" sha1="19fc1fe13a3c50a5d03d44d2e93440967c7f3618" sha256="73762463297ce7b9c82d8d8630b0d523d93ce9753630357dcda9341443ba26d0" status="verified" serial="NMEP" />
+	</game>
+	<game name="Mace - The Dark Age (USA)" id="0389" cloneofid="0388">
+		<description>Mace - The Dark Age (USA)</description>
+		<rom name="Mace - The Dark Age (USA).n64" />
+		<rom name="Mace - The Dark Age (USA).z64" size="12582912" crc="d2a363a6" md5="39a2bca1c17cd4cf1a9f3ae2b725b5c6" sha1="05d82a2c73ac536180b68137dbb9972a9e8e883e" serial="NMEE" />
+	</game>
+	<game name="Mace - The Dark Age (USA) (Beta)" id="1063" cloneofid="0388">
+		<description>Mace - The Dark Age (USA) (Beta)</description>
+		<rom name="Mace - The Dark Age (USA) (Beta).n64" />
+		<rom name="Mace - The Dark Age (USA) (Beta).z64" size="13144800" crc="2b23212f" md5="3eb81ab11b8c58305a64ce06817d0538" sha1="c515895faaa5ebf0d043d285aaf51046b5e28b8f" sha256="7be225fb574fcccd1a7f46f0a2c2e0e44709e555a0ec1badb38385246dfaf3b7" serial="!none" />
+	</game>
+	<game name="Madden Football 64 (Europe)" id="0390">
+		<description>Madden Football 64 (Europe)</description>
+		<rom name="Madden Football 64 (Europe).n64" />
+		<rom name="Madden Football 64 (Europe).z64" size="12582912" crc="fab3e50d" md5="67c96076459eb5f71733f39d7fcc76a3" sha1="acf22b715b11609f42df24abac143bc0221d12f4" sha256="7eaef372a0e0f00a8e0150150686d1c72a87c5232a9ea3b374424275efdad059" status="verified" serial="N8MP" />
+	</game>
+	<game name="Madden Football 64 (USA)" id="0391" cloneofid="0390">
+		<description>Madden Football 64 (USA)</description>
+		<rom name="Madden Football 64 (USA).n64" />
+		<rom name="Madden Football 64 (USA).z64" size="12582912" crc="42e5fafa" md5="903b912ce88626900221731224e9dbe8" sha1="b0de34b759f18ad86d39a4c68c9840d35ce25809" sha256="39f25dad3af4782a909bf58d7127acae700ea7c6f17c48d39ab76fe331735d6f" status="verified" serial="N8ME" />
+	</game>
+	<game name="Madden NFL 2000 (USA)" id="0392">
+		<description>Madden NFL 2000 (USA)</description>
+		<rom name="Madden NFL 2000 (USA).n64" />
+		<rom name="Madden NFL 2000 (USA).z64" size="12582912" crc="ef5f997b" md5="955d19e26b4ba7cc941f86a54a0fc13d" sha1="ec01de96960ea23a9ee997f4456c5c8ee7baf7e4" serial="NMDE" />
+	</game>
+	<game name="Madden NFL 2001 (USA)" id="0393">
+		<description>Madden NFL 2001 (USA)</description>
+		<rom name="Madden NFL 2001 (USA).n64" />
+		<rom name="Madden NFL 2001 (USA).z64" size="12582912" crc="245eaee8" md5="441fa65faa5c12339f89a0bb7db43c8f" sha1="93f5ba646098e1aa45ecec6312604a0932edd24b" serial="NFLE" />
+	</game>
+	<game name="Madden NFL 2002 (USA)" id="0394">
+		<description>Madden NFL 2002 (USA)</description>
+		<rom name="Madden NFL 2002 (USA).n64" />
+		<rom name="Madden NFL 2002 (USA).z64" size="12582912" crc="f573f107" md5="ad0f2ec565d7575fb37512bc8df8a092" sha1="de51147a238158adc059d0cc75fd39bbb08dcfc6" serial="N2ME" />
+	</game>
+	<game name="Madden NFL 99 (Europe)" id="0395">
+		<description>Madden NFL 99 (Europe)</description>
+		<rom name="Madden NFL 99 (Europe).n64" />
+		<rom name="Madden NFL 99 (Europe).z64" size="12582912" crc="d0929942" md5="e7bf80861a0ab2a788959463d953b5d5" sha1="7c55ba6741dcf96208432507b8191b3c15f666df" sha256="0614ccd5bbe6fa5b40f899ca000505390bf49eb6a13f6c1b053ba827c84309b6" status="verified" serial="N9MP" />
+	</game>
+	<game name="Madden NFL 99 (USA)" id="0396" cloneofid="0395">
+		<description>Madden NFL 99 (USA)</description>
+		<rom name="Madden NFL 99 (USA).n64" />
+		<rom name="Madden NFL 99 (USA).z64" size="12582912" crc="2eb64fc2" md5="507ceab72ef2a1bf145bf190f5ce1c80" sha1="2e8595c6ea0267a0344c0e203b4b08f00a42b13a" serial="N9ME" />
+	</game>
+	<game name="Madden NFL 99 (USA) (1998-08-05) (Beta)" id="1028" cloneofid="0395">
+		<description>Madden NFL 99 (USA) (1998-08-05) (Beta)</description>
+		<rom name="Madden NFL 99 (USA) (1998-08-05) (Beta).n64" />
+		<rom name="Madden NFL 99 (USA) (1998-08-05) (Beta).z64" size="16777216" crc="033a2ca6" md5="5f3d42d5f96191f3ce50d70e0e42127a" sha1="80236fc4ce2bb95de513f3b2be74acec9da4804c" serial="N9ME" />
+	</game>
+	<game name="Madden NFL 99 (USA) (Rev 1)" id="1025" cloneofid="0395">
+		<description>Madden NFL 99 (USA) (Rev 1)</description>
+		<rom name="Madden NFL 99 (USA) (Rev 1).n64" />
+		<rom name="Madden NFL 99 (USA) (Rev 1).z64" size="12582912" crc="56769a44" md5="5ad80a8ef44dee1fdc456d66104165b4" sha1="68c0c53489b790568acb1d863b74b89975db4a62" serial="N9ME" />
+	</game>
+	<game name="Magical Tetris Challenge (Europe)" id="0397">
+		<description>Magical Tetris Challenge (Europe)</description>
+		<rom name="Magical Tetris Challenge (Europe).n64" />
+		<rom name="Magical Tetris Challenge (Europe).z64" size="16777216" crc="af3b099e" md5="20e51b27e8098a9d101b44689014c281" sha1="ecc73f8a0a530ee42a56b46611da6f74b728fe7d" serial="NMTP" />
+	</game>
+	<game name="Magical Tetris Challenge (Germany)" id="0398" cloneofid="0397">
 		<description>Magical Tetris Challenge (Germany)</description>
 		<rom name="Magical Tetris Challenge (Germany).n64" />
-		<release name="Magical Tetris Challenge (Germany)" region="GER" />
-		<rom name="Magical Tetris Challenge (Germany).z64" size="16777216" crc="377f18e9" md5="e0992a90191be4f1b2ba02258599334e" sha1="ace81319209d50d074418934554cbfb261d27288" />
+		<rom name="Magical Tetris Challenge (Germany).z64" size="16777216" crc="377f18e9" md5="e0992a90191be4f1b2ba02258599334e" sha1="ace81319209d50d074418934554cbfb261d27288" serial="NMTD" />
 	</game>
-	<game name="Magical Tetris Challenge (USA)" cloneof="Magical Tetris Challenge (Europe)">
+	<game name="Magical Tetris Challenge (USA)" id="0399" cloneofid="0397">
 		<description>Magical Tetris Challenge (USA)</description>
 		<rom name="Magical Tetris Challenge (USA).n64" />
-		<release name="Magical Tetris Challenge (USA)" region="USA" />
-		<rom name="Magical Tetris Challenge (USA).z64" size="16777216" crc="22fe979c" md5="79fcc98002d1f4c79deaf55784222df8" sha1="ca3fbd17406031a88e04bb79959d851550b641d0" />
+		<rom name="Magical Tetris Challenge (USA).z64" size="16777216" crc="22fe979c" md5="79fcc98002d1f4c79deaf55784222df8" sha1="ca3fbd17406031a88e04bb79959d851550b641d0" serial="NMTE" />
 	</game>
-	<game name="Magical Tetris Challenge featuring Mickey (Japan)" cloneof="Magical Tetris Challenge (Europe)">
+	<game name="Magical Tetris Challenge featuring Mickey (Japan)" id="0400" cloneofid="0397">
 		<description>Magical Tetris Challenge featuring Mickey (Japan)</description>
 		<rom name="Magical Tetris Challenge featuring Mickey (Japan).n64" />
-		<release name="Magical Tetris Challenge featuring Mickey (Japan)" region="JPN" />
-		<rom name="Magical Tetris Challenge featuring Mickey (Japan).z64" size="16777216" crc="7efb2f1e" md5="f1ff1f364c459701f42beb8989675d44" sha1="fe7c8fa25ea09280f94d08623bb8838d88eec2e3" />
+		<rom name="Magical Tetris Challenge featuring Mickey (Japan).z64" size="16777216" crc="7efb2f1e" md5="f1ff1f364c459701f42beb8989675d44" sha1="fe7c8fa25ea09280f94d08623bb8838d88eec2e3" serial="NMTJ" />
 	</game>
-	<game name="Mahjong 64 (Japan)">
+	<game name="Mahjong 64 (Japan)" id="0401">
 		<description>Mahjong 64 (Japan)</description>
 		<rom name="Mahjong 64 (Japan).n64" />
-		<release name="Mahjong 64 (Japan)" region="JPN" />
-		<rom name="Mahjong 64 (Japan).z64" size="8388608" crc="dbe7d51a" md5="8ae2e8f0c356fee638c8d908dcbb3381" sha1="41c73c372ff316322593b791d09934b37c461f9f" />
+		<rom name="Mahjong 64 (Japan).z64" size="8388608" crc="dbe7d51a" md5="8ae2e8f0c356fee638c8d908dcbb3381" sha1="41c73c372ff316322593b791d09934b37c461f9f" serial="NMJJ" />
 	</game>
-	<game name="Mahjong Hourouki Classic (Japan)">
+	<game name="Mahjong Hourouki Classic (Japan)" id="0402">
 		<description>Mahjong Hourouki Classic (Japan)</description>
 		<rom name="Mahjong Hourouki Classic (Japan).n64" />
-		<release name="Mahjong Hourouki Classic (Japan)" region="JPN" />
-		<rom name="Mahjong Hourouki Classic (Japan).z64" size="12582912" crc="990a8e54" md5="e942a3eeb1eb572badd6f705eb12a22c" sha1="405e6bcb6ad4a1452fe50aac1278a3f411c378c0" />
+		<rom name="Mahjong Hourouki Classic (Japan).z64" size="12582912" crc="990a8e54" md5="e942a3eeb1eb572badd6f705eb12a22c" sha1="405e6bcb6ad4a1452fe50aac1278a3f411c378c0" serial="NMHJ" />
 	</game>
-	<game name="Mahjong Master (Japan)">
+	<game name="Mahjong Master (Japan)" id="0403">
 		<description>Mahjong Master (Japan)</description>
 		<rom name="Mahjong Master (Japan).n64" />
-		<release name="Mahjong Master (Japan)" region="JPN" />
-		<rom name="Mahjong Master (Japan).z64" size="8388608" crc="b68d596f" md5="cf0d228e8efdf823a227979bb352dd5b" sha1="556dd6dbbec02680e47362552d2babd4f8720050" />
+		<rom name="Mahjong Master (Japan).z64" size="8388608" crc="b68d596f" md5="cf0d228e8efdf823a227979bb352dd5b" sha1="556dd6dbbec02680e47362552d2babd4f8720050" serial="NMMJ" />
 	</game>
-	<game name="Major League Baseball Featuring Ken Griffey Jr. (USA)">
-		<description>Major League Baseball Featuring Ken Griffey Jr. (USA)</description>
-		<rom name="Major League Baseball Featuring Ken Griffey Jr. (USA).n64" />
-		<release name="Major League Baseball Featuring Ken Griffey Jr. (USA)" region="USA" />
-		<rom name="Major League Baseball Featuring Ken Griffey Jr. (USA).z64" size="16777216" crc="2ef1ea20" md5="764f22ad3d0f59667a7f083d2f789b31" sha1="54b8c97523089d92754c2582a7b7a43246947122" />
-	</game>
-	<game name="Major League Baseball Featuring Ken Griffey Jr. (Australia)" cloneof="Major League Baseball Featuring Ken Griffey Jr. (USA)">
+	<game name="Major League Baseball Featuring Ken Griffey Jr. (Australia)" id="0404" cloneofid="0405">
 		<description>Major League Baseball Featuring Ken Griffey Jr. (Australia)</description>
 		<rom name="Major League Baseball Featuring Ken Griffey Jr. (Australia).n64" />
-		<release name="Major League Baseball Featuring Ken Griffey Jr. (Australia)" region="AUS" />
-		<rom name="Major League Baseball Featuring Ken Griffey Jr. (Australia).z64" size="16777216" crc="e08f7578" md5="152b9939a5f50734d5401980028856b4" sha1="e300e8acb110d72bc5bfee4fc4981e09b881300e" />
+		<rom name="Major League Baseball Featuring Ken Griffey Jr. (Australia).z64" size="16777216" crc="e08f7578" md5="152b9939a5f50734d5401980028856b4" sha1="e300e8acb110d72bc5bfee4fc4981e09b881300e" serial="NKGP" />
 	</game>
-	<game name="Mario Golf (Europe)">
+	<game name="Major League Baseball Featuring Ken Griffey Jr. (USA)" id="0405">
+		<description>Major League Baseball Featuring Ken Griffey Jr. (USA)</description>
+		<rom name="Major League Baseball Featuring Ken Griffey Jr. (USA).n64" />
+		<rom name="Major League Baseball Featuring Ken Griffey Jr. (USA).z64" size="16777216" crc="2ef1ea20" md5="764f22ad3d0f59667a7f083d2f789b31" sha1="54b8c97523089d92754c2582a7b7a43246947122" serial="NKGE" />
+	</game>
+	<game name="Mario Golf (Europe)" id="0406">
 		<description>Mario Golf (Europe)</description>
 		<rom name="Mario Golf (Europe).n64" />
-		<release name="Mario Golf (Europe)" region="EUR" />
-		<rom name="Mario Golf (Europe).z64" size="33554432" crc="a5071a77" md5="55634ff90ee997790781f79a5b0097ee" sha1="a3f057212e134c411258837271db8a08a6a7921e" status="verified" />
+		<rom name="Mario Golf (Europe).z64" size="33554432" crc="a5071a77" md5="55634ff90ee997790781f79a5b0097ee" sha1="a3f057212e134c411258837271db8a08a6a7921e" sha256="9df6ee0c9a3b463032726400de0e2879578ee55c0d03876bf9d7507e56aa99b9" status="verified" serial="NMFP" />
 	</game>
-	<game name="Mario Golf (USA)" cloneof="Mario Golf (Europe)">
+	<game name="Mario Golf (USA)" id="0407" cloneofid="0406">
 		<description>Mario Golf (USA)</description>
 		<rom name="Mario Golf (USA).n64" />
-		<release name="Mario Golf (USA)" region="USA" />
-		<rom name="Mario Golf (USA).z64" size="33554432" crc="2fc4c216" md5="903e6929666531d72d05d1e4c522e305" sha1="e2c4e7a905b29529b49a1619a401fe699224829b" />
+		<rom name="Mario Golf (USA).z64" size="33554432" crc="2fc4c216" md5="903e6929666531d72d05d1e4c522e305" sha1="e2c4e7a905b29529b49a1619a401fe699224829b" sha256="871134c893d5d671ef90c88dfbe98fb20fa20853b3370936a1d09aee6de1beae" serial="NMFE" />
 	</game>
-	<game name="Mario Golf 64 (Japan)" cloneof="Mario Golf (Europe)">
+	<game name="Mario Golf (USA) (LodgeNet)" id="1145" cloneofid="0406">
+		<category>Games</category>
+		<rom name="Mario Golf (USA) (LodgeNet).n64" />
+		<description>Mario Golf (USA) (LodgeNet)</description>
+		<rom name="Mario Golf (USA) (LodgeNet).i64" size="64" crc="df31532f" md5="77b511becb278dac7c383e9f9109a71a" sha1="51db8e096b345ca306d34d114dc82bf36211db1d" />
+		<rom name="Mario Golf (USA) (LodgeNet).z64" size="33554432" crc="1c256575" md5="335c3f0ca75a77b222ca50e7af308563" sha1="47c5f700940bb65be1145e7d6543ddf1a816ddda" />
+	</game>
+	<game name="Mario Golf 64 (Japan)" id="0408" cloneofid="0406">
 		<description>Mario Golf 64 (Japan)</description>
 		<rom name="Mario Golf 64 (Japan).n64" />
-		<rom name="Mario Golf 64 (Japan).z64" size="33554432" crc="bb03a1a6" md5="cd87ba2998d63c13b4366eb2c54e1eb6" sha1="1e2c5b63298cd3e8ee5e5f1ebba93c3d6fcb27df" />
+		<rom name="Mario Golf 64 (Japan).z64" size="33554432" crc="bb03a1a6" md5="cd87ba2998d63c13b4366eb2c54e1eb6" sha1="1e2c5b63298cd3e8ee5e5f1ebba93c3d6fcb27df" sha256="7a8180e46e1761bae7add2a46cad472c9d328f16e8c574a46915adc1f658620e" status="verified" serial="NMFJ" />
 	</game>
-	<game name="Mario Golf 64 (Japan) (Rev 1)" cloneof="Mario Golf (Europe)">
+	<game name="Mario Golf 64 (Japan) (Rev 1)" id="0900" cloneofid="0406">
 		<description>Mario Golf 64 (Japan) (Rev 1)</description>
 		<rom name="Mario Golf 64 (Japan) (Rev 1).n64" />
-		<release name="Mario Golf 64 (Japan) (Rev 1)" region="JPN" />
-		<rom name="Mario Golf 64 (Japan) (Rev 1).z64" size="33554432" crc="ad1758ac" md5="570b4f55a3005b709e6ed5d625981b90" sha1="ef0984fe1b9f925b31d74bb8fe65b6660095ed4e" status="verified" />
+		<rom name="Mario Golf 64 (Japan) (Rev 1).z64" size="33554432" crc="ad1758ac" md5="570b4f55a3005b709e6ed5d625981b90" sha1="ef0984fe1b9f925b31d74bb8fe65b6660095ed4e" sha256="9a7b624eaa0625d2eea38e54afdd7b3aca906464736109da185be45a7bd93845" status="verified" serial="NMFJ" />
 	</game>
-	<game name="Mario Kadingche (China) (v6) (iQue) (Manual)">
-		<description>Mario Kadingche (China) (v6) (iQue) (Manual)</description>
-		<rom name="Mario Kadingche (China) (v6) (iQue) (Manual).n64" />
-		<release name="Mario Kadingche (China) (v6) (iQue) (Manual)" region="CHN" />
-		<rom name="Mario Kadingche (China) (v6) (iQue) (Manual).z64" size="425984" crc="abdbf9f4" md5="76176b237d4f60e59f98d247283d9365" sha1="b966688b8c5e2c8d70c91ec0a1caeeaa519c6170" />
-	</game>
-	<game name="Mario Kadingche (China) (v2) (iQue) (Manual)" cloneof="Mario Kadingche (China) (v6) (iQue) (Manual)">
-		<description>Mario Kadingche (China) (v2) (iQue) (Manual)</description>
-		<rom name="Mario Kadingche (China) (v2) (iQue) (Manual).n64" />
-		<rom name="Mario Kadingche (China) (v2) (iQue) (Manual).z64" size="245760" crc="1ad7f15b" md5="c70af6197e67b310f316c34cced64c19" sha1="d600d06eab14f9d54957b19832120ec3ee515b95" />
-	</game>
-	<game name="Mario Kart 64 (Europe) (Rev 1)">
-		<description>Mario Kart 64 (Europe) (Rev 1)</description>
-		<rom name="Mario Kart 64 (Europe) (Rev 1).n64" />
-		<release name="Mario Kart 64 (Europe) (Rev 1)" region="EUR" />
-		<rom name="Mario Kart 64 (Europe) (Rev 1).z64" size="12582912" crc="0248f6c3" md5="2bb149a583fdefea96805f628fe42fd9" sha1="f6b5f519dd57ea59e9f013cc64816e9d273b2329" status="verified" />
-	</game>
-	<game name="Mario Kadingche (China) (v4) (iQue)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
-		<description>Mario Kadingche (China) (v4) (iQue)</description>
-		<rom name="Mario Kadingche (China) (v4) (iQue).n64" />
-		<rom name="Mario Kadingche (China) (v4) (iQue).z64" size="12533760" crc="ea0813c7" md5="78771beb349d481e69baa9225b36d63a" sha1="219660d0a321fc200ac4295dd79fd3417da3eea8" />
-	</game>
-	<game name="Mario Kadingche (China) (v5) (iQue)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
-		<description>Mario Kadingche (China) (v5) (iQue)</description>
-		<rom name="Mario Kadingche (China) (v5) (iQue).n64" />
-		<rom name="Mario Kadingche (China) (v5) (iQue).z64" size="12533760" crc="47e69f28" md5="5ea0ed74cf1ddaaa964d728a129e7cf9" sha1="d6605879918b0dca3eafa1c75ecbc850a3b2535d" />
-	</game>
-	<game name="Mario Kart 64 (Europe)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
+	<game name="Mario Kart 64 (Europe)" id="0409" cloneofid="0410">
 		<description>Mario Kart 64 (Europe)</description>
 		<rom name="Mario Kart 64 (Europe).n64" />
-		<rom name="Mario Kart 64 (Europe).z64" size="12582912" crc="faa6b083" md5="8fad1e4fa7baf1443b7f21ad1947b429" sha1="a729039453210b84f17019dda3f248d5888f7690" />
+		<rom name="Mario Kart 64 (Europe).z64" size="12582912" crc="faa6b083" md5="8fad1e4fa7baf1443b7f21ad1947b429" sha1="a729039453210b84f17019dda3f248d5888f7690" serial="NKTP" />
 	</game>
-	<game name="Mario Kart 64 (Japan)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
+	<game name="Mario Kart 64 (Europe) (Rev 1)" id="0410">
+		<description>Mario Kart 64 (Europe) (Rev 1)</description>
+		<rom name="Mario Kart 64 (Europe) (Rev 1).n64" />
+		<rom name="Mario Kart 64 (Europe) (Rev 1).z64" size="12582912" crc="0248f6c3" md5="2bb149a583fdefea96805f628fe42fd9" sha1="f6b5f519dd57ea59e9f013cc64816e9d273b2329" sha256="8d9d2a68bbc5e9512200cab281b6d98c1d49e1028c092e3fb821ae4076e1ce6d" status="verified" serial="NKTP" />
+	</game>
+	<game name="Mario Kart 64 (Japan)" id="0411" cloneofid="0410">
 		<description>Mario Kart 64 (Japan)</description>
 		<rom name="Mario Kart 64 (Japan).n64" />
-		<rom name="Mario Kart 64 (Japan).z64" size="12582912" crc="5d9696df" md5="bf964ceca78a13a82055ebda80b95cca" sha1="afeeec65b9a03f0cb8ec92f9ba7a9f0122e8bd0e" />
+		<rom name="Mario Kart 64 (Japan).z64" size="12582912" crc="5d9696df" md5="bf964ceca78a13a82055ebda80b95cca" sha1="afeeec65b9a03f0cb8ec92f9ba7a9f0122e8bd0e" serial="NKTJ" />
 	</game>
-	<game name="Mario Kart 64 (Japan) (Rev 1)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
+	<game name="Mario Kart 64 (Japan) (Rev 1)" id="0412" cloneofid="0410">
 		<description>Mario Kart 64 (Japan) (Rev 1)</description>
 		<rom name="Mario Kart 64 (Japan) (Rev 1).n64" />
-		<release name="Mario Kart 64 (Japan) (Rev 1)" region="JPN" />
-		<rom name="Mario Kart 64 (Japan) (Rev 1).z64" size="12582912" crc="6ced6472" md5="60535265bae43ddfcbdb0d71594b1693" sha1="9f439457585146a4e1da7e1dd9104f7f94381688" status="verified" />
+		<rom name="Mario Kart 64 (Japan) (Rev 1).z64" size="12582912" crc="6ced6472" md5="60535265bae43ddfcbdb0d71594b1693" sha1="9f439457585146a4e1da7e1dd9104f7f94381688" sha256="ffe65c81d29a901cc6831eabf9a49aef31acbe6e55ec5b56b73d9238a00dfd8d" status="verified" serial="NKTJ" />
 	</game>
-	<game name="Mario Kart 64 (USA)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
+	<game name="Mario Kart 64 (USA)" id="0413" cloneofid="0410">
 		<description>Mario Kart 64 (USA)</description>
 		<rom name="Mario Kart 64 (USA).n64" />
-		<release name="Mario Kart 64 (USA)" region="USA" />
-		<rom name="Mario Kart 64 (USA).z64" size="12582912" crc="434389c1" md5="3a67d9986f54eb282924fca4cd5f6dff" sha1="579c48e211ae952530ffc8738709f078d5dd215e" status="verified" />
+		<rom name="Mario Kart 64 (USA).z64" size="12582912" crc="434389c1" md5="3a67d9986f54eb282924fca4cd5f6dff" sha1="579c48e211ae952530ffc8738709f078d5dd215e" sha256="d6b8538dd63f0132ecb2856e7d32816ed3c30e3e479aecd23cf83fb6ba17a5da" status="verified" serial="NKTE" />
 	</game>
-	<game name="Mario no Photopie (Japan)">
+	<game name="Mario Kart 64 (USA) (LodgeNet)" id="1146" cloneofid="0410">
+		<category>Games</category>
+		<rom name="Mario Kart 64 (USA) (LodgeNet).n64" />
+		<description>Mario Kart 64 (USA) (LodgeNet)</description>
+		<rom name="Mario Kart 64 (USA) (LodgeNet).i64" size="64" crc="de24f369" md5="13a6b6a82c52fedaab208ec00467ac1c" sha1="45ffe8cdac5266f261b7b1ca3d2cca7c48877bea" />
+		<rom name="Mario Kart 64 (USA) (LodgeNet).z64" size="12582912" crc="407edef1" md5="f4ea3e26711521ceb467d96bc418dda5" sha1="5b0a0c8b57881f43f9314b427a84d29a46a12607" />
+	</game>
+	<game name="Mario no Photopie (Japan)" id="0414">
 		<description>Mario no Photopie (Japan)</description>
 		<rom name="Mario no Photopie (Japan).n64" />
-		<release name="Mario no Photopie (Japan)" region="JPN" />
-		<rom name="Mario no Photopie (Japan).z64" size="16777216" crc="176b3683" md5="7f4ed2aaf94a2197b0ad63c6ece9dea9" sha1="3d591ea869696f067913308886edea544b77ed3f" />
+		<rom name="Mario no Photopie (Japan).z64" size="16777216" crc="176b3683" md5="7f4ed2aaf94a2197b0ad63c6ece9dea9" sha1="3d591ea869696f067913308886edea544b77ed3f" sha256="616f74a23cd5730fed7059892cc87420e4f7da174b425ebe8eff088366a7d252" status="verified" serial="NMPJ" />
 	</game>
-	<game name="Mario Party (Europe) (En,Fr,De)">
+	<game name="Mario Party (Europe) (En,Fr,De)" id="0415">
 		<description>Mario Party (Europe) (En,Fr,De)</description>
 		<rom name="Mario Party (Europe) (En,Fr,De).n64" />
-		<release name="Mario Party (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Mario Party (Europe) (En,Fr,De).z64" size="33554432" crc="da98a5d3" md5="9773150709bd804b8e57e35f1d6b0eed" sha1="d7ba071c220a71f5e4503e55c98c91ff8f027848" />
+		<rom name="Mario Party (Europe) (En,Fr,De).z64" size="33554432" crc="da98a5d3" md5="9773150709bd804b8e57e35f1d6b0eed" sha1="d7ba071c220a71f5e4503e55c98c91ff8f027848" sha256="48e6cbb83735ec4e4662866fa99cd6895da97a3b90814f5078bfabd132cbfb9a" status="verified" serial="NLBP" />
 	</game>
-	<game name="Mario Party (Japan)" cloneof="Mario Party (Europe) (En,Fr,De)">
+	<game name="Mario Party (Japan)" id="0416" cloneofid="0415">
 		<description>Mario Party (Japan)</description>
 		<rom name="Mario Party (Japan).n64" />
-		<release name="Mario Party (Japan)" region="JPN" />
-		<rom name="Mario Party (Japan).z64" size="33554432" crc="4f1adc7b" md5="3f556cc3b3a996cd2f471fa0d992d529" sha1="37fd6d27f55c468dc36efb92a255f7ab04ffc0a8" />
+		<rom name="Mario Party (Japan).z64" size="33554432" crc="4f1adc7b" md5="3f556cc3b3a996cd2f471fa0d992d529" sha1="37fd6d27f55c468dc36efb92a255f7ab04ffc0a8" sha256="2fed99bec5458b07900bbc58cbacf0bbec46b3250ac35de00100310d7265c09d" status="verified" serial="CLBJ" />
 	</game>
-	<game name="Mario Party (USA)" cloneof="Mario Party (Europe) (En,Fr,De)">
+	<game name="Mario Party (USA)" id="0417" cloneofid="0415">
 		<description>Mario Party (USA)</description>
 		<rom name="Mario Party (USA).n64" />
-		<release name="Mario Party (USA)" region="USA" />
-		<rom name="Mario Party (USA).z64" size="33554432" crc="4d60abe5" md5="8bc2712139fbf0c56c8ea835802c52dc" sha1="1159bd56730094bfc71be30113e1cfc8bacf34f3" status="verified" />
+		<rom name="Mario Party (USA).z64" size="33554432" crc="4d60abe5" md5="8bc2712139fbf0c56c8ea835802c52dc" sha1="1159bd56730094bfc71be30113e1cfc8bacf34f3" sha256="ca4fb9605fff4884e9ba4319dfa23d96b7347ce88ffb8d04e6c25a3a9ff9ed6a" status="verified" serial="CLBE" />
 	</game>
-	<game name="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
+	<game name="Mario Party 2 (Europe) (En,Fr,De,Es,It)" id="0418">
 		<description>Mario Party 2 (Europe) (En,Fr,De,Es,It)</description>
 		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Mario Party 2 (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="dc00357a" md5="f70112b652b0ee4856af83f4e8005c31" sha1="fa5d1426488b298a1c5c383360a78f1a3de18dc7" status="verified" />
+		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="dc00357a" md5="f70112b652b0ee4856af83f4e8005c31" sha1="fa5d1426488b298a1c5c383360a78f1a3de18dc7" sha256="4fe18c71dba3520dab2a0618fdd949cf0869579325ea2ecfd2040337daff3863" status="verified" serial="NMWP" />
 	</game>
-	<game name="Mario Party 2 (Japan)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
+	<game name="Mario Party 2 (Japan)" id="0419" cloneofid="0418">
 		<description>Mario Party 2 (Japan)</description>
 		<rom name="Mario Party 2 (Japan).n64" />
-		<release name="Mario Party 2 (Japan)" region="JPN" />
-		<rom name="Mario Party 2 (Japan).z64" size="33554432" crc="7457b081" md5="f23e4cd437465f3e725262253cf3ea59" sha1="26f4637167aaaa0e420bb4fdb26a965fd34f8d19" />
+		<rom name="Mario Party 2 (Japan).z64" size="33554432" crc="7457b081" md5="f23e4cd437465f3e725262253cf3ea59" sha1="26f4637167aaaa0e420bb4fdb26a965fd34f8d19" sha256="bae1720d257791b58fc29189241553d64dece6ce241a6c2af275bf77d25bb96f" status="verified" serial="NMWJ" />
 	</game>
-	<game name="Mario Party 2 (USA)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
+	<game name="Mario Party 2 (USA)" id="0420" cloneofid="0418">
 		<description>Mario Party 2 (USA)</description>
 		<rom name="Mario Party 2 (USA).n64" />
-		<release name="Mario Party 2 (USA)" region="USA" />
-		<rom name="Mario Party 2 (USA).z64" size="33554432" crc="e58a1955" md5="04840612a35ece222afdb2dfbf926409" sha1="166eda1c05670d337e2c3f15a5db528ae1e5d6e3" />
+		<rom name="Mario Party 2 (USA).z64" size="33554432" crc="e58a1955" md5="04840612a35ece222afdb2dfbf926409" sha1="166eda1c05670d337e2c3f15a5db528ae1e5d6e3" sha256="0b7b2ec3bd2ac8713b4c43f74a634285a720779964ee2658f7ad2dfa97b33576" serial="NMWE" />
 	</game>
-	<game name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
+	<game name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console)" id="0995" cloneofid="0418">
 		<description>Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console)</description>
 		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console).n64" />
-		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console).z64" size="33554432" crc="dca66040" md5="4a834d275abf14a6255aa11be81e339d" sha1="3db98872699002f3e9fb82cf9a3f79f1b52e2a51" />
+		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console).z64" size="33554432" crc="dca66040" md5="4a834d275abf14a6255aa11be81e339d" sha1="3db98872699002f3e9fb82cf9a3f79f1b52e2a51" serial="NMWP" />
 	</game>
-	<game name="Mario Party 2 (Japan) (Wii Virtual Console)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
+	<game name="Mario Party 2 (Japan) (Wii Virtual Console)" id="0996" cloneofid="0418">
 		<description>Mario Party 2 (Japan) (Wii Virtual Console)</description>
 		<rom name="Mario Party 2 (Japan) (Wii Virtual Console).n64" />
-		<rom name="Mario Party 2 (Japan) (Wii Virtual Console).z64" size="33554432" crc="fdc89220" md5="9e25ffe8fb0931f67b4e42c5f74ecbc0" sha1="3da1dfddf2117830b9f43c006970c9d78d0f1b6a" />
+		<rom name="Mario Party 2 (Japan) (Wii Virtual Console).z64" size="33554432" crc="fdc89220" md5="9e25ffe8fb0931f67b4e42c5f74ecbc0" sha1="3da1dfddf2117830b9f43c006970c9d78d0f1b6a" serial="NMWJ" />
 	</game>
-	<game name="Mario Party 2 (USA) (Wii Virtual Console)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
+	<game name="Mario Party 2 (USA) (Wii Virtual Console)" id="0997" cloneofid="0418">
 		<description>Mario Party 2 (USA) (Wii Virtual Console)</description>
 		<rom name="Mario Party 2 (USA) (Wii Virtual Console).n64" />
-		<rom name="Mario Party 2 (USA) (Wii Virtual Console).z64" size="33554432" crc="6f45853e" md5="54765a3b1dcc6eb3c29c1891958da5e2" sha1="6b950ea20edcfc2b0c30ef3eef0da5aad628f9fa" />
+		<rom name="Mario Party 2 (USA) (Wii Virtual Console).z64" size="33554432" crc="6f45853e" md5="54765a3b1dcc6eb3c29c1891958da5e2" sha1="6b950ea20edcfc2b0c30ef3eef0da5aad628f9fa" serial="NMWE" />
 	</game>
-	<game name="Mario Party 3 (Europe) (En,Fr,De,Es)">
+	<game name="Mario Party 3 (Europe) (En,Fr,De,Es)" id="0421">
 		<description>Mario Party 3 (Europe) (En,Fr,De,Es)</description>
 		<rom name="Mario Party 3 (Europe) (En,Fr,De,Es).n64" />
-		<release name="Mario Party 3 (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Mario Party 3 (Europe) (En,Fr,De,Es).z64" size="33554432" crc="813b13f2" md5="8e62ec6fbe3cc9ff6284191c9c88e68f" sha1="9e1ddfe872c6d43ae51010a9e8a6fe2d2e634b50" />
+		<rom name="Mario Party 3 (Europe) (En,Fr,De,Es).z64" size="33554432" crc="813b13f2" md5="8e62ec6fbe3cc9ff6284191c9c88e68f" sha1="9e1ddfe872c6d43ae51010a9e8a6fe2d2e634b50" sha256="23a33bd5ec1ef62f6888e0d7b68f56ffb36da83025be789ca1170da43266242f" status="verified" serial="NMVP" />
 	</game>
-	<game name="Mario Party 3 (Japan)" cloneof="Mario Party 3 (Europe) (En,Fr,De,Es)">
+	<game name="Mario Party 3 (Japan)" id="0422" cloneofid="0421">
 		<description>Mario Party 3 (Japan)</description>
 		<rom name="Mario Party 3 (Japan).n64" />
-		<release name="Mario Party 3 (Japan)" region="JPN" />
-		<rom name="Mario Party 3 (Japan).z64" size="33554432" crc="3fc04053" md5="ed99f330ce7a2638ab13351012eeb86b" sha1="43cf5eb8bd68ef57ba1c9b4cae7bd18f1826e543" />
+		<rom name="Mario Party 3 (Japan).z64" size="33554432" crc="3fc04053" md5="ed99f330ce7a2638ab13351012eeb86b" sha1="43cf5eb8bd68ef57ba1c9b4cae7bd18f1826e543" sha256="bdf532f2f9c927a4398a1657b5e9ecfb34d416db68e791c743929ef5d0628f69" status="verified" serial="NMVJ" />
 	</game>
-	<game name="Mario Party 3 (USA)" cloneof="Mario Party 3 (Europe) (En,Fr,De,Es)">
+	<game name="Mario Party 3 (USA)" id="0423" cloneofid="0421">
 		<description>Mario Party 3 (USA)</description>
 		<rom name="Mario Party 3 (USA).n64" />
-		<release name="Mario Party 3 (USA)" region="USA" />
-		<rom name="Mario Party 3 (USA).z64" size="33554432" crc="b7445ddc" md5="76a8bbc81bc2060ec99c9645867237cc" sha1="6beb80ff822b96bcf85dcdb512e8b2b7969d8259" />
+		<rom name="Mario Party 3 (USA).z64" size="33554432" crc="b7445ddc" md5="76a8bbc81bc2060ec99c9645867237cc" sha1="6beb80ff822b96bcf85dcdb512e8b2b7969d8259" sha256="a08cbd6a4f40d15cbd8bcdee644f80cdfb843e06d569d1334bcd49f23262855a" serial="NMVE" />
 	</game>
-	<game name="Mario Tennis (Europe)">
+	<game name="Mario Party 3 (USA) (Beta)" id="1080" cloneofid="0421">
+		<description>Mario Party 3 (USA) (Beta)</description>
+		<rom name="Mario Party 3 (USA) (Beta).n64" />
+		<rom name="Mario Party 3 (USA) (Beta).z64" size="67108864" crc="697c1777" md5="f6e3475f64b966b3ff2867ca69dbf759" sha1="c0c2a8eefa4c06264095df9dc78f459a9f3975bb" sha256="06661f5715023a75cc92ec40a1b520f6a84a4bb6f12db126a5ea759e1a8bf8cf" />
+	</game>
+	<game name="Mario Party 3 (USA) (LodgeNet)" id="1147" cloneofid="0421">
+		<category>Games</category>
+		<rom name="Mario Party 3 (USA) (LodgeNet).n64" />
+		<description>Mario Party 3 (USA) (LodgeNet)</description>
+		<rom name="Mario Party 3 (USA) (LodgeNet).i64" size="64" crc="80ee8f86" md5="32feadd97e77beb453fe44a119e2daa3" sha1="c2c18a6d2b2c098767d7015f06300a1fc5772a33" />
+		<rom name="Mario Party 3 (USA) (LodgeNet).z64" size="33554432" crc="9f929c0f" md5="5f157c80a9a6941a8986ac9e292b01cb" sha1="9be79ddb66a6306dec7404e934c6d9fe454f42f4" />
+	</game>
+	<game name="Mario Story (Japan)" id="0424" cloneofid="0536">
+		<description>Mario Story (Japan)</description>
+		<rom name="Mario Story (Japan).n64" />
+		<rom name="Mario Story (Japan).z64" size="41943040" crc="bd60ca66" md5="df54f17fb84fb5b5bcf6aa9af65b0942" sha1="b9cca3ff260b9ff427d981626b82f96de73586d3" sha256="a62c669817f87fba067248962f6737d9a8d27e78a843798d739d9d2a39d73874" status="verified" serial="NMQJ" />
+	</game>
+	<game name="Mario Tennis (Europe)" id="0425">
 		<description>Mario Tennis (Europe)</description>
 		<rom name="Mario Tennis (Europe).n64" />
-		<release name="Mario Tennis (Europe)" region="EUR" />
-		<rom name="Mario Tennis (Europe).z64" size="16777216" crc="29aa5df4" md5="fff9b3e22abb9b60215dafb13ad5a4de" sha1="b5e4aa1abf8fc8022fc47f30cd6d4ac6a6b21684" />
+		<rom name="Mario Tennis (Europe).z64" size="16777216" crc="29aa5df4" md5="fff9b3e22abb9b60215dafb13ad5a4de" sha1="b5e4aa1abf8fc8022fc47f30cd6d4ac6a6b21684" serial="NM8P" />
 	</game>
-	<game name="Mario Tennis (USA)" cloneof="Mario Tennis (Europe)">
+	<game name="Mario Tennis (USA)" id="0426" cloneofid="0425">
 		<description>Mario Tennis (USA)</description>
 		<rom name="Mario Tennis (USA).n64" />
-		<release name="Mario Tennis (USA)" region="USA" />
-		<rom name="Mario Tennis (USA).z64" size="16777216" crc="4e9560f6" md5="759358fad1ed5ae31dcb2001a07f2fe5" sha1="999047f07cec931ffbdcc7b33b8502ef602807ee" />
+		<rom name="Mario Tennis (USA).z64" size="16777216" crc="4e9560f6" md5="759358fad1ed5ae31dcb2001a07f2fe5" sha1="999047f07cec931ffbdcc7b33b8502ef602807ee" sha256="6341ec31c937eddf6fab5c848470c9b7c27f43a42a494a7a1aae943eb91d90fb" serial="NM8E" />
 	</game>
-	<game name="Mario Tennis (Europe) (Wii Virtual Console)" cloneof="Mario Tennis (Europe)">
+	<game name="Mario Tennis (Europe) (Wii Virtual Console)" id="0998" cloneofid="0425">
 		<description>Mario Tennis (Europe) (Wii Virtual Console)</description>
 		<rom name="Mario Tennis (Europe) (Wii Virtual Console).n64" />
-		<rom name="Mario Tennis (Europe) (Wii Virtual Console).z64" size="16777216" crc="e9ba8e6b" md5="d40fb0e87996af902eff9c194027fc3b" sha1="e1f1ec3bb2deea60ebea05a846c2ef4e5ce5d90f" />
+		<rom name="Mario Tennis (Europe) (Wii Virtual Console).z64" size="16777216" crc="e9ba8e6b" md5="d40fb0e87996af902eff9c194027fc3b" sha1="e1f1ec3bb2deea60ebea05a846c2ef4e5ce5d90f" serial="NM8P" />
 	</game>
-	<game name="Mario Tennis (USA) (Wii Virtual Console)" cloneof="Mario Tennis (Europe)">
+	<game name="Mario Tennis (USA) (Wii Virtual Console)" id="1000" cloneofid="0425">
 		<description>Mario Tennis (USA) (Wii Virtual Console)</description>
 		<rom name="Mario Tennis (USA) (Wii Virtual Console).n64" />
-		<rom name="Mario Tennis (USA) (Wii Virtual Console).z64" size="16777216" crc="8e85b369" md5="4731025e850faf8c0500dc04e1a3bff2" sha1="36bcbb5b9b5592d05482ac677a0c54df51b122a1" />
+		<rom name="Mario Tennis (USA) (Wii Virtual Console).z64" size="16777216" crc="8e85b369" md5="4731025e850faf8c0500dc04e1a3bff2" sha1="36bcbb5b9b5592d05482ac677a0c54df51b122a1" serial="NM8E" />
 	</game>
-	<game name="Mario Tennis 64 (Japan)" cloneof="Mario Tennis (Europe)">
+	<game name="Mario Tennis (USA) (LodgeNet)" id="1148" cloneofid="0425">
+		<category>Games</category>
+		<rom name="Mario Tennis (USA) (LodgeNet).n64" />
+		<description>Mario Tennis (USA) (LodgeNet)</description>
+		<rom name="Mario Tennis (USA) (LodgeNet).i64" size="64" crc="fe9453db" md5="c08f0b1fbaa6ad8709c91f9a088d5bfb" sha1="0c1a3f857838c2f3c6268a825b9533725aabeec8" />
+		<rom name="Mario Tennis (USA) (LodgeNet).z64" size="16777216" crc="02af0a24" md5="dfb78505e91a874662618d8c1076a58b" sha1="1f76e775c5f2e247d6550aecc2666149c6025989" />
+	</game>
+	<game name="Mario Tennis 64 (Japan)" id="0427" cloneofid="0425">
 		<description>Mario Tennis 64 (Japan)</description>
 		<rom name="Mario Tennis 64 (Japan).n64" />
-		<release name="Mario Tennis 64 (Japan)" region="JPN" />
-		<rom name="Mario Tennis 64 (Japan).z64" size="16777216" crc="c665301d" md5="8eb1c2443d0b2e6eda52a4eea66d6c35" sha1="8aa424795bbe87c659f777d0843e236340b12e16" status="verified" />
+		<rom name="Mario Tennis 64 (Japan).z64" size="16777216" crc="c665301d" md5="8eb1c2443d0b2e6eda52a4eea66d6c35" sha1="8aa424795bbe87c659f777d0843e236340b12e16" sha256="b8d053a22ea2764904f32ed19daa60552e1bca28e1f1c074f4e4c59c91b9fe47" status="verified" serial="NM8J" />
 	</game>
-	<game name="Mario Tennis 64 (Japan) (Wii Virtual Console)" cloneof="Mario Tennis (Europe)">
+	<game name="Mario Tennis 64 (Japan) (Wii Virtual Console)" id="0999" cloneofid="0425">
 		<description>Mario Tennis 64 (Japan) (Wii Virtual Console)</description>
 		<rom name="Mario Tennis 64 (Japan) (Wii Virtual Console).n64" />
-		<rom name="Mario Tennis 64 (Japan) (Wii Virtual Console).z64" size="16777216" crc="32c58af3" md5="137a4e7dd0485edccb3bf598b1472d11" sha1="c188e98c6c7f4aae5d7efa2d0d4720e08f96d9b9" />
+		<rom name="Mario Tennis 64 (Japan) (Wii Virtual Console).z64" size="16777216" crc="32c58af3" md5="137a4e7dd0485edccb3bf598b1472d11" sha1="c188e98c6c7f4aae5d7efa2d0d4720e08f96d9b9" serial="NM8J" />
 	</game>
-	<game name="Mario Yisheng (China) (v4) (iQue) (Manual)">
-		<description>Mario Yisheng (China) (v4) (iQue) (Manual)</description>
-		<rom name="Mario Yisheng (China) (v4) (iQue) (Manual).n64" />
-		<release name="Mario Yisheng (China) (v4) (iQue) (Manual)" region="CHN" />
-		<rom name="Mario Yisheng (China) (v4) (iQue) (Manual).z64" size="393216" crc="84a5f66c" md5="b524d10a8a26764eb2198acec3f09948" sha1="4c74e74f8af2a6ae4110aba7dbe542f8add9b61a" />
-	</game>
-	<game name="Mario Yisheng (China) (v2) (iQue) (Manual)" cloneof="Mario Yisheng (China) (v4) (iQue) (Manual)">
-		<description>Mario Yisheng (China) (v2) (iQue) (Manual)</description>
-		<rom name="Mario Yisheng (China) (v2) (iQue) (Manual).n64" />
-		<rom name="Mario Yisheng (China) (v2) (iQue) (Manual).z64" size="294912" crc="b862a4fe" md5="fe49420725f9c1cf0f15ba5682d27709" sha1="72e8e15a281b9fc81269f6ebc7ab3be3adeee508" />
-	</game>
-	<game name="Mega Man 64 (USA)">
+	<game name="Mega Man 64 (USA)" id="0428">
 		<description>Mega Man 64 (USA)</description>
 		<rom name="Mega Man 64 (USA).n64" />
-		<release name="Mega Man 64 (USA)" region="USA" />
-		<rom name="Mega Man 64 (USA).z64" size="33554432" crc="1bfc71f0" md5="3620674acb51e436d5150738ac1c0969" sha1="f24fe0aff01aec018e2dd558ec4f076cf328129f" />
+		<rom name="Mega Man 64 (USA).z64" size="33554432" crc="1bfc71f0" md5="3620674acb51e436d5150738ac1c0969" sha1="f24fe0aff01aec018e2dd558ec4f076cf328129f" sha256="618d49bf62913b376e4858f1422a51a4352792b070fe6305860dd43e28353999" serial="NM6E" />
 	</game>
-	<game name="Mega Man 64 (USA) (Beta)" cloneof="Mega Man 64 (USA)">
+	<game name="Mega Man 64 (USA) (Beta)" id="0949" cloneofid="0428">
 		<description>Mega Man 64 (USA) (Beta)</description>
 		<rom name="Mega Man 64 (USA) (Beta).n64" />
 		<rom name="Mega Man 64 (USA) (Beta).z64" size="67108864" crc="d3562b57" md5="cd0824e9405185af434837ba1c8c0cd5" sha1="7fc1db2b88cd43a5e76697ee449bc946e9a48c03" />
 	</game>
-	<game name="Rockman Dash - Hagane no Boukenshin (Japan)" cloneof="Mega Man 64 (USA)">
-		<description>Rockman Dash - Hagane no Boukenshin (Japan)</description>
-		<rom name="Rockman Dash - Hagane no Boukenshin (Japan).n64" />
-		<release name="Rockman Dash - Hagane no Boukenshin (Japan)" region="JPN" />
-		<rom name="Rockman Dash - Hagane no Boukenshin (Japan).z64" size="33554432" crc="61eaee83" md5="0c74b44680276ffe808cfa6045329819" sha1="e807ed78db0b3440f76b445bf989a943bc05e0ad" />
-	</game>
-	<game name="Michael Owen's WLS 2000 (Europe)">
-		<description>Michael Owen's WLS 2000 (Europe)</description>
-		<rom name="Michael Owen's WLS 2000 (Europe).n64" />
-		<release name="Michael Owen's WLS 2000 (Europe)" region="EUR" />
-		<rom name="Michael Owen's WLS 2000 (Europe).z64" size="16777216" crc="bb680cbe" md5="892222cc4baf9958405d20bc492175bf" sha1="f629a56ed36fb3889841a047d7c4cd2b9731eb43" />
-	</game>
-	<game name="Mia Hamm Soccer 64 (USA) (En,Es)" cloneof="Michael Owen's WLS 2000 (Europe)">
+	<game name="Mia Hamm Soccer 64 (USA) (En,Es)" id="0429" cloneofid="0430">
 		<description>Mia Hamm Soccer 64 (USA) (En,Es)</description>
 		<rom name="Mia Hamm Soccer 64 (USA) (En,Es).n64" />
-		<release name="Mia Hamm Soccer 64 (USA) (En,Es)" region="USA" />
-		<rom name="Mia Hamm Soccer 64 (USA) (En,Es).z64" size="16777216" crc="2db3d3d6" md5="a4039368e0472c68e3072c02c7a80f94" sha1="62ce9d1c1f4cf7beaa1ef7c456c155f63f13f057" />
+		<rom name="Mia Hamm Soccer 64 (USA) (En,Es).z64" size="16777216" crc="2db3d3d6" md5="a4039368e0472c68e3072c02c7a80f94" sha1="62ce9d1c1f4cf7beaa1ef7c456c155f63f13f057" serial="NHME" />
 	</game>
-	<game name="RTL World League Soccer 2000 (Germany)" cloneof="Michael Owen's WLS 2000 (Europe)">
-		<description>RTL World League Soccer 2000 (Germany)</description>
-		<rom name="RTL World League Soccer 2000 (Germany).n64" />
-		<release name="RTL World League Soccer 2000 (Germany)" region="GER" />
-		<rom name="RTL World League Soccer 2000 (Germany).z64" size="16777216" crc="0a17da7b" md5="a1082a6676455c040843fd75e92de1a3" sha1="a68294e47c82639c9bcdae1b7306ac2a2e2f47b5" />
+	<game name="Michael Owen's WLS 2000 (Europe)" id="0430">
+		<description>Michael Owen's WLS 2000 (Europe)</description>
+		<rom name="Michael Owen's WLS 2000 (Europe).n64" />
+		<rom name="Michael Owen's WLS 2000 (Europe).z64" size="16777216" crc="bb680cbe" md5="892222cc4baf9958405d20bc492175bf" sha1="f629a56ed36fb3889841a047d7c4cd2b9731eb43" sha256="fa5256878922978dadd8ab20769b93821e2e68806b33822140ff723684711d2e" status="verified" serial="NWKX" />
 	</game>
-	<game name="Telefoot Soccer 2000 (France)" cloneof="Michael Owen's WLS 2000 (Europe)">
-		<description>Telefoot Soccer 2000 (France)</description>
-		<rom name="Telefoot Soccer 2000 (France).n64" />
-		<release name="Telefoot Soccer 2000 (France)" region="FRA" />
-		<rom name="Telefoot Soccer 2000 (France).z64" size="16777216" crc="7bd20931" md5="7f244aff8d729417e32b6a5b299afda5" sha1="ffc1f3271929b0e7d6467fdcbed9e0ccf2eba0a5" />
+	<game name="Michael Owen's WLS 2000 (Europe) (En,Fr,De,Es,It) (Beta)" id="1105" cloneofid="0430">
+		<category>Games</category>
+		<rom name="Michael Owen's WLS 2000 (Europe) (En,Fr,De,Es,It) (Beta).n64" />
+		<description>Michael Owen's WLS 2000 (Europe) (En,Fr,De,Es,It) (Beta)</description>
+		<rom name="Michael Owen's WLS 2000 (Europe) (En,Fr,De,Es,It) (Beta).z64" size="33554432" crc="16cb30af" md5="033d72e91b2ad5c47835be02da38a6e4" sha1="083ee244e4199972ffb763f88de6a1da27cbd679" sha256="695886b29e5b69e498e474a2a380bdab988ef7ecda7ae7c5a8fd1a4f9a1134e7" serial="!none" />
 	</game>
-	<game name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)">
-		<description>Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="0ae51ea5" md5="5ba3dc37860c08a209f24286b8dfec8c" sha1="c583ed998a6b422a22ffd3f8376c3cef0c3710d9" />
-	</game>
-	<game name="Mickey no Racing Challenge USA (Japan)" cloneof="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)">
+	<game name="Mickey no Racing Challenge USA (Japan)" id="0431" cloneofid="0432">
 		<description>Mickey no Racing Challenge USA (Japan)</description>
 		<rom name="Mickey no Racing Challenge USA (Japan).n64" />
-		<release name="Mickey no Racing Challenge USA (Japan)" region="JPN" />
-		<rom name="Mickey no Racing Challenge USA (Japan).z64" size="33554432" crc="1aecfc56" md5="288a514e98972bf9d329167aa29e66b6" sha1="5b4f7bad6591de2199c095352a811a2eb7fc6f53" />
+		<rom name="Mickey no Racing Challenge USA (Japan).z64" size="33554432" crc="1aecfc56" md5="288a514e98972bf9d329167aa29e66b6" sha1="5b4f7bad6591de2199c095352a811a2eb7fc6f53" serial="NMLJ" />
 	</game>
-	<game name="Mickey's Speedway USA (USA)" cloneof="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)">
+	<game name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)" id="0432">
+		<description>Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="0ae51ea5" md5="5ba3dc37860c08a209f24286b8dfec8c" sha1="c583ed998a6b422a22ffd3f8376c3cef0c3710d9" sha256="2e5e4836c0ede78c7d81da352584172102f5d4f26f187e991f624dc70cbf308e" status="verified" serial="NMLP" />
+	</game>
+	<game name="Mickey's Speedway USA (USA)" id="0433" cloneofid="0432">
 		<description>Mickey's Speedway USA (USA)</description>
 		<rom name="Mickey's Speedway USA (USA).n64" />
-		<release name="Mickey's Speedway USA (USA)" region="USA" />
-		<rom name="Mickey's Speedway USA (USA).z64" size="33554432" crc="2d4f8f1b" md5="0bf64427cf68e49c70e9ec2c9d815209" sha1="507341c0a40ca3e9a7cee969b396ee53facfb548" status="verified" />
+		<rom name="Mickey's Speedway USA (USA).z64" size="33554432" crc="2d4f8f1b" md5="0bf64427cf68e49c70e9ec2c9d815209" sha1="507341c0a40ca3e9a7cee969b396ee53facfb548" sha256="21c0c73d97d578dbf750acfa2a03ac2e224f703d8b9fc4e431356a27b46cf026" status="verified" serial="NMLE" />
 	</game>
-	<game name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)">
+	<game name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)" id="0434">
 		<description>Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)</description>
 		<rom name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="10b9ff1f" md5="9a8465e302263d635557a14aa197fe3c" sha1="e5e2d6169af2663e5519795b28bec018934e86ee" />
+		<rom name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="10b9ff1f" md5="9a8465e302263d635557a14aa197fe3c" sha1="e5e2d6169af2663e5519795b28bec018934e86ee" sha256="591ace6eb8ab7c8328a16de545b3baa38230fe31f4c388c88acc94996785feb6" status="verified" serial="NV3P" />
 	</game>
-	<game name="Micro Machines 64 Turbo (USA)" cloneof="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)">
+	<game name="Micro Machines 64 Turbo (USA)" id="0435" cloneofid="0434">
 		<description>Micro Machines 64 Turbo (USA)</description>
 		<rom name="Micro Machines 64 Turbo (USA).n64" />
-		<release name="Micro Machines 64 Turbo (USA)" region="USA" />
-		<rom name="Micro Machines 64 Turbo (USA).z64" size="12582912" crc="a62a2763" md5="74eb415e16c333b252847a8e09432fd9" sha1="9672fa010a06adf01074c9720ee46031f5d9e101" />
+		<rom name="Micro Machines 64 Turbo (USA).z64" size="12582912" crc="a62a2763" md5="74eb415e16c333b252847a8e09432fd9" sha1="9672fa010a06adf01074c9720ee46031f5d9e101" serial="NV3E" />
 	</game>
-	<game name="Midway's Greatest Arcade Hits - Volume 1 (USA)">
+	<game name="Midway's Greatest Arcade Hits - Volume 1 (USA)" id="0436">
 		<description>Midway's Greatest Arcade Hits - Volume 1 (USA)</description>
 		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA).n64" />
-		<release name="Midway's Greatest Arcade Hits - Volume 1 (USA)" region="USA" />
-		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA).z64" size="4194304" crc="e5c1fedc" md5="2b86775ea4d848202e4f4a39c33571ca" sha1="e24c61aaa5cf15112258052ec78d24ad047ba5ae" />
+		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA).z64" size="4194304" crc="e5c1fedc" md5="2b86775ea4d848202e4f4a39c33571ca" sha1="e24c61aaa5cf15112258052ec78d24ad047ba5ae" serial="NAIE" />
 	</game>
-	<game name="Mike Piazza's Strike Zone (USA)">
+	<game name="Midway's Greatest Arcade Hits - Volume 1 (USA) (LodgeNet)" id="1149" cloneofid="0436">
+		<category>Games</category>
+		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA) (LodgeNet).n64" />
+		<description>Midway's Greatest Arcade Hits - Volume 1 (USA) (LodgeNet)</description>
+		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA) (LodgeNet).i64" size="64" crc="ecd08883" md5="46b62795678d47432ff6d567cf42095a" sha1="7ece35ed1c97dfc8c1364dbf5f4a08475237dd45" />
+		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA) (LodgeNet).z64" size="4194304" crc="f3c48bb7" md5="93a6e228baf65682501442582e2e0e8d" sha1="a36131328ad707800f6841289cdede17b3b9ee16" />
+	</game>
+	<game name="Mike Piazza's Strike Zone (USA)" id="0437">
 		<description>Mike Piazza's Strike Zone (USA)</description>
 		<rom name="Mike Piazza's Strike Zone (USA).n64" />
-		<release name="Mike Piazza's Strike Zone (USA)" region="USA" />
-		<rom name="Mike Piazza's Strike Zone (USA).z64" size="12582912" crc="cc253cab" md5="eb1908e51c8d10af8b9caf77797bfe00" sha1="09c90701261e345c0023c55b61b37e6aaf809e57" />
+		<rom name="Mike Piazza's Strike Zone (USA).z64" size="12582912" crc="cc253cab" md5="eb1908e51c8d10af8b9caf77797bfe00" sha1="09c90701261e345c0023c55b61b37e6aaf809e57" sha256="3ba45ed9af91bb99ac30d59bc278c872f482ed5a13a475c711c02315c187b0ca" serial="NMBE" />
 	</game>
-	<game name="Milo's Astro Lanes (Europe)">
+	<game name="Milo's Astro Lanes (Europe)" id="0438">
 		<description>Milo's Astro Lanes (Europe)</description>
 		<rom name="Milo's Astro Lanes (Europe).n64" />
-		<release name="Milo's Astro Lanes (Europe)" region="EUR" />
-		<rom name="Milo's Astro Lanes (Europe).z64" size="4194304" crc="c08ce624" md5="43b02af2789990a14f77ce020e6f135c" sha1="77da41c16cd8989291a82159a15ce98d155916a6" />
+		<rom name="Milo's Astro Lanes (Europe).z64" size="4194304" crc="c08ce624" md5="43b02af2789990a14f77ce020e6f135c" sha1="77da41c16cd8989291a82159a15ce98d155916a6" sha256="c66522df27baed11ac5caf126820bef22c92d6602b25acfc369a5bd1afe39c64" status="verified" serial="NBRP" />
 	</game>
-	<game name="Milo's Astro Lanes (USA)" cloneof="Milo's Astro Lanes (Europe)">
+	<game name="Milo's Astro Lanes (USA)" id="0439" cloneofid="0438">
 		<description>Milo's Astro Lanes (USA)</description>
 		<rom name="Milo's Astro Lanes (USA).n64" />
-		<release name="Milo's Astro Lanes (USA)" region="USA" />
-		<rom name="Milo's Astro Lanes (USA).z64" size="4194304" crc="172fca97" md5="4f256146bac4a3dde5ad0d5f9c909251" sha1="7a0246e367ff84b46c0bec9a6b760d3b67b13041" />
+		<rom name="Milo's Astro Lanes (USA).z64" size="4194304" crc="172fca97" md5="4f256146bac4a3dde5ad0d5f9c909251" sha1="7a0246e367ff84b46c0bec9a6b760d3b67b13041" sha256="5e2901b55a23f748c013257e9697a4b63ed3cc24504b809fb7964c538bd75380" serial="NBRE" />
 	</game>
-	<game name="Mini Racers (USA) (Ja) (Proto)">
+	<game name="Mini Racers (USA) (Ja) (Proto)" id="0923">
 		<description>Mini Racers (USA) (Ja) (Proto)</description>
 		<rom name="Mini Racers (USA) (Ja) (Proto).n64" />
-		<release name="Mini Racers (USA) (Ja) (Proto)" region="USA" />
-		<rom name="Mini Racers (USA) (Ja) (Proto).z64" size="16777216" crc="f59f881b" md5="9c6cf9d3cb5852439de4ef4a399253b9" sha1="109c1960a060cdab0da75e336195ffa15f111d23" />
+		<rom name="Mini Racers (USA) (Ja) (Proto).z64" size="16777216" crc="f59f881b" md5="9c6cf9d3cb5852439de4ef4a399253b9" sha1="109c1960a060cdab0da75e336195ffa15f111d23" serial="!none" />
 	</game>
-	<game name="Tamiya Racing 64 (USA) (Proto)" cloneof="Mini Racers (USA) (Ja) (Proto)">
-		<description>Tamiya Racing 64 (USA) (Proto)</description>
-		<rom name="Tamiya Racing 64 (USA) (Proto).n64" />
-		<rom name="Tamiya Racing 64 (USA) (Proto).z64" size="16777216" crc="1b4c53fa" md5="cecab8df02c02f38c9cf1bdd57b1da00" sha1="be11aa2170fb3900379b127241161833400bf58c" />
-	</game>
-	<game name="Mischief Makers (Europe)">
+	<game name="Mischief Makers (Europe)" id="0440">
 		<description>Mischief Makers (Europe)</description>
 		<rom name="Mischief Makers (Europe).n64" />
-		<release name="Mischief Makers (Europe)" region="EUR" />
-		<rom name="Mischief Makers (Europe).z64" size="8388608" crc="68a4f072" md5="eb3b078a74d4dc827e1e79791004dfbb" sha1="e5405aad683959edab641b5da05b8159cac93e63" />
+		<rom name="Mischief Makers (Europe).z64" size="8388608" crc="68a4f072" md5="eb3b078a74d4dc827e1e79791004dfbb" sha1="e5405aad683959edab641b5da05b8159cac93e63" sha256="b1fc1d0d8cd36ffaf49870ab52879987e3d34226ae007839252d7a514a3fbf57" status="verified" serial="NTMP" />
 	</game>
-	<game name="Mischief Makers (USA)" cloneof="Mischief Makers (Europe)">
+	<game name="Mischief Makers (USA)" id="0441" cloneofid="0440">
 		<description>Mischief Makers (USA)</description>
 		<rom name="Mischief Makers (USA).n64" />
-		<rom name="Mischief Makers (USA).z64" size="8388608" crc="7d222d3f" md5="495a9bffd6620be43225db7133373fc5" sha1="5eb5a9d6f413a379fe297fe1542d21f728393a27" />
+		<rom name="Mischief Makers (USA).z64" size="8388608" crc="7d222d3f" md5="495a9bffd6620be43225db7133373fc5" sha1="5eb5a9d6f413a379fe297fe1542d21f728393a27" serial="NTME" />
 	</game>
-	<game name="Mischief Makers (USA) (Rev 1)" cloneof="Mischief Makers (Europe)">
+	<game name="Mischief Makers (USA) (Rev 1)" id="0890" cloneofid="0440">
 		<description>Mischief Makers (USA) (Rev 1)</description>
 		<rom name="Mischief Makers (USA) (Rev 1).n64" />
-		<release name="Mischief Makers (USA) (Rev 1)" region="USA" />
-		<rom name="Mischief Makers (USA) (Rev 1).z64" size="8388608" crc="c3300cef" md5="2ee917366f64a06472d7622a2a05990e" sha1="811709c6473f74cbf283aa61f056e1de3046ec73" />
+		<rom name="Mischief Makers (USA) (Rev 1).z64" size="8388608" crc="c3300cef" md5="2ee917366f64a06472d7622a2a05990e" sha1="811709c6473f74cbf283aa61f056e1de3046ec73" serial="NTME" />
 	</game>
-	<game name="Yuke Yuke!! Trouble Makers (Japan)" cloneof="Mischief Makers (Europe)">
-		<description>Yuke Yuke!! Trouble Makers (Japan)</description>
-		<rom name="Yuke Yuke!! Trouble Makers (Japan).n64" />
-		<release name="Yuke Yuke!! Trouble Makers (Japan)" region="JPN" />
-		<rom name="Yuke Yuke!! Trouble Makers (Japan).z64" size="8388608" crc="b69d3068" md5="2ae35bdf163613024d876a09f25063f3" sha1="039a75636c34d219d489d0a84a671d00dc23e7c4" />
-	</game>
-	<game name="Mission - Impossible (Europe)">
+	<game name="Mission - Impossible (Europe)" id="0442">
 		<description>Mission - Impossible (Europe)</description>
 		<rom name="Mission - Impossible (Europe).n64" />
-		<release name="Mission - Impossible (Europe)" region="EUR" />
-		<rom name="Mission - Impossible (Europe).z64" size="12582912" crc="2c7131d6" md5="599b5d40b51f53c2c9a909e0139702fc" sha1="1a406d19f527d1e394fa140290fde04d81d3e639" status="verified" />
+		<rom name="Mission - Impossible (Europe).z64" size="12582912" crc="2c7131d6" md5="599b5d40b51f53c2c9a909e0139702fc" sha1="1a406d19f527d1e394fa140290fde04d81d3e639" status="verified" serial="NMIP" />
 	</game>
-	<game name="Mission - Impossible (France)" cloneof="Mission - Impossible (Europe)">
+	<game name="Mission - Impossible (France)" id="0443" cloneofid="0442">
 		<description>Mission - Impossible (France)</description>
 		<rom name="Mission - Impossible (France).n64" />
-		<release name="Mission - Impossible (France)" region="FRA" />
-		<rom name="Mission - Impossible (France).z64" size="12582912" crc="282a350d" md5="fd0c0e8c523437f9b6b630e369fdfc69" sha1="ea934f931124db891f12e92726faae5edde39c45" />
+		<rom name="Mission - Impossible (France).z64" size="12582912" crc="282a350d" md5="fd0c0e8c523437f9b6b630e369fdfc69" sha1="ea934f931124db891f12e92726faae5edde39c45" sha256="c587e1a98f879b08f9f98325b1aaddd4717c48f4eb1586ff36ef59f642863a1b" status="verified" serial="NMIF" />
 	</game>
-	<game name="Mission - Impossible (Germany)" cloneof="Mission - Impossible (Europe)">
+	<game name="Mission - Impossible (Germany)" id="0444" cloneofid="0442">
 		<description>Mission - Impossible (Germany)</description>
 		<rom name="Mission - Impossible (Germany).n64" />
-		<release name="Mission - Impossible (Germany)" region="GER" />
-		<rom name="Mission - Impossible (Germany).z64" size="12582912" crc="67c30a2d" md5="4111482c92ee806484aaa2c210893a52" sha1="906ffab2f8e8eece17e0846ffbd9ea32370206da" />
+		<rom name="Mission - Impossible (Germany).z64" size="12582912" crc="67c30a2d" md5="4111482c92ee806484aaa2c210893a52" sha1="906ffab2f8e8eece17e0846ffbd9ea32370206da" serial="NMID" />
 	</game>
-	<game name="Mission - Impossible (Italy)" cloneof="Mission - Impossible (Europe)">
+	<game name="Mission - Impossible (Italy)" id="0445" cloneofid="0442">
 		<description>Mission - Impossible (Italy)</description>
 		<rom name="Mission - Impossible (Italy).n64" />
-		<release name="Mission - Impossible (Italy)" region="ITA" />
-		<rom name="Mission - Impossible (Italy).z64" size="12582912" crc="2d789d98" md5="66c7eb8148e0714b5a71f5717dff8642" sha1="9ee0e754b7afaf751df281b9411ec1d8f30a894d" />
+		<rom name="Mission - Impossible (Italy).z64" size="12582912" crc="2d789d98" md5="66c7eb8148e0714b5a71f5717dff8642" sha1="9ee0e754b7afaf751df281b9411ec1d8f30a894d" serial="NMII" />
 	</game>
-	<game name="Mission - Impossible (Spain)" cloneof="Mission - Impossible (Europe)">
+	<game name="Mission - Impossible (Spain)" id="0446" cloneofid="0442">
 		<description>Mission - Impossible (Spain)</description>
 		<rom name="Mission - Impossible (Spain).n64" />
-		<rom name="Mission - Impossible (Spain).z64" size="12582912" crc="ebb060dc" md5="d1ba3b1899576a4b67908abb6544d75a" sha1="d79c313b8581b558dbeca29f797d91a8b3122841" />
+		<rom name="Mission - Impossible (Spain).z64" size="12582912" crc="ebb060dc" md5="d1ba3b1899576a4b67908abb6544d75a" sha1="d79c313b8581b558dbeca29f797d91a8b3122841" sha256="b12cb258396a66a5881a364ba460e508573655f98490304f5b8a223c26943f60" status="verified" serial="NMIS" />
 	</game>
-	<game name="Mission - Impossible (USA)" cloneof="Mission - Impossible (Europe)">
+	<game name="Mission - Impossible (USA)" id="0447" cloneofid="0442">
 		<description>Mission - Impossible (USA)</description>
 		<rom name="Mission - Impossible (USA).n64" />
-		<release name="Mission - Impossible (USA)" region="USA" />
-		<rom name="Mission - Impossible (USA).z64" size="12582912" crc="3677a8b8" md5="eebdfbd7cb57202d70cfffcaaf55e93e" sha1="7546d5df1fc93fed8205a066f1333fd7dd50c1e1" />
+		<rom name="Mission - Impossible (USA).z64" size="12582912" crc="3677a8b8" md5="eebdfbd7cb57202d70cfffcaaf55e93e" sha1="7546d5df1fc93fed8205a066f1333fd7dd50c1e1" sha256="3e82a0ca1dd758d4aa633fb06edb5314fad9b23d52156168ff4b8d1cc4569b16" status="verified" serial="NMIE" />
 	</game>
-	<game name="Mission - Impossible (Spain) (Rev 1)" cloneof="Mission - Impossible (Europe)">
+	<game name="Mission - Impossible (Spain) (Rev 1)" id="1034" cloneofid="0442">
 		<description>Mission - Impossible (Spain) (Rev 1)</description>
 		<rom name="Mission - Impossible (Spain) (Rev 1).n64" />
-		<release name="Mission - Impossible (Spain) (Rev 1)" region="SPA" />
-		<rom name="Mission - Impossible (Spain) (Rev 1).z64" size="12582912" crc="e1c470fd" md5="16a3143dc0e5fe6639f49db7a51d24d4" sha1="e195bde1941f16f5bc693dcc4e47d63e770b18eb" />
+		<rom name="Mission - Impossible (Spain) (Rev 1).z64" size="12582912" crc="e1c470fd" md5="16a3143dc0e5fe6639f49db7a51d24d4" sha1="e195bde1941f16f5bc693dcc4e47d63e770b18eb" serial="NMIS" />
 	</game>
-	<game name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)">
-		<description>Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)</description>
-		<rom name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).n64" />
-		<release name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)" region="EUR" />
-		<rom name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).z64" size="16777216" crc="3f5e5830" md5="c93a17d130b96fba27a0e959cab2a450" sha1="39a7f5515dd822a32c0fc8d9e01a72f0c8b2a1f7" />
+	<game name="Mission - Impossible (Europe) (Beta)" id="1113" cloneofid="0442">
+		<category>Games</category>
+		<rom name="Mission - Impossible (Europe) (Beta).n64" />
+		<description>Mission - Impossible (Europe) (Beta)</description>
+		<rom name="Mission - Impossible (Europe) (Beta).z64" size="12582912" crc="6bf87502" md5="c1b7c20f64364206ac8525c797113754" sha1="a40b54566b93088400e8588778e9237620895600" sha256="66a7b6106fe1b527a96a204886e6ff45e9025b14e64387454140cef4cf22d850" serial="NMIP" />
 	</game>
-	<game name="Monaco Grand Prix (USA)" cloneof="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)">
+	<game name="Monaco Grand Prix (USA)" id="0448" cloneofid="0449">
 		<description>Monaco Grand Prix (USA)</description>
 		<rom name="Monaco Grand Prix (USA).n64" />
-		<release name="Monaco Grand Prix (USA)" region="USA" />
-		<rom name="Monaco Grand Prix (USA).z64" size="16777216" crc="e2bbeac1" md5="4ff9589a3224aaa46e9877d6b25e68e3" sha1="477f945dc38f930336e0d05cfdcba2c4c30f6a31" />
+		<rom name="Monaco Grand Prix (USA).z64" size="16777216" crc="e2bbeac1" md5="4ff9589a3224aaa46e9877d6b25e68e3" sha1="477f945dc38f930336e0d05cfdcba2c4c30f6a31" serial="NMGE" />
 	</game>
-	<game name="Racing Simulation 2 (Germany)" cloneof="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)">
-		<description>Racing Simulation 2 (Germany)</description>
-		<rom name="Racing Simulation 2 (Germany).n64" />
-		<release name="Racing Simulation 2 (Germany)" region="GER" />
-		<rom name="Racing Simulation 2 (Germany).z64" size="16777216" crc="ba73a7e4" md5="aa57d69867f53456f351a289eba08c3d" sha1="08bc64cb8c64db9b048fc1522fd5e808ff63ce1a" />
+	<game name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)" id="0449">
+		<description>Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)</description>
+		<rom name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).n64" />
+		<rom name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).z64" size="16777216" crc="3f5e5830" md5="c93a17d130b96fba27a0e959cab2a450" sha1="39a7f5515dd822a32c0fc8d9e01a72f0c8b2a1f7" sha256="c328e2350bae9828779b89283751f1b30318fe5e1625e1bbe848359e2b2c8f02" status="verified" serial="NMGP" />
 	</game>
-	<game name="Monopoly (USA)">
+	<game name="Monopoly (USA)" id="0450">
 		<description>Monopoly (USA)</description>
 		<rom name="Monopoly (USA).n64" />
-		<release name="Monopoly (USA)" region="USA" />
-		<rom name="Monopoly (USA).z64" size="8388608" crc="c8cad8f6" md5="d51506edb0a941a00eb45850703b32cb" sha1="fd724bdc323aa81d4873768acf789529cc1c08e5" />
+		<rom name="Monopoly (USA).z64" size="8388608" crc="c8cad8f6" md5="d51506edb0a941a00eb45850703b32cb" sha1="fd724bdc323aa81d4873768acf789529cc1c08e5" serial="NMOE" />
 	</game>
-	<game name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)">
+	<game name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)" id="0451">
 		<description>Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)</description>
 		<rom name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="4731df5c" md5="e3b408997d7db91f8219f168c6d57d26" sha1="a702b0616030bfc5feb78feaf365eab74f1a8b6e" status="verified" />
+		<rom name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="4731df5c" md5="e3b408997d7db91f8219f168c6d57d26" sha1="a702b0616030bfc5feb78feaf365eab74f1a8b6e" sha256="eb84ef801d3723c3709fc62b5551c5cc83887015d4831392039e99f236eb0c76" status="verified" serial="NM3P" />
 	</game>
-	<game name="Monster Truck Madness 64 (USA)" cloneof="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)">
+	<game name="Monster Truck Madness 64 (USA)" id="0452" cloneofid="0451">
 		<description>Monster Truck Madness 64 (USA)</description>
 		<rom name="Monster Truck Madness 64 (USA).n64" />
-		<release name="Monster Truck Madness 64 (USA)" region="USA" />
-		<rom name="Monster Truck Madness 64 (USA).z64" size="8388608" crc="3fd0604d" md5="514d61d3b3d5e6326869783eb2e84a00" sha1="f8c7ae14df7341881346b1ceaf838d2219291279" />
+		<rom name="Monster Truck Madness 64 (USA).z64" size="8388608" crc="3fd0604d" md5="514d61d3b3d5e6326869783eb2e84a00" sha1="f8c7ae14df7341881346b1ceaf838d2219291279" sha256="52501f827a677df01ba3861b1f4616c7e6bb47dc000e174267c8fbed9e4ae3dd" serial="NM3E" />
 	</game>
-	<game name="Morita Shougi 64 (Japan)">
+	<game name="Morita Shougi 64 (Japan)" id="0453">
 		<description>Morita Shougi 64 (Japan)</description>
 		<rom name="Morita Shougi 64 (Japan).n64" />
-		<release name="Morita Shougi 64 (Japan)" region="JPN" />
-		<rom name="Morita Shougi 64 (Japan).z64" size="8388608" crc="88c83511" md5="462b9c4f38758c2e558312ac60df2b91" sha1="d079ae0f578032347541b7eae8935907c8ab79e3" />
+		<rom name="Morita Shougi 64 (Japan).z64" size="8388608" crc="88c83511" md5="462b9c4f38758c2e558312ac60df2b91" sha1="d079ae0f578032347541b7eae8935907c8ab79e3" serial="NMSJ" />
 	</game>
-	<game name="Mortal Kombat 4 (Europe)">
+	<game name="Mortal Kombat 4 (Europe)" id="0454">
 		<description>Mortal Kombat 4 (Europe)</description>
 		<rom name="Mortal Kombat 4 (Europe).n64" />
-		<release name="Mortal Kombat 4 (Europe)" region="EUR" />
-		<rom name="Mortal Kombat 4 (Europe).z64" size="16777216" crc="635adeca" md5="264b82f0fc2431d6eefde9c9f3ed7596" sha1="34a25cc52f0d2b5ff3a65552f9d43d8714a8e10c" />
+		<rom name="Mortal Kombat 4 (Europe).z64" size="16777216" crc="635adeca" md5="264b82f0fc2431d6eefde9c9f3ed7596" sha1="34a25cc52f0d2b5ff3a65552f9d43d8714a8e10c" sha256="9bf17deaf7a7beabccb285ccf6e0394cbeb2cc88dcc390efdc2a79ef20e79f34" status="verified" serial="NM4P" />
 	</game>
-	<game name="Mortal Kombat 4 (USA)" cloneof="Mortal Kombat 4 (Europe)">
+	<game name="Mortal Kombat 4 (USA)" id="0455" cloneofid="0454">
 		<description>Mortal Kombat 4 (USA)</description>
 		<rom name="Mortal Kombat 4 (USA).n64" />
-		<release name="Mortal Kombat 4 (USA)" region="USA" />
-		<rom name="Mortal Kombat 4 (USA).z64" size="16777216" crc="b7f46516" md5="c70b91430866300ce38b49098019ef9d" sha1="f47d05bbd1bcadddff2ec7a21bc2e795cbef9f9b" status="verified" />
+		<rom name="Mortal Kombat 4 (USA).z64" size="16777216" crc="b7f46516" md5="c70b91430866300ce38b49098019ef9d" sha1="f47d05bbd1bcadddff2ec7a21bc2e795cbef9f9b" sha256="ea908a1f790340dc34f1056c4799f7d0984048d90344607f2910d96abf036478" status="verified" serial="NM4E" />
 	</game>
-	<game name="Mortal Kombat Mythologies - Sub-Zero (Europe)">
+	<game name="Mortal Kombat 4 (USA) (LodgeNet)" id="1150" cloneofid="0454">
+		<category>Games</category>
+		<rom name="Mortal Kombat 4 (USA) (LodgeNet).n64" />
+		<description>Mortal Kombat 4 (USA) (LodgeNet)</description>
+		<rom name="Mortal Kombat 4 (USA) (LodgeNet).i64" size="64" crc="d8b7a45d" md5="10a21b65a0e82bce0952c281370b893a" sha1="11c67fab63842aa58dc9bb41535d1924222d5a54" />
+		<rom name="Mortal Kombat 4 (USA) (LodgeNet).z64" size="16777216" crc="ea494c11" md5="08157e5657048aa90783d772d2940e1f" sha1="535429836cfd4b6f533dd6dda540a19286613518" />
+	</game>
+	<game name="Mortal Kombat Mythologies - Sub-Zero (Europe)" id="0456">
 		<description>Mortal Kombat Mythologies - Sub-Zero (Europe)</description>
 		<rom name="Mortal Kombat Mythologies - Sub-Zero (Europe).n64" />
-		<release name="Mortal Kombat Mythologies - Sub-Zero (Europe)" region="EUR" />
-		<rom name="Mortal Kombat Mythologies - Sub-Zero (Europe).z64" size="16777216" crc="ea21015a" md5="38a82a56ae61a4d354c6a26e64d25e1c" sha1="e674e0f08d7218136f31ca99a9c5323f0d2bb4d4" />
+		<rom name="Mortal Kombat Mythologies - Sub-Zero (Europe).z64" size="16777216" crc="ea21015a" md5="38a82a56ae61a4d354c6a26e64d25e1c" sha1="e674e0f08d7218136f31ca99a9c5323f0d2bb4d4" sha256="619ab0dae6d2fcdf785167231786c6a743d0fe9081b269d57dc005b7d00fa86a" status="verified" serial="NMYP" />
 	</game>
-	<game name="Mortal Kombat Mythologies - Sub-Zero (USA)" cloneof="Mortal Kombat Mythologies - Sub-Zero (Europe)">
+	<game name="Mortal Kombat Mythologies - Sub-Zero (USA)" id="0457" cloneofid="0456">
 		<description>Mortal Kombat Mythologies - Sub-Zero (USA)</description>
 		<rom name="Mortal Kombat Mythologies - Sub-Zero (USA).n64" />
-		<release name="Mortal Kombat Mythologies - Sub-Zero (USA)" region="USA" />
-		<rom name="Mortal Kombat Mythologies - Sub-Zero (USA).z64" size="16777216" crc="51a07fd9" md5="deec4faec416f4e02d934c2e42c0caad" sha1="ef3df4e1496260d44c44ab7dd145751141f11c60" />
+		<rom name="Mortal Kombat Mythologies - Sub-Zero (USA).z64" size="16777216" crc="51a07fd9" md5="deec4faec416f4e02d934c2e42c0caad" sha1="ef3df4e1496260d44c44ab7dd145751141f11c60" serial="NMYE" />
 	</game>
-	<game name="Mortal Kombat Trilogy (Europe)">
+	<game name="Mortal Kombat Trilogy (Europe)" id="0458">
 		<description>Mortal Kombat Trilogy (Europe)</description>
 		<rom name="Mortal Kombat Trilogy (Europe).n64" />
-		<release name="Mortal Kombat Trilogy (Europe)" region="EUR" />
-		<rom name="Mortal Kombat Trilogy (Europe).z64" size="12582912" crc="bc04c62f" md5="7a558bbad8ce8828414a9cf3b044a87d" sha1="5796aaf21bfa0e8532ef225ba4be3b39eef1be63" />
+		<rom name="Mortal Kombat Trilogy (Europe).z64" size="12582912" crc="bc04c62f" md5="7a558bbad8ce8828414a9cf3b044a87d" sha1="5796aaf21bfa0e8532ef225ba4be3b39eef1be63" sha256="4159adfdaf27068353c899d785ebdefea2a58ad9708a723b3dabbdb2cc8fb810" status="verified" serial="NMKP" />
 	</game>
-	<game name="Mortal Kombat Trilogy (USA)" cloneof="Mortal Kombat Trilogy (Europe)">
+	<game name="Mortal Kombat Trilogy (USA)" id="0459" cloneofid="0458">
 		<description>Mortal Kombat Trilogy (USA)</description>
 		<rom name="Mortal Kombat Trilogy (USA).n64" />
-		<rom name="Mortal Kombat Trilogy (USA).z64" size="12582912" crc="50a99d60" md5="9b7f29aab911d6753f2011c48da752bf" sha1="39b3cb20417c503f1c047d5037df814d1ccf90dd" />
+		<rom name="Mortal Kombat Trilogy (USA).z64" size="12582912" crc="50a99d60" md5="9b7f29aab911d6753f2011c48da752bf" sha1="39b3cb20417c503f1c047d5037df814d1ccf90dd" serial="NMKE" />
 	</game>
-	<game name="Mortal Kombat Trilogy (USA) (Rev 2)" cloneof="Mortal Kombat Trilogy (Europe)">
+	<game name="Mortal Kombat Trilogy (USA) (Rev 2)" id="0460" cloneofid="0458">
 		<description>Mortal Kombat Trilogy (USA) (Rev 2)</description>
 		<rom name="Mortal Kombat Trilogy (USA) (Rev 2).n64" />
-		<release name="Mortal Kombat Trilogy (USA) (Rev 2)" region="USA" />
-		<rom name="Mortal Kombat Trilogy (USA) (Rev 2).z64" size="12582912" crc="0f323d00" md5="3dcb15043063bd656a0223c519218cfb" sha1="11f2488b21f9f7185c25905dd02c2955c35ad5c1" />
+		<rom name="Mortal Kombat Trilogy (USA) (Rev 2).z64" size="12582912" crc="0f323d00" md5="3dcb15043063bd656a0223c519218cfb" sha1="11f2488b21f9f7185c25905dd02c2955c35ad5c1" serial="NMKE" />
 	</game>
-	<game name="Mortal Kombat Trilogy (USA) (Rev 1)" cloneof="Mortal Kombat Trilogy (Europe)">
+	<game name="Mortal Kombat Trilogy (USA) (Rev 1)" id="0888" cloneofid="0458">
 		<description>Mortal Kombat Trilogy (USA) (Rev 1)</description>
 		<rom name="Mortal Kombat Trilogy (USA) (Rev 1).n64" />
-		<rom name="Mortal Kombat Trilogy (USA) (Rev 1).z64" size="12582912" crc="ba64f824" md5="26129419799db01bfe79f279ec43b334" sha1="2a10cb20332beaa067d61e5923cd18bedd6436d7" />
+		<rom name="Mortal Kombat Trilogy (USA) (Rev 1).z64" size="12582912" crc="ba64f824" md5="26129419799db01bfe79f279ec43b334" sha1="2a10cb20332beaa067d61e5923cd18bedd6436d7" serial="NMKE" />
 	</game>
-	<game name="Mortal Kombat Trilogy (USA) (Beta) (1996-05-13)" cloneof="Mortal Kombat Trilogy (Europe)">
-		<description>Mortal Kombat Trilogy (USA) (Beta) (1996-05-13)</description>
-		<rom name="Mortal Kombat Trilogy (USA) (Beta) (1996-05-13).n64" />
-		<rom name="Mortal Kombat Trilogy (USA) (Beta) (1996-05-13).z64" size="16777216" crc="eab22c06" md5="b6a7b85c123df4e0b9cc118578dbc9a2" sha1="2f95ce7f8233f1df82e0ad39ad5ba6a5ebfb6db7" />
+	<game name="Mortal Kombat Trilogy (USA) (1996-05-13) (Beta)" id="1024" cloneofid="0458">
+		<description>Mortal Kombat Trilogy (USA) (1996-05-13) (Beta)</description>
+		<rom name="Mortal Kombat Trilogy (USA) (1996-05-13) (Beta).n64" />
+		<rom name="Mortal Kombat Trilogy (USA) (1996-05-13) (Beta).z64" size="16777216" crc="eab22c06" md5="b6a7b85c123df4e0b9cc118578dbc9a2" sha1="2f95ce7f8233f1df82e0ad39ad5ba6a5ebfb6db7" />
 	</game>
-	<game name="MRC - Multi-Racing Championship (Europe) (En,Fr,De)">
+	<game name="MRC - Multi-Racing Championship (Europe) (En,Fr,De)" id="0461">
 		<description>MRC - Multi-Racing Championship (Europe) (En,Fr,De)</description>
 		<rom name="MRC - Multi-Racing Championship (Europe) (En,Fr,De).n64" />
-		<release name="MRC - Multi-Racing Championship (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="MRC - Multi-Racing Championship (Europe) (En,Fr,De).z64" size="12582912" crc="bc966b10" md5="0054b7fc0c2acbed650efe727cdba472" sha1="6d8600a1326c39b4b80bb1d4a6500c3f0c6202a1" />
+		<rom name="MRC - Multi-Racing Championship (Europe) (En,Fr,De).z64" size="12582912" crc="bc966b10" md5="0054b7fc0c2acbed650efe727cdba472" sha1="6d8600a1326c39b4b80bb1d4a6500c3f0c6202a1" sha256="7d9e4554abd1c360f9af32ff72c6be47d8f67ce3f08e1c8ffef0ea8aa70ad622" status="verified" serial="NMRP" />
 	</game>
-	<game name="MRC - Multi-Racing Championship (Japan)" cloneof="MRC - Multi-Racing Championship (Europe) (En,Fr,De)">
+	<game name="MRC - Multi-Racing Championship (Japan)" id="0462" cloneofid="0461">
 		<description>MRC - Multi-Racing Championship (Japan)</description>
 		<rom name="MRC - Multi-Racing Championship (Japan).n64" />
-		<release name="MRC - Multi-Racing Championship (Japan)" region="JPN" />
-		<rom name="MRC - Multi-Racing Championship (Japan).z64" size="12582912" crc="bea43300" md5="8e18064a2c4b3ec15a20c3d676644b3a" sha1="b0992a8029622df74d3165814aa40df19a14b4a4" />
+		<rom name="MRC - Multi-Racing Championship (Japan).z64" size="12582912" crc="bea43300" md5="8e18064a2c4b3ec15a20c3d676644b3a" sha1="b0992a8029622df74d3165814aa40df19a14b4a4" serial="NMRJ" />
 	</game>
-	<game name="MRC - Multi-Racing Championship (USA)" cloneof="MRC - Multi-Racing Championship (Europe) (En,Fr,De)">
+	<game name="MRC - Multi-Racing Championship (USA)" id="0463" cloneofid="0461">
 		<description>MRC - Multi-Racing Championship (USA)</description>
 		<rom name="MRC - Multi-Racing Championship (USA).n64" />
-		<release name="MRC - Multi-Racing Championship (USA)" region="USA" />
-		<rom name="MRC - Multi-Racing Championship (USA).z64" size="12582912" crc="1dc1c812" md5="fc61d60f2c6fe4610f70ce4949a7a062" sha1="8bea68833d63b2f17daad4477a572c274a9468be" />
+		<rom name="MRC - Multi-Racing Championship (USA).z64" size="12582912" crc="1dc1c812" md5="fc61d60f2c6fe4610f70ce4949a7a062" sha1="8bea68833d63b2f17daad4477a572c274a9468be" sha256="5729e822337b7dfac5ae81210f1c2e3bfa739b90dfc8182d9e573a4990dd14d9" status="verified" serial="NMRE" />
 	</game>
-	<game name="Ms. Pac-Man - Maze Madness (USA)">
+	<game name="Ms. Pac-Man - Maze Madness (USA)" id="0464">
 		<description>Ms. Pac-Man - Maze Madness (USA)</description>
 		<rom name="Ms. Pac-Man - Maze Madness (USA).n64" />
-		<release name="Ms. Pac-Man - Maze Madness (USA)" region="USA" />
-		<rom name="Ms. Pac-Man - Maze Madness (USA).z64" size="12582912" crc="e34c7060" md5="08bea3310e778a6584eb64cd3f15f86e" sha1="99028c738b5ac5ff99d73698b50d14f5e58ddea7" />
+		<rom name="Ms. Pac-Man - Maze Madness (USA).z64" size="12582912" crc="e34c7060" md5="08bea3310e778a6584eb64cd3f15f86e" sha1="99028c738b5ac5ff99d73698b50d14f5e58ddea7" serial="NP9E" />
 	</game>
-	<game name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)">
+	<game name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)" id="0465">
 		<description>Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)</description>
 		<rom name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De).n64" />
-		<release name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De).z64" size="16777216" crc="3502dbbe" md5="e6b5c17b7bbbb7c432b3506c085d16c4" sha1="aadd1d7e943cbfa5496a370158b5f8fe17b06415" />
+		<rom name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De).z64" size="16777216" crc="3502dbbe" md5="e6b5c17b7bbbb7c432b3506c085d16c4" sha1="aadd1d7e943cbfa5496a370158b5f8fe17b06415" sha256="f5f308d6c0fcec49570c91f20ed27729266c6fdaffef445331b11aba7032db9b" status="verified" serial="NGMP" />
 	</game>
-	<game name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)" cloneof="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)">
-		<description>Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)</description>
-		<rom name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).n64" />
-		<release name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)" region="JPN" />
-		<rom name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).z64" size="16777216" crc="08c41e0e" md5="96ca36d474e82c270a129d775c63167a" sha1="2ab71b71665a688d40832e16d897548ece9f0dd4" />
-	</game>
-	<game name="Goemon's Great Adventure (USA)" cloneof="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)">
-		<description>Goemon's Great Adventure (USA)</description>
-		<rom name="Goemon's Great Adventure (USA).n64" />
-		<release name="Goemon's Great Adventure (USA)" region="USA" />
-		<rom name="Goemon's Great Adventure (USA).z64" size="16777216" crc="52d418e1" md5="29bc5c1a24d3979d376ad421000ac9cb" sha1="9f9e860816f9e2a68bb5f4f56086e0c7450c64d7" />
-	</game>
-	<game name="Mystical Ninja Starring Goemon (Europe)">
+	<game name="Mystical Ninja Starring Goemon (Europe)" id="0466">
 		<description>Mystical Ninja Starring Goemon (Europe)</description>
 		<rom name="Mystical Ninja Starring Goemon (Europe).n64" />
-		<release name="Mystical Ninja Starring Goemon (Europe)" region="EUR" />
-		<rom name="Mystical Ninja Starring Goemon (Europe).z64" size="16777216" crc="3bd9059a" md5="698930c7ccd844673d77ffeccb3dd66e" sha1="f7304934ba4e8d98a71500c249bacb168bca5af0" status="verified" />
+		<rom name="Mystical Ninja Starring Goemon (Europe).z64" size="16777216" crc="3bd9059a" md5="698930c7ccd844673d77ffeccb3dd66e" sha1="f7304934ba4e8d98a71500c249bacb168bca5af0" sha256="e051aeff5600e184394ea08f4eed7c295255f729279a8b5ef450014520cc2f02" status="verified" serial="NG5P" />
 	</game>
-	<game name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)" cloneof="Mystical Ninja Starring Goemon (Europe)">
-		<description>Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)</description>
-		<rom name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).n64" />
-		<release name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)" region="JPN" />
-		<rom name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).z64" size="16777216" crc="2e91efc9" md5="9b929e0bf8d63e62820f2fa6257cc5cf" sha1="9843ee979b5f6c80f5eda85df0baed9ae7c4e73b" />
-	</game>
-	<game name="Mystical Ninja Starring Goemon (USA)" cloneof="Mystical Ninja Starring Goemon (Europe)">
+	<game name="Mystical Ninja Starring Goemon (USA)" id="0467" cloneofid="0466">
 		<description>Mystical Ninja Starring Goemon (USA)</description>
 		<rom name="Mystical Ninja Starring Goemon (USA).n64" />
-		<release name="Mystical Ninja Starring Goemon (USA)" region="USA" />
-		<rom name="Mystical Ninja Starring Goemon (USA).z64" size="16777216" crc="4180c296" md5="643cce1ab06f97e9590241d27e5c2363" sha1="df8083a54296b8c151917c5333e1c85f014a2a66" />
+		<rom name="Mystical Ninja Starring Goemon (USA).z64" size="16777216" crc="4180c296" md5="643cce1ab06f97e9590241d27e5c2363" sha1="df8083a54296b8c151917c5333e1c85f014a2a66" serial="NG5E" />
 	</game>
-	<game name="Nagano Winter Olympics '98 (Europe)">
+	<game name="Nagano Winter Olympics '98 (Europe)" id="0468">
 		<description>Nagano Winter Olympics '98 (Europe)</description>
 		<rom name="Nagano Winter Olympics '98 (Europe).n64" />
-		<release name="Nagano Winter Olympics '98 (Europe)" region="EUR" />
-		<rom name="Nagano Winter Olympics '98 (Europe).z64" size="12582912" crc="c44de11c" md5="b935b87f3dcca8aeeb6a9365124846dc" sha1="8faca645020857b87ed3842bd26cccbdf31bec39" />
+		<rom name="Nagano Winter Olympics '98 (Europe).z64" size="12582912" crc="c44de11c" md5="b935b87f3dcca8aeeb6a9365124846dc" sha1="8faca645020857b87ed3842bd26cccbdf31bec39" sha256="a84cc56686cce0a09f7c1a3a35db71a9015521d628e079099e8721669bebb324" status="verified" serial="NH5P" />
 	</game>
-	<game name="Hyper Olympics in Nagano 64 (Japan)" cloneof="Nagano Winter Olympics '98 (Europe)">
-		<description>Hyper Olympics in Nagano 64 (Japan)</description>
-		<rom name="Hyper Olympics in Nagano 64 (Japan).n64" />
-		<release name="Hyper Olympics in Nagano 64 (Japan)" region="JPN" />
-		<rom name="Hyper Olympics in Nagano 64 (Japan).z64" size="12582912" crc="c1ea5d33" md5="d2f7b3ace75a2ce7a06beac929711d94" sha1="3d0f36371f99c8abc8e835dae4e0913757ee4827" />
-	</game>
-	<game name="Nagano Winter Olympics '98 (USA)" cloneof="Nagano Winter Olympics '98 (Europe)">
+	<game name="Nagano Winter Olympics '98 (USA)" id="0469" cloneofid="0468">
 		<description>Nagano Winter Olympics '98 (USA)</description>
 		<rom name="Nagano Winter Olympics '98 (USA).n64" />
-		<release name="Nagano Winter Olympics '98 (USA)" region="USA" />
-		<rom name="Nagano Winter Olympics '98 (USA).z64" size="12582912" crc="ee8288d4" md5="c17f78a103d99b21533f0c1566378ef6" sha1="eaf543e195731031a84f4136b506449209e3a8f5" />
+		<rom name="Nagano Winter Olympics '98 (USA).z64" size="12582912" crc="ee8288d4" md5="c17f78a103d99b21533f0c1566378ef6" sha1="eaf543e195731031a84f4136b506449209e3a8f5" serial="NH5E" />
 	</game>
-	<game name="Namco Museum 64 (USA)">
+	<game name="Namco Museum 64 (USA)" id="0470">
 		<description>Namco Museum 64 (USA)</description>
 		<rom name="Namco Museum 64 (USA).n64" />
-		<release name="Namco Museum 64 (USA)" region="USA" />
-		<rom name="Namco Museum 64 (USA).z64" size="4194304" crc="ce361f92" md5="e61251d2819e3bf3a9c0b95329f60f70" sha1="a934e08f80778111d1bc03caf0a170a2d8c4e6a7" />
+		<rom name="Namco Museum 64 (USA).z64" size="4194304" crc="ce361f92" md5="e61251d2819e3bf3a9c0b95329f60f70" sha1="a934e08f80778111d1bc03caf0a170a2d8c4e6a7" sha256="f62aa0a6de87c0d1a3a862bccea0c1be377112accf421e525c0b3752ae85eca9" serial="NNME" />
 	</game>
-	<game name="NASCAR 2000 (USA)">
+	<game name="NASCAR 2000 (USA)" id="0471">
 		<description>NASCAR 2000 (USA)</description>
 		<rom name="NASCAR 2000 (USA).n64" />
-		<release name="NASCAR 2000 (USA)" region="USA" />
-		<rom name="NASCAR 2000 (USA).z64" size="12582912" crc="02bf7c2d" md5="45feb0fbbec6cb48ff21deae176e9b6b" sha1="36cd848be9196c9e04eb3a9b0371a04afc8baea3" />
+		<rom name="NASCAR 2000 (USA).z64" size="12582912" crc="02bf7c2d" md5="45feb0fbbec6cb48ff21deae176e9b6b" sha1="36cd848be9196c9e04eb3a9b0371a04afc8baea3" serial="NN2E" />
 	</game>
-	<game name="NASCAR 99 (Europe) (En,Fr,De)">
+	<game name="NASCAR 99 (Europe) (En,Fr,De)" id="0472">
 		<description>NASCAR 99 (Europe) (En,Fr,De)</description>
 		<rom name="NASCAR 99 (Europe) (En,Fr,De).n64" />
-		<release name="NASCAR 99 (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="NASCAR 99 (Europe) (En,Fr,De).z64" size="12582912" crc="76e79cea" md5="15a87a6d01dba1a7c4375ffbc1214bb8" sha1="cb43ee3d86a7b85befec8d068d72192fa8174eb0" />
+		<rom name="NASCAR 99 (Europe) (En,Fr,De).z64" size="12582912" crc="76e79cea" md5="15a87a6d01dba1a7c4375ffbc1214bb8" sha1="cb43ee3d86a7b85befec8d068d72192fa8174eb0" sha256="148a7acb816c844c99af9289237666b7a421d24c7722616ad38f401006864e55" status="verified" serial="N9CP" />
 	</game>
-	<game name="NASCAR 99 (USA)" cloneof="NASCAR 99 (Europe) (En,Fr,De)">
+	<game name="NASCAR 99 (USA)" id="0473" cloneofid="0472">
 		<description>NASCAR 99 (USA)</description>
 		<rom name="NASCAR 99 (USA).n64" />
-		<release name="NASCAR 99 (USA)" region="USA" />
-		<rom name="NASCAR 99 (USA).z64" size="12582912" crc="3d8eb950" md5="dc5f1a814c8423b4b43f71c229d65a84" sha1="0fbbaeb4c286d45d27c977d5722e38415efd1a74" />
+		<rom name="NASCAR 99 (USA).z64" size="12582912" crc="3d8eb950" md5="dc5f1a814c8423b4b43f71c229d65a84" sha1="0fbbaeb4c286d45d27c977d5722e38415efd1a74" sha256="800aa25d7b0275db5214bf81c6a537aa45f3ea7e01872fdf515c32cfbb6413bd" status="verified" serial="N9CE" />
 	</game>
-	<game name="NBA Courtside 2 featuring Kobe Bryant (USA)">
+	<game name="NBA Courtside 2 featuring Kobe Bryant (USA)" id="0474">
 		<description>NBA Courtside 2 featuring Kobe Bryant (USA)</description>
 		<rom name="NBA Courtside 2 featuring Kobe Bryant (USA).n64" />
-		<release name="NBA Courtside 2 featuring Kobe Bryant (USA)" region="USA" />
-		<rom name="NBA Courtside 2 featuring Kobe Bryant (USA).z64" size="16777216" crc="a7cc4ce2" md5="73bb54ffd3c0fc71f941d9a8cc57e2a1" sha1="8c27333189fc19570bc494bc3ed9e3879d6e54be" />
+		<rom name="NBA Courtside 2 featuring Kobe Bryant (USA).z64" size="16777216" crc="a7cc4ce2" md5="73bb54ffd3c0fc71f941d9a8cc57e2a1" sha1="8c27333189fc19570bc494bc3ed9e3879d6e54be" sha256="11967ed55a7369170d62910bc9b8df2a65ae6a9bd96983dee91cd5f005ca47d3" serial="NCKE" />
 	</game>
-	<game name="NBA Hangtime (Europe)">
+	<game name="NBA Hangtime (Europe)" id="0475">
 		<description>NBA Hangtime (Europe)</description>
 		<rom name="NBA Hangtime (Europe).n64" />
-		<release name="NBA Hangtime (Europe)" region="EUR" />
-		<rom name="NBA Hangtime (Europe).z64" size="12582912" crc="7e6d00ae" md5="62365463743857cfc823978e0e590d84" sha1="2bcbdd92ccb4c72757739d32557098f4eec36312" />
+		<rom name="NBA Hangtime (Europe).z64" size="12582912" crc="7e6d00ae" md5="62365463743857cfc823978e0e590d84" sha1="2bcbdd92ccb4c72757739d32557098f4eec36312" sha256="7d98514e3f3e5c3b64882bc3a8d3644c8b8383b41bd63aafc9834ce487eb61e7" status="verified" serial="NXGP" />
 	</game>
-	<game name="NBA Hangtime (USA)" cloneof="NBA Hangtime (Europe)">
+	<game name="NBA Hangtime (USA)" id="0476" cloneofid="0475">
 		<description>NBA Hangtime (USA)</description>
 		<rom name="NBA Hangtime (USA).n64" />
-		<release name="NBA Hangtime (USA)" region="USA" />
-		<rom name="NBA Hangtime (USA).z64" size="12582912" crc="714cf532" md5="dc15fcbeae0f1fef7bee141d77bb25a0" sha1="3c96741db636938f140e9592ad34e93ac25c7762" />
+		<rom name="NBA Hangtime (USA).z64" size="12582912" crc="714cf532" md5="dc15fcbeae0f1fef7bee141d77bb25a0" sha1="3c96741db636938f140e9592ad34e93ac25c7762" sha256="6e1304d5bf8922a652f4063f9d26120ac8c3e9af2a5f8a4f4bc733cf003edf83" serial="NXGE" />
 	</game>
-	<game name="NBA in the Zone 2000 (Europe)">
-		<description>NBA in the Zone 2000 (Europe)</description>
-		<rom name="NBA in the Zone 2000 (Europe).n64" />
-		<release name="NBA in the Zone 2000 (Europe)" region="EUR" />
-		<rom name="NBA in the Zone 2000 (Europe).z64" size="16777216" crc="a4973197" md5="4244cc48674c26bd848718c05688f821" sha1="255aadf60e9de652247bb1f7c63b50415d6c4354" />
-	</game>
-	<game name="NBA in the Zone 2000 (USA)" cloneof="NBA in the Zone 2000 (Europe)">
-		<description>NBA in the Zone 2000 (USA)</description>
-		<rom name="NBA in the Zone 2000 (USA).n64" />
-		<release name="NBA in the Zone 2000 (USA)" region="USA" />
-		<rom name="NBA in the Zone 2000 (USA).z64" size="16777216" crc="cbb4b730" md5="1942833ac1a71be8bae74bbdfd6de278" sha1="7e838c203f29336cbdaba77051ebe48d9eae798d" />
-	</game>
-	<game name="NBA Jam 2000 (Europe)">
-		<description>NBA Jam 2000 (Europe)</description>
-		<rom name="NBA Jam 2000 (Europe).n64" />
-		<release name="NBA Jam 2000 (Europe)" region="EUR" />
-		<rom name="NBA Jam 2000 (Europe).z64" size="16777216" crc="9f95485e" md5="604feb17258044a3e6c3aa9d2c5b62f9" sha1="a91c52ac8af8de6172411c5bf8e57f5795be7f78" status="verified" />
-	</game>
-	<game name="NBA Jam 2000 (USA)" cloneof="NBA Jam 2000 (Europe)">
-		<description>NBA Jam 2000 (USA)</description>
-		<rom name="NBA Jam 2000 (USA).n64" />
-		<release name="NBA Jam 2000 (USA)" region="USA" />
-		<rom name="NBA Jam 2000 (USA).z64" size="16777216" crc="163dadf9" md5="afecc9a2df7b1a66a6b7ab3aa8b4bd2e" sha1="94139439d6c234a560fc5d0e5d9c0aa4508fc7b6" />
-	</game>
-	<game name="NBA Jam 99 (Europe)">
-		<description>NBA Jam 99 (Europe)</description>
-		<rom name="NBA Jam 99 (Europe).n64" />
-		<release name="NBA Jam 99 (Europe)" region="EUR" />
-		<rom name="NBA Jam 99 (Europe).z64" size="12582912" crc="90e4275b" md5="be72be370bc0a76d403ff2b9ed2a9173" sha1="cf6c46785b75f9bc1d5b1fd08dafb72dd595f68a" />
-	</game>
-	<game name="NBA Jam 99 (USA)" cloneof="NBA Jam 99 (Europe)">
-		<description>NBA Jam 99 (USA)</description>
-		<rom name="NBA Jam 99 (USA).n64" />
-		<release name="NBA Jam 99 (USA)" region="USA" />
-		<rom name="NBA Jam 99 (USA).z64" size="12582912" crc="559cd6b1" md5="adbe5ca10f659af2be712038e8522704" sha1="2e306d2123ad4220e672d8a07874ca7b515d57e0" />
-	</game>
-	<game name="NBA Live 2000 (Europe) (En,Fr,De,Es)">
-		<description>NBA Live 2000 (Europe) (En,Fr,De,Es)</description>
-		<rom name="NBA Live 2000 (Europe) (En,Fr,De,Es).n64" />
-		<release name="NBA Live 2000 (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="NBA Live 2000 (Europe) (En,Fr,De,Es).z64" size="16777216" crc="0e4b944c" md5="7fec099d1a989d5222d3f9e1a7770404" sha1="d4cb60eb3645ae803a1efc234ceffd8f424dc8f7" />
-	</game>
-	<game name="NBA Live 2000 (USA) (En,Fr,De,Es)" cloneof="NBA Live 2000 (Europe) (En,Fr,De,Es)">
-		<description>NBA Live 2000 (USA) (En,Fr,De,Es)</description>
-		<rom name="NBA Live 2000 (USA) (En,Fr,De,Es).n64" />
-		<release name="NBA Live 2000 (USA) (En,Fr,De,Es)" region="USA" />
-		<rom name="NBA Live 2000 (USA) (En,Fr,De,Es).z64" size="16777216" crc="7c3bc95e" md5="fc47f85cc501c8c5bd9d0ca4db48258f" sha1="4ba671a132125bcaa6552542b7fc2c7f6dc56a0e" />
-	</game>
-	<game name="NBA Live 99 (Europe) (En,Fr,De,Es,It)">
-		<description>NBA Live 99 (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="NBA Live 99 (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="NBA Live 99 (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="NBA Live 99 (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="a316df37" md5="226c19c8759314ac740420ddc3a34eb4" sha1="530ef95c12f0ca73bc4e178a397ce677a57ad858" />
-	</game>
-	<game name="NBA Live 99 (USA) (En,Fr,De,Es,It)" cloneof="NBA Live 99 (Europe) (En,Fr,De,Es,It)">
-		<description>NBA Live 99 (USA) (En,Fr,De,Es,It)</description>
-		<rom name="NBA Live 99 (USA) (En,Fr,De,Es,It).n64" />
-		<release name="NBA Live 99 (USA) (En,Fr,De,Es,It)" region="USA" />
-		<rom name="NBA Live 99 (USA) (En,Fr,De,Es,It).z64" size="16777216" crc="9be0a7ac" md5="dbe79ae6531b491b8f8ee8b2b814d665" sha1="89e47ffac3eae25b37e1a20ce66ca24e343912dd" />
-	</game>
-	<game name="NBA Pro 98 (Europe)">
-		<description>NBA Pro 98 (Europe)</description>
-		<rom name="NBA Pro 98 (Europe).n64" />
-		<release name="NBA Pro 98 (Europe)" region="EUR" />
-		<rom name="NBA Pro 98 (Europe).z64" size="12582912" crc="04b75ccc" md5="a4111a6cddbde0a45489106f0df0ca2b" sha1="94416270d83a87e360bac5059cc5f7365ca120ac" />
-	</game>
-	<game name="NBA in the Zone '98 (Japan)" cloneof="NBA Pro 98 (Europe)">
+	<game name="NBA in the Zone '98 (Japan)" id="0477" cloneofid="0491">
 		<description>NBA in the Zone '98 (Japan)</description>
 		<rom name="NBA in the Zone '98 (Japan).n64" />
-		<release name="NBA in the Zone '98 (Japan)" region="JPN" />
-		<rom name="NBA in the Zone '98 (Japan).z64" size="12582912" crc="aed2700a" md5="4c7a2f4881eaca75dc2fc36673ae2a20" sha1="c4dc9049094100d48a010d39f2901e1ab164a8fa" />
+		<rom name="NBA in the Zone '98 (Japan).z64" size="12582912" crc="aed2700a" md5="4c7a2f4881eaca75dc2fc36673ae2a20" sha1="c4dc9049094100d48a010d39f2901e1ab164a8fa" serial="NBAJ" />
 	</game>
-	<game name="NBA in the Zone '98 (USA)" cloneof="NBA Pro 98 (Europe)">
+	<game name="NBA in the Zone '98 (USA)" id="0478" cloneofid="0491">
 		<description>NBA in the Zone '98 (USA)</description>
 		<rom name="NBA in the Zone '98 (USA).n64" />
-		<release name="NBA in the Zone '98 (USA)" region="USA" />
-		<rom name="NBA in the Zone '98 (USA).z64" size="12582912" crc="a245d737" md5="bbb48be198089a26050c84fe5b7b8bd5" sha1="a306d80f483f8bb5891a543919c53fac61d9348f" />
+		<rom name="NBA in the Zone '98 (USA).z64" size="12582912" crc="a245d737" md5="bbb48be198089a26050c84fe5b7b8bd5" sha1="a306d80f483f8bb5891a543919c53fac61d9348f" serial="NBAE" />
 	</game>
-	<game name="NBA Pro 99 (Europe)">
-		<description>NBA Pro 99 (Europe)</description>
-		<rom name="NBA Pro 99 (Europe).n64" />
-		<release name="NBA Pro 99 (Europe)" region="EUR" />
-		<rom name="NBA Pro 99 (Europe).z64" size="12582912" crc="588e60e8" md5="c5ebbdd41eaea8bd02cf520640ccccdf" sha1="5decf930d859e8b834a5f897955880556ca6aadf" />
-	</game>
-	<game name="NBA in the Zone '99 (USA)" cloneof="NBA Pro 99 (Europe)">
+	<game name="NBA in the Zone '99 (USA)" id="0479" cloneofid="0492">
 		<description>NBA in the Zone '99 (USA)</description>
 		<rom name="NBA in the Zone '99 (USA).n64" />
-		<release name="NBA in the Zone '99 (USA)" region="USA" />
-		<rom name="NBA in the Zone '99 (USA).z64" size="12582912" crc="eab083b8" md5="6cbf4014c053e16852a3db80aeb4c853" sha1="6964baec49592e64c34782b55e234c7bd32c8a99" />
+		<rom name="NBA in the Zone '99 (USA).z64" size="12582912" crc="eab083b8" md5="6cbf4014c053e16852a3db80aeb4c853" sha1="6964baec49592e64c34782b55e234c7bd32c8a99" serial="NB2E" />
 	</game>
-	<game name="NBA in the Zone 2 (Japan)" cloneof="NBA Pro 99 (Europe)">
+	<game name="NBA in the Zone 2 (Japan)" id="0480" cloneofid="0492">
 		<description>NBA in the Zone 2 (Japan)</description>
 		<rom name="NBA in the Zone 2 (Japan).n64" />
-		<release name="NBA in the Zone 2 (Japan)" region="JPN" />
-		<rom name="NBA in the Zone 2 (Japan).z64" size="12582912" crc="41093b73" md5="f8f87aeb2c537c9cb2e9913050bfc928" sha1="a7685c8833256ecd1033862ea077e75147f9c49a" />
+		<rom name="NBA in the Zone 2 (Japan).z64" size="12582912" crc="41093b73" md5="f8f87aeb2c537c9cb2e9913050bfc928" sha1="a7685c8833256ecd1033862ea077e75147f9c49a" serial="NB2J" />
 	</game>
-	<game name="NBA Showtime - NBA on NBC (USA)">
+	<game name="NBA in the Zone 2000 (Europe)" id="0481">
+		<description>NBA in the Zone 2000 (Europe)</description>
+		<rom name="NBA in the Zone 2000 (Europe).n64" />
+		<rom name="NBA in the Zone 2000 (Europe).z64" size="16777216" crc="a4973197" md5="4244cc48674c26bd848718c05688f821" sha1="255aadf60e9de652247bb1f7c63b50415d6c4354" sha256="e419c6695240feb1a1217333ca4ad4778b003fa55a56fa08de2fc63138816713" status="verified" serial="NWZP" />
+	</game>
+	<game name="NBA in the Zone 2000 (USA)" id="0482" cloneofid="0481">
+		<description>NBA in the Zone 2000 (USA)</description>
+		<rom name="NBA in the Zone 2000 (USA).n64" />
+		<rom name="NBA in the Zone 2000 (USA).z64" size="16777216" crc="cbb4b730" md5="1942833ac1a71be8bae74bbdfd6de278" sha1="7e838c203f29336cbdaba77051ebe48d9eae798d" sha256="20abe4f093131dd2c8ab7c694e01734faf4fd28c442a5cbb3054b0ddf42a1f3c" serial="NWZE" />
+	</game>
+	<game name="NBA Jam 2000 (Europe)" id="0483">
+		<description>NBA Jam 2000 (Europe)</description>
+		<rom name="NBA Jam 2000 (Europe).n64" />
+		<rom name="NBA Jam 2000 (Europe).z64" size="16777216" crc="9f95485e" md5="604feb17258044a3e6c3aa9d2c5b62f9" sha1="a91c52ac8af8de6172411c5bf8e57f5795be7f78" sha256="76778e298da9b3929c1659c2374d19df1d542fb2db89ff5be7d53c7dfa267fca" status="verified" serial="NJAP" />
+	</game>
+	<game name="NBA Jam 2000 (USA)" id="0484" cloneofid="0483">
+		<description>NBA Jam 2000 (USA)</description>
+		<rom name="NBA Jam 2000 (USA).n64" />
+		<rom name="NBA Jam 2000 (USA).z64" size="16777216" crc="163dadf9" md5="afecc9a2df7b1a66a6b7ab3aa8b4bd2e" sha1="94139439d6c234a560fc5d0e5d9c0aa4508fc7b6" serial="NJAE" />
+	</game>
+	<game name="NBA Jam 99 (Europe)" id="0485">
+		<description>NBA Jam 99 (Europe)</description>
+		<rom name="NBA Jam 99 (Europe).n64" />
+		<rom name="NBA Jam 99 (Europe).z64" size="12582912" crc="90e4275b" md5="be72be370bc0a76d403ff2b9ed2a9173" sha1="cf6c46785b75f9bc1d5b1fd08dafb72dd595f68a" sha256="f37cf583be0b9b5b94c7b7725ba219b09c90a1e33dc80f77b139fe2ca121c71e" status="verified" serial="NB9P" />
+	</game>
+	<game name="NBA Jam 99 (USA)" id="0486" cloneofid="0485">
+		<description>NBA Jam 99 (USA)</description>
+		<rom name="NBA Jam 99 (USA).n64" />
+		<rom name="NBA Jam 99 (USA).z64" size="12582912" crc="559cd6b1" md5="adbe5ca10f659af2be712038e8522704" sha1="2e306d2123ad4220e672d8a07874ca7b515d57e0" serial="NB9E" />
+	</game>
+	<game name="NBA Jam 99 (USA) (Beta) (1998-09-25)" id="1190" cloneofid="0485">
+		<category>Games</category>
+		<rom name="NBA Jam 99 (USA) (Beta) (1998-09-25).n64" />
+		<category>Preproduction</category>
+		<description>NBA Jam 99 (USA) (Beta) (1998-09-25)</description>
+		<rom name="NBA Jam 99 (USA) (Beta) (1998-09-25).z64" size="16777216" crc="8bf6a686" md5="2fed0445c97a9d293a3fba5c786b2c39" sha1="12d0caed77721df269fe3db96ae1bc9733b9d45f" sha256="ea9305d5d0c1005809552abaf1c18d108bd43967c91b8852b7e8b8f7870c2663" serial="!none" />
+	</game>
+	<game name="NBA Live 2000 (Europe) (En,Fr,De,Es)" id="0487">
+		<description>NBA Live 2000 (Europe) (En,Fr,De,Es)</description>
+		<rom name="NBA Live 2000 (Europe) (En,Fr,De,Es).n64" />
+		<rom name="NBA Live 2000 (Europe) (En,Fr,De,Es).z64" size="16777216" crc="0e4b944c" md5="7fec099d1a989d5222d3f9e1a7770404" sha1="d4cb60eb3645ae803a1efc234ceffd8f424dc8f7" sha256="d0c85a3035687673be6b4c38cfba3728a6c50cf7beee36fc3a8572f4013a512b" status="verified" serial="NNLP" />
+	</game>
+	<game name="NBA Live 2000 (USA) (En,Fr,De,Es)" id="0488" cloneofid="0487">
+		<description>NBA Live 2000 (USA) (En,Fr,De,Es)</description>
+		<rom name="NBA Live 2000 (USA) (En,Fr,De,Es).n64" />
+		<rom name="NBA Live 2000 (USA) (En,Fr,De,Es).z64" size="16777216" crc="7c3bc95e" md5="fc47f85cc501c8c5bd9d0ca4db48258f" sha1="4ba671a132125bcaa6552542b7fc2c7f6dc56a0e" serial="NNLE" />
+	</game>
+	<game name="NBA Live 99 (Europe) (En,Fr,De,Es,It)" id="0489">
+		<description>NBA Live 99 (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="NBA Live 99 (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="NBA Live 99 (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="a316df37" md5="226c19c8759314ac740420ddc3a34eb4" sha1="530ef95c12f0ca73bc4e178a397ce677a57ad858" sha256="f21ddf33f8e597a0b49e1dde2b0d9cf55d2b8fd007cf20a92996a0783f7de411" status="verified" serial="N9BP" />
+	</game>
+	<game name="NBA Live 99 (USA) (En,Fr,De,Es,It)" id="0490" cloneofid="0489">
+		<description>NBA Live 99 (USA) (En,Fr,De,Es,It)</description>
+		<rom name="NBA Live 99 (USA) (En,Fr,De,Es,It).n64" />
+		<rom name="NBA Live 99 (USA) (En,Fr,De,Es,It).z64" size="16777216" crc="9be0a7ac" md5="dbe79ae6531b491b8f8ee8b2b814d665" sha1="89e47ffac3eae25b37e1a20ce66ca24e343912dd" serial="N9BE" />
+	</game>
+	<game name="NBA Pro 98 (Europe)" id="0491">
+		<description>NBA Pro 98 (Europe)</description>
+		<rom name="NBA Pro 98 (Europe).n64" />
+		<rom name="NBA Pro 98 (Europe).z64" size="12582912" crc="04b75ccc" md5="a4111a6cddbde0a45489106f0df0ca2b" sha1="94416270d83a87e360bac5059cc5f7365ca120ac" sha256="90ed10e89d507758551d40e549520228acba39eccd495a4c3088b0e73f6c63c9" status="verified" serial="NBAP" />
+	</game>
+	<game name="NBA Pro 99 (Europe)" id="0492">
+		<description>NBA Pro 99 (Europe)</description>
+		<rom name="NBA Pro 99 (Europe).n64" />
+		<rom name="NBA Pro 99 (Europe).z64" size="12582912" crc="588e60e8" md5="c5ebbdd41eaea8bd02cf520640ccccdf" sha1="5decf930d859e8b834a5f897955880556ca6aadf" sha256="765bb9b7b8f7a5660ac27459b92ef111e58ff710a88ff70599622492f0b2b96e" status="verified" serial="NB2P" />
+	</game>
+	<game name="NBA Showtime - NBA on NBC (USA)" id="0493">
 		<description>NBA Showtime - NBA on NBC (USA)</description>
 		<rom name="NBA Showtime - NBA on NBC (USA).n64" />
-		<release name="NBA Showtime - NBA on NBC (USA)" region="USA" />
-		<rom name="NBA Showtime - NBA on NBC (USA).z64" size="16777216" crc="a4e378f4" md5="881e98b47f32093c330a8b0dad6bb65d" sha1="702d6d55fc23c56b8a57d7348d159098fff98650" />
+		<rom name="NBA Showtime - NBA on NBC (USA).z64" size="16777216" crc="a4e378f4" md5="881e98b47f32093c330a8b0dad6bb65d" sha1="702d6d55fc23c56b8a57d7348d159098fff98650" serial="NSOE" />
 	</game>
-	<game name="Neon Genesis Evangelion (Japan)">
+	<game name="Neon Genesis Evangelion (Japan)" id="0494">
 		<description>Neon Genesis Evangelion (Japan)</description>
 		<rom name="Neon Genesis Evangelion (Japan).n64" />
-		<release name="Neon Genesis Evangelion (Japan)" region="JPN" />
-		<rom name="Neon Genesis Evangelion (Japan).z64" size="33554432" crc="a10a86af" md5="5e1940ca1236a76e8f2d15de0414ae55" sha1="a9ba0a4afeed48080f54aa237850f3676b3d9980" />
+		<rom name="Neon Genesis Evangelion (Japan).z64" size="33554432" crc="a10a86af" md5="5e1940ca1236a76e8f2d15de0414ae55" sha1="a9ba0a4afeed48080f54aa237850f3676b3d9980" serial="NEVJ" />
 	</game>
-	<game name="New Tetris, The (Europe)">
+	<game name="New Tetris, The (Europe)" id="0495">
 		<description>New Tetris, The (Europe)</description>
 		<rom name="New Tetris, The (Europe).n64" />
-		<release name="New Tetris, The (Europe)" region="EUR" />
-		<rom name="New Tetris, The (Europe).z64" size="12582912" crc="983263d7" md5="c4ecfec66eceea23f39632ab6753300f" sha1="2392f403b0993f838912cefa83aefd35d34a05a0" />
+		<rom name="New Tetris, The (Europe).z64" size="12582912" crc="983263d7" md5="c4ecfec66eceea23f39632ab6753300f" sha1="2392f403b0993f838912cefa83aefd35d34a05a0" sha256="1e83aaef23061c68023e3fa3d25ff8b554590fba56c25099079f7d6c55aff7bd" status="verified" serial="NRIP" />
 	</game>
-	<game name="New Tetris, The (USA)" cloneof="New Tetris, The (Europe)">
+	<game name="New Tetris, The (USA)" id="0496" cloneofid="0495">
 		<description>New Tetris, The (USA)</description>
 		<rom name="New Tetris, The (USA).n64" />
-		<release name="New Tetris, The (USA)" region="USA" />
-		<rom name="New Tetris, The (USA).z64" size="12582912" crc="528a07fa" md5="7a28179b00734c9aa0f0609fafaafd5f" sha1="83fff25e82181a6993f28c91b9eeb8430396838b" />
+		<rom name="New Tetris, The (USA).z64" size="12582912" crc="528a07fa" md5="7a28179b00734c9aa0f0609fafaafd5f" sha1="83fff25e82181a6993f28c91b9eeb8430396838b" sha256="ef64737d6b7b668bc9d4c8a0349b70e934bb692f272bc8d3d4831299800bbc39" serial="NRIE" />
 	</game>
-	<game name="NFL Blitz (USA)">
+	<game name="New Tetris, The (USA) (LodgeNet)" id="1151" cloneofid="0495">
+		<category>Games</category>
+		<rom name="New Tetris, The (USA) (LodgeNet).n64" />
+		<description>New Tetris, The (USA) (LodgeNet)</description>
+		<rom name="New Tetris, The (USA) (LodgeNet).i64" size="64" crc="b120d9e4" md5="cebac1b405788c9d1d91294a74f02040" sha1="18ebc23a139eea274333cce9635a2852bcf3ea2a" />
+		<rom name="New Tetris, The (USA) (LodgeNet).z64" size="12582912" crc="d3523b37" md5="ac795288c731d4ac2a5159b3e1580bf4" sha1="cf52ba144788ecc9c1f7cfd61d7878c6173b1ef6" />
+	</game>
+	<game name="NFL Blitz (USA)" id="0497">
 		<description>NFL Blitz (USA)</description>
 		<rom name="NFL Blitz (USA).n64" />
-		<release name="NFL Blitz (USA)" region="USA" />
-		<rom name="NFL Blitz (USA).z64" size="16777216" crc="9bcd670f" md5="7f6c5e71711dec81e77ccf71060f67ca" sha1="2853afd9e38d63d913c8484f546804708c8ad712" />
+		<rom name="NFL Blitz (USA).z64" size="16777216" crc="9bcd670f" md5="7f6c5e71711dec81e77ccf71060f67ca" sha1="2853afd9e38d63d913c8484f546804708c8ad712" sha256="1c37ed9d1d88122dd174b6258fa72b23b404b4c64a259592504392fa7e21e41e" status="verified" serial="NBZE" />
 	</game>
-	<game name="NFL Blitz - Special Edition (USA)">
+	<game name="NFL Blitz - Special Edition (USA)" id="0498">
 		<description>NFL Blitz - Special Edition (USA)</description>
 		<rom name="NFL Blitz - Special Edition (USA).n64" />
-		<release name="NFL Blitz - Special Edition (USA)" region="USA" />
-		<rom name="NFL Blitz - Special Edition (USA).z64" size="16777216" crc="5d1907f7" md5="7e856fa8f743900feba5a4e28c234af7" sha1="a109f44bbb3270205205755ba9a889bafc6ff5ab" />
+		<rom name="NFL Blitz - Special Edition (USA).z64" size="16777216" crc="5d1907f7" md5="7e856fa8f743900feba5a4e28c234af7" sha1="a109f44bbb3270205205755ba9a889bafc6ff5ab" serial="NSZE" />
 	</game>
-	<game name="NFL Blitz 2000 (USA) (Rev 1)">
-		<description>NFL Blitz 2000 (USA) (Rev 1)</description>
-		<rom name="NFL Blitz 2000 (USA) (Rev 1).n64" />
-		<release name="NFL Blitz 2000 (USA) (Rev 1)" region="USA" />
-		<rom name="NFL Blitz 2000 (USA) (Rev 1).z64" size="16777216" crc="b591cfea" md5="dd96bb80e652cd1cf23ca4b8294ba7b5" sha1="3754c8fdf5cdce5de62685ce9be73e06ba5e3577" status="verified" />
-	</game>
-	<game name="NFL Blitz 2000 (USA)" cloneof="NFL Blitz 2000 (USA) (Rev 1)">
+	<game name="NFL Blitz 2000 (USA)" id="0499" cloneofid="0938">
 		<description>NFL Blitz 2000 (USA)</description>
 		<rom name="NFL Blitz 2000 (USA).n64" />
-		<rom name="NFL Blitz 2000 (USA).z64" size="16777216" crc="7f471773" md5="ba49514441023722f02d41c62612f6c3" sha1="36e124746a842a2e1f72480f122dfe9188fc5575" />
+		<rom name="NFL Blitz 2000 (USA).z64" size="16777216" crc="7f471773" md5="ba49514441023722f02d41c62612f6c3" sha1="36e124746a842a2e1f72480f122dfe9188fc5575" sha256="81fd09077c4be225eea90539b0fddc56339b5d1afd7e313b5d08e0c795aeefeb" serial="NBIE" />
 	</game>
-	<game name="NFL Blitz 2001 (USA)">
+	<game name="NFL Blitz 2000 (USA) (Rev 1)" id="0938">
+		<description>NFL Blitz 2000 (USA) (Rev 1)</description>
+		<rom name="NFL Blitz 2000 (USA) (Rev 1).n64" />
+		<rom name="NFL Blitz 2000 (USA) (Rev 1).z64" size="16777216" crc="b591cfea" md5="dd96bb80e652cd1cf23ca4b8294ba7b5" sha1="3754c8fdf5cdce5de62685ce9be73e06ba5e3577" sha256="4f6d18eb5531d3b08aec0e33c942af0babeba4acb02b0dd67d171ca121a2145e" status="verified" serial="NBIE" />
+	</game>
+	<game name="NFL Blitz 2001 (USA)" id="0500">
 		<description>NFL Blitz 2001 (USA)</description>
 		<rom name="NFL Blitz 2001 (USA).n64" />
-		<release name="NFL Blitz 2001 (USA)" region="USA" />
-		<rom name="NFL Blitz 2001 (USA).z64" size="16777216" crc="18eeb41b" md5="e4edd73cb036c6b143cee9aeeed60341" sha1="279bc9ed596663610265a618a1656dbb8ea4237a" />
+		<rom name="NFL Blitz 2001 (USA).z64" size="16777216" crc="18eeb41b" md5="e4edd73cb036c6b143cee9aeeed60341" sha1="279bc9ed596663610265a618a1656dbb8ea4237a" serial="NFBE" />
 	</game>
-	<game name="NFL QB Club 2001 (USA)">
+	<game name="NFL QB Club 2001 (USA)" id="0503">
 		<description>NFL QB Club 2001 (USA)</description>
 		<rom name="NFL QB Club 2001 (USA).n64" />
-		<release name="NFL QB Club 2001 (USA)" region="USA" />
-		<rom name="NFL QB Club 2001 (USA).z64" size="12582912" crc="6d849e17" md5="fd2cbdea0992452b52e2803224232d12" sha1="c81421bb204270ef5ddd8f60dda51cdf73482fe2" />
+		<rom name="NFL QB Club 2001 (USA).z64" size="12582912" crc="6d849e17" md5="fd2cbdea0992452b52e2803224232d12" sha1="c81421bb204270ef5ddd8f60dda51cdf73482fe2" serial="NQCE" />
 	</game>
-	<game name="NFL Quarterback Club 2000 (Europe)">
+	<game name="NFL Quarterback Club 2000 (Europe)" id="0501">
 		<description>NFL Quarterback Club 2000 (Europe)</description>
 		<rom name="NFL Quarterback Club 2000 (Europe).n64" />
-		<release name="NFL Quarterback Club 2000 (Europe)" region="EUR" />
-		<rom name="NFL Quarterback Club 2000 (Europe).z64" size="12582912" crc="ceef5c29" md5="75c0121d84915bf5c1fbd389cf9f9c17" sha1="cd97aece871f0ae5d29af9f92142a470a34273b9" />
+		<rom name="NFL Quarterback Club 2000 (Europe).z64" size="12582912" crc="ceef5c29" md5="75c0121d84915bf5c1fbd389cf9f9c17" sha1="cd97aece871f0ae5d29af9f92142a470a34273b9" sha256="a89fab662762377041fec54f2610b01fc06aaea417d3e03c38695bec428ed6b3" status="verified" serial="NQBP" />
 	</game>
-	<game name="NFL Quarterback Club 2000 (USA)" cloneof="NFL Quarterback Club 2000 (Europe)">
+	<game name="NFL Quarterback Club 2000 (USA)" id="0502" cloneofid="0501">
 		<description>NFL Quarterback Club 2000 (USA)</description>
 		<rom name="NFL Quarterback Club 2000 (USA).n64" />
-		<release name="NFL Quarterback Club 2000 (USA)" region="USA" />
-		<rom name="NFL Quarterback Club 2000 (USA).z64" size="12582912" crc="8f54f999" md5="ec18e3131040842e32ebab66c7496ebd" sha1="390fea44c8df84f601b20a3e506fdd611ab34a8b" />
+		<rom name="NFL Quarterback Club 2000 (USA).z64" size="12582912" crc="8f54f999" md5="ec18e3131040842e32ebab66c7496ebd" sha1="390fea44c8df84f601b20a3e506fdd611ab34a8b" serial="NQBE" />
 	</game>
-	<game name="NFL Quarterback Club 98 (Europe)">
+	<game name="NFL Quarterback Club 98 (Europe)" id="0504">
 		<description>NFL Quarterback Club 98 (Europe)</description>
 		<rom name="NFL Quarterback Club 98 (Europe).n64" />
-		<release name="NFL Quarterback Club 98 (Europe)" region="EUR" />
-		<rom name="NFL Quarterback Club 98 (Europe).z64" size="8388608" crc="34a21417" md5="a18ca5dbc85668667aa467add6a62b39" sha1="1f00635179fb741fbbcf31ffaff399469da16ecf" />
+		<rom name="NFL Quarterback Club 98 (Europe).z64" size="8388608" crc="34a21417" md5="a18ca5dbc85668667aa467add6a62b39" sha1="1f00635179fb741fbbcf31ffaff399469da16ecf" sha256="493a19ce012a9f37dc2a35671e8d4b8d4e60d66963777de3ef4fc7ce30a3b6fb" status="verified" serial="NQ8P" />
 	</game>
-	<game name="NFL Quarterback Club 98 (USA)" cloneof="NFL Quarterback Club 98 (Europe)">
+	<game name="NFL Quarterback Club 98 (USA)" id="0505" cloneofid="0504">
 		<description>NFL Quarterback Club 98 (USA)</description>
 		<rom name="NFL Quarterback Club 98 (USA).n64" />
-		<release name="NFL Quarterback Club 98 (USA)" region="USA" />
-		<rom name="NFL Quarterback Club 98 (USA).z64" size="8388608" crc="abf0e8f2" md5="709f966c30ce6df1833e95740a5a2ab2" sha1="8e53de9eb6dcecb3b0bb3e707ef01690de7efab2" />
+		<rom name="NFL Quarterback Club 98 (USA).z64" size="8388608" crc="abf0e8f2" md5="709f966c30ce6df1833e95740a5a2ab2" sha1="8e53de9eb6dcecb3b0bb3e707ef01690de7efab2" sha256="937c256ee962095dc57aff47e5196004f02b5e70bbc7fb430bad0ad4d8385a95" serial="NQ8E" />
 	</game>
-	<game name="NFL Quarterback Club 99 (Europe)">
+	<game name="NFL Quarterback Club 99 (Europe)" id="0506">
 		<description>NFL Quarterback Club 99 (Europe)</description>
 		<rom name="NFL Quarterback Club 99 (Europe).n64" />
-		<release name="NFL Quarterback Club 99 (Europe)" region="EUR" />
-		<rom name="NFL Quarterback Club 99 (Europe).z64" size="12582912" crc="f688bdf3" md5="7ec0484c2ba6aa9f0a45d7ac1f4117da" sha1="1ee4ebaf6b0c189164397ea257f17b45eedf0767" />
+		<rom name="NFL Quarterback Club 99 (Europe).z64" size="12582912" crc="f688bdf3" md5="7ec0484c2ba6aa9f0a45d7ac1f4117da" sha1="1ee4ebaf6b0c189164397ea257f17b45eedf0767" sha256="c8150c8b97af3871373e19fa9e2f43a266de6a500d55c96a1f9e9a3112565354" status="verified" serial="NQ9P" />
 	</game>
-	<game name="NFL Quarterback Club 99 (USA)" cloneof="NFL Quarterback Club 99 (Europe)">
+	<game name="NFL Quarterback Club 99 (USA)" id="0507" cloneofid="0506">
 		<description>NFL Quarterback Club 99 (USA)</description>
 		<rom name="NFL Quarterback Club 99 (USA).n64" />
-		<release name="NFL Quarterback Club 99 (USA)" region="USA" />
-		<rom name="NFL Quarterback Club 99 (USA).z64" size="12582912" crc="44496b26" md5="928869d1ce001b813ba908dfe18d7f94" sha1="8dba75859d21219b3638e337991851db31b4d70e" />
+		<rom name="NFL Quarterback Club 99 (USA).z64" size="12582912" crc="44496b26" md5="928869d1ce001b813ba908dfe18d7f94" sha1="8dba75859d21219b3638e337991851db31b4d70e" serial="NQ9E" />
 	</game>
-	<game name="NHL 99 (Europe) (En,De,Sv,Fi)">
+	<game name="NHL 99 (Europe) (En,De,Sv,Fi)" id="0508">
 		<description>NHL 99 (Europe) (En,De,Sv,Fi)</description>
 		<rom name="NHL 99 (Europe) (En,De,Sv,Fi).n64" />
-		<release name="NHL 99 (Europe) (En,De,Sv,Fi)" region="EUR" />
-		<rom name="NHL 99 (Europe) (En,De,Sv,Fi).z64" size="12582912" crc="f3b2aa4d" md5="b7e41d34d209b6cfa92e3d622f911c4e" sha1="87cd5ecff93d5b34c246cb96a6249b78b5b90126" />
+		<rom name="NHL 99 (Europe) (En,De,Sv,Fi).z64" size="12582912" crc="f3b2aa4d" md5="b7e41d34d209b6cfa92e3d622f911c4e" sha1="87cd5ecff93d5b34c246cb96a6249b78b5b90126" sha256="1660afff428682d1b4852239bc4fab2e35b2fd14d6c2d9d339269430702df731" status="verified" serial="N9HP" />
 	</game>
-	<game name="NHL 99 (USA)" cloneof="NHL 99 (Europe) (En,De,Sv,Fi)">
+	<game name="NHL 99 (USA)" id="0509" cloneofid="0508">
 		<description>NHL 99 (USA)</description>
 		<rom name="NHL 99 (USA).n64" />
-		<release name="NHL 99 (USA)" region="USA" />
-		<rom name="NHL 99 (USA).z64" size="12582912" crc="e5df2afe" md5="a62fa044bcb5507d358424abda6419db" sha1="d730540d8c447420de4aa81f6a2776c2e310d12a" />
+		<rom name="NHL 99 (USA).z64" size="12582912" crc="e5df2afe" md5="a62fa044bcb5507d358424abda6419db" sha1="d730540d8c447420de4aa81f6a2776c2e310d12a" serial="N9HE" />
 	</game>
-	<game name="NHL Breakaway 98 (Europe)">
-		<description>NHL Breakaway 98 (Europe)</description>
-		<rom name="NHL Breakaway 98 (Europe).n64" />
-		<release name="NHL Breakaway 98 (Europe)" region="EUR" />
-		<rom name="NHL Breakaway 98 (Europe).z64" size="12582912" crc="8c0c9669" md5="46476a5626cd99b3749ac1ee1e234fac" sha1="6d6631fe93b7c70ae28960f4141ac7656b333aa4" />
-	</game>
-	<game name="NHL Breakaway 98 (USA)" cloneof="NHL Breakaway 98 (Europe)">
-		<description>NHL Breakaway 98 (USA)</description>
-		<rom name="NHL Breakaway 98 (USA).n64" />
-		<release name="NHL Breakaway 98 (USA)" region="USA" />
-		<rom name="NHL Breakaway 98 (USA).z64" size="12582912" crc="49d86c00" md5="b62076fa1421b8e7fdec2b4f8a910ea3" sha1="2658334bf4091d0d3ed2de3327592d04fc0b6849" />
-	</game>
-	<game name="NHL Breakaway 99 (Europe)">
-		<description>NHL Breakaway 99 (Europe)</description>
-		<rom name="NHL Breakaway 99 (Europe).n64" />
-		<release name="NHL Breakaway 99 (Europe)" region="EUR" />
-		<rom name="NHL Breakaway 99 (Europe).z64" size="12582912" crc="572060e0" md5="4ba95aa97ecfee36051ebe0a9024eee8" sha1="46147db00bd9d80f0d22e8eb1b00603106de2692" />
-	</game>
-	<game name="NHL Breakaway 99 (USA)" cloneof="NHL Breakaway 99 (Europe)">
-		<description>NHL Breakaway 99 (USA)</description>
-		<rom name="NHL Breakaway 99 (USA).n64" />
-		<release name="NHL Breakaway 99 (USA)" region="USA" />
-		<rom name="NHL Breakaway 99 (USA).z64" size="12582912" crc="75f75b9d" md5="af1d07679014760b88923a4827658caf" sha1="65c0f8bf81d8dec3e5d719b167a61a73b2436e84" />
-	</game>
-	<game name="NHL Pro 99 (Europe)">
-		<description>NHL Pro 99 (Europe)</description>
-		<rom name="NHL Pro 99 (Europe).n64" />
-		<release name="NHL Pro 99 (Europe)" region="EUR" />
-		<rom name="NHL Pro 99 (Europe).z64" size="12582912" crc="e272867e" md5="a61854cf27e536c8513174faef08dfcb" sha1="4ff557ccd19982699b3aa82d4c44f436d1d87f93" />
-	</game>
-	<game name="NHL Blades of Steel '99 (USA)" cloneof="NHL Pro 99 (Europe)">
+	<game name="NHL Blades of Steel '99 (USA)" id="0510" cloneofid="0515">
 		<description>NHL Blades of Steel '99 (USA)</description>
 		<rom name="NHL Blades of Steel '99 (USA).n64" />
-		<release name="NHL Blades of Steel '99 (USA)" region="USA" />
-		<rom name="NHL Blades of Steel '99 (USA).z64" size="12582912" crc="1ee678fe" md5="349f61f9747f2d2098f305924c97a1bf" sha1="c55e9771b1548cfe4297646adcfcafe85712da5e" />
+		<rom name="NHL Blades of Steel '99 (USA).z64" size="12582912" crc="1ee678fe" md5="349f61f9747f2d2098f305924c97a1bf" sha1="c55e9771b1548cfe4297646adcfcafe85712da5e" serial="NHOE" />
 	</game>
-	<game name="Nightmare Creatures (USA)">
+	<game name="NHL Breakaway 98 (Europe)" id="0511">
+		<description>NHL Breakaway 98 (Europe)</description>
+		<rom name="NHL Breakaway 98 (Europe).n64" />
+		<rom name="NHL Breakaway 98 (Europe).z64" size="12582912" crc="8c0c9669" md5="46476a5626cd99b3749ac1ee1e234fac" sha1="6d6631fe93b7c70ae28960f4141ac7656b333aa4" sha256="77d6d4ce6b3f8a116f62b27968e91bbb36dbc93c303b21f3141b40887c3a8a27" status="verified" serial="NHLP" />
+	</game>
+	<game name="NHL Breakaway 98 (USA)" id="0512" cloneofid="0511">
+		<description>NHL Breakaway 98 (USA)</description>
+		<rom name="NHL Breakaway 98 (USA).n64" />
+		<rom name="NHL Breakaway 98 (USA).z64" size="12582912" crc="49d86c00" md5="b62076fa1421b8e7fdec2b4f8a910ea3" sha1="2658334bf4091d0d3ed2de3327592d04fc0b6849" serial="NHLE" />
+	</game>
+	<game name="NHL Breakaway 99 (Europe)" id="0513">
+		<description>NHL Breakaway 99 (Europe)</description>
+		<rom name="NHL Breakaway 99 (Europe).n64" />
+		<rom name="NHL Breakaway 99 (Europe).z64" size="12582912" crc="572060e0" md5="4ba95aa97ecfee36051ebe0a9024eee8" sha1="46147db00bd9d80f0d22e8eb1b00603106de2692" sha256="d43243d318b79cb458ed34e04aa9923eadd6ce1f99df7bdd7d82e00497befb93" status="verified" serial="NH9P" />
+	</game>
+	<game name="NHL Breakaway 99 (USA)" id="0514" cloneofid="0513">
+		<description>NHL Breakaway 99 (USA)</description>
+		<rom name="NHL Breakaway 99 (USA).n64" />
+		<rom name="NHL Breakaway 99 (USA).z64" size="12582912" crc="75f75b9d" md5="af1d07679014760b88923a4827658caf" sha1="65c0f8bf81d8dec3e5d719b167a61a73b2436e84" serial="NH9E" />
+	</game>
+	<game name="NHL Pro 99 (Europe)" id="0515">
+		<description>NHL Pro 99 (Europe)</description>
+		<rom name="NHL Pro 99 (Europe).n64" />
+		<rom name="NHL Pro 99 (Europe).z64" size="12582912" crc="e272867e" md5="a61854cf27e536c8513174faef08dfcb" sha1="4ff557ccd19982699b3aa82d4c44f436d1d87f93" sha256="800dcc787de9fcdb1210b88bc8c23045a4770e7f692222fde039c306c26e5f12" status="verified" serial="NHOP" />
+	</game>
+	<game name="Nightmare Creatures (USA)" id="0516">
 		<description>Nightmare Creatures (USA)</description>
 		<rom name="Nightmare Creatures (USA).n64" />
-		<release name="Nightmare Creatures (USA)" region="USA" />
-		<rom name="Nightmare Creatures (USA).z64" size="16777216" crc="6a1eb795" md5="4116cf435db315a2481af8d1e9352feb" sha1="bea6c21b3ef5950bdf8cdb255955da6c4746eea8" />
+		<rom name="Nightmare Creatures (USA).z64" size="16777216" crc="6a1eb795" md5="4116cf435db315a2481af8d1e9352feb" sha1="bea6c21b3ef5950bdf8cdb255955da6c4746eea8" serial="NNCE" />
 	</game>
-	<game name="Nintama Rantarou 64 Game Gallery (Japan)">
+	<game name="Nintama Rantarou 64 Game Gallery (Japan)" id="0517">
 		<description>Nintama Rantarou 64 Game Gallery (Japan)</description>
 		<rom name="Nintama Rantarou 64 Game Gallery (Japan).n64" />
-		<release name="Nintama Rantarou 64 Game Gallery (Japan)" region="JPN" />
-		<rom name="Nintama Rantarou 64 Game Gallery (Japan).z64" size="8388608" crc="8c7c2dca" md5="b04957d052ef850c5edece69db7377b3" sha1="1bf5217924c5fb00f8e8829e9ebf3fbceb89b9cd" />
+		<rom name="Nintama Rantarou 64 Game Gallery (Japan).z64" size="8388608" crc="8c7c2dca" md5="b04957d052ef850c5edece69db7377b3" sha1="1bf5217924c5fb00f8e8829e9ebf3fbceb89b9cd" status="verified" serial="NHBJ" />
 	</game>
-	<game name="Nuclear Strike 64 (Europe) (En,Fr)">
+	<game name="Nintendo 64 Modem (Japan) (Add-on)" id="1084">
+		<description>Nintendo 64 Modem (Japan) (Add-on)</description>
+		<rom name="Nintendo 64 Modem (Japan) (Add-on).n64" />
+		<rom name="Nintendo 64 Modem (Japan) (Add-on).z64" size="8388608" crc="77d7b7e3" md5="6ebbbe58d717b3b41985be70a8dfe1be" sha1="8373625fb53d888cd8e74f3b1598c2a6577c01d6" sha256="c2c9edaadac5aa6680cd454368941a8553824474e53c1acdf03dc9bf9f3bb210" serial="CMDJ" />
+	</game>
+	<game name="Nintendo All-Star! Dairantou Smash Brothers (Japan)" id="0518" cloneofid="0721">
+		<description>Nintendo All-Star! Dairantou Smash Brothers (Japan)</description>
+		<rom name="Nintendo All-Star! Dairantou Smash Brothers (Japan).n64" />
+		<rom name="Nintendo All-Star! Dairantou Smash Brothers (Japan).z64" size="16777216" crc="04c9d3b1" md5="66db457b130d31a286a23d6e4dd9726e" sha1="4b71f0e01878696733eefa9c80d11c147ecb4984" sha256="527bdd5a36d6f1b90988523ac8d44276e32b44cf93f609ef6d76f399c9733f25" status="verified" serial="NALJ" />
+	</game>
+	<game name="Nuclear Strike 64 (Europe) (En,Fr)" id="0519">
 		<description>Nuclear Strike 64 (Europe) (En,Fr)</description>
 		<rom name="Nuclear Strike 64 (Europe) (En,Fr).n64" />
-		<release name="Nuclear Strike 64 (Europe) (En,Fr)" region="EUR" />
-		<rom name="Nuclear Strike 64 (Europe) (En,Fr).z64" size="33554432" crc="9afbfcaf" md5="710ba49ebd5c9a2b26653fae93bd667a" sha1="34a23cfa247de4e8ecdb8d72431af93d35c69753" />
+		<rom name="Nuclear Strike 64 (Europe) (En,Fr).z64" size="33554432" crc="9afbfcaf" md5="710ba49ebd5c9a2b26653fae93bd667a" sha1="34a23cfa247de4e8ecdb8d72431af93d35c69753" sha256="5e2a6401cc36c760996aa0a49f4e76181a03f723cbe9bc3d555ce320f3a7cd09" status="verified" serial="NCEP" />
 	</game>
-	<game name="Nuclear Strike 64 (Germany)" cloneof="Nuclear Strike 64 (Europe) (En,Fr)">
+	<game name="Nuclear Strike 64 (Germany)" id="0520" cloneofid="0519">
 		<description>Nuclear Strike 64 (Germany)</description>
 		<rom name="Nuclear Strike 64 (Germany).n64" />
-		<release name="Nuclear Strike 64 (Germany)" region="GER" />
-		<rom name="Nuclear Strike 64 (Germany).z64" size="33554432" crc="d175397b" md5="ca996f7a126da8104b806d4c7bfa20b8" sha1="141aafb638f782809943fff526ddb2e542e6df52" />
+		<rom name="Nuclear Strike 64 (Germany).z64" size="33554432" crc="d175397b" md5="ca996f7a126da8104b806d4c7bfa20b8" sha1="141aafb638f782809943fff526ddb2e542e6df52" sha256="66705531964873b3c260a051cb174d40ed64dfd714347d520ac4ee3d4465bf86" serial="NCED" />
 	</game>
-	<game name="Nuclear Strike 64 (USA)" cloneof="Nuclear Strike 64 (Europe) (En,Fr)">
+	<game name="Nuclear Strike 64 (USA)" id="0521" cloneofid="0519">
 		<description>Nuclear Strike 64 (USA)</description>
 		<rom name="Nuclear Strike 64 (USA).n64" />
-		<release name="Nuclear Strike 64 (USA)" region="USA" />
-		<rom name="Nuclear Strike 64 (USA).z64" size="33554432" crc="d7467294" md5="ffc584040d0d052fbab4cb6c19245449" sha1="6a8b0b450e87fbfbadeee3854ada0731deb6e8b5" status="verified" />
+		<rom name="Nuclear Strike 64 (USA).z64" size="33554432" crc="d7467294" md5="ffc584040d0d052fbab4cb6c19245449" sha1="6a8b0b450e87fbfbadeee3854ada0731deb6e8b5" sha256="2f8409ee74e82ede8d71e692ccef39b4bc549caa260083ffe98a5934de808313" status="verified" serial="NCEE" />
 	</game>
-	<game name="Nuclear Strike 64 (Germany) (Beta) (1999-11-17)" cloneof="Nuclear Strike 64 (Europe) (En,Fr)">
-		<description>Nuclear Strike 64 (Germany) (Beta) (1999-11-17)</description>
-		<rom name="Nuclear Strike 64 (Germany) (Beta) (1999-11-17).n64" />
-		<rom name="Nuclear Strike 64 (Germany) (Beta) (1999-11-17).z64" size="33554432" crc="020b6443" md5="aced6f89b3500c618afe47c04f0256e8" sha1="fb1c682546b02b5d76fd83cf5b24e2a3c8285adf" />
+	<game name="Nuclear Strike 64 (Germany) (1999-11-17) (Beta)" id="1052" cloneofid="0519">
+		<description>Nuclear Strike 64 (Germany) (1999-11-17) (Beta)</description>
+		<rom name="Nuclear Strike 64 (Germany) (1999-11-17) (Beta).n64" />
+		<rom name="Nuclear Strike 64 (Germany) (1999-11-17) (Beta).z64" size="33554432" crc="020b6443" md5="aced6f89b3500c618afe47c04f0256e8" sha1="fb1c682546b02b5d76fd83cf5b24e2a3c8285adf" sha256="208f3562cb00621e1a6fac045f2c40d04227ab98ee772827da9eb61f77ceffbc" serial="NCED" />
 	</game>
-	<game name="Nushi Zuri 64 (Japan) (Rev 1)">
-		<description>Nushi Zuri 64 (Japan) (Rev 1)</description>
-		<rom name="Nushi Zuri 64 (Japan) (Rev 1).n64" />
-		<release name="Nushi Zuri 64 (Japan) (Rev 1)" region="JPN" />
-		<rom name="Nushi Zuri 64 (Japan) (Rev 1).z64" size="16777216" crc="16414ae4" md5="d2af6993e4d657d00520c2cce741480e" sha1="a33d47bf0007467c7380c9a37d9a0c30abc67df5" />
+	<game name="Nuclear Strike 64 (USA) (1999-09-21) (Beta)" id="1107" cloneofid="0519">
+		<category>Demos</category>
+		<rom name="Nuclear Strike 64 (USA) (1999-09-21) (Beta).n64" />
+		<description>Nuclear Strike 64 (USA) (1999-09-21) (Beta)</description>
+		<rom name="Nuclear Strike 64 (USA) (1999-09-21) (Beta).z64" size="33554432" crc="a23c4e0c" md5="146e9b9f8ba71f202a89fa011fc7f2ce" sha1="9e4867328ac65bedc3a4058d3f5a82a84898d432" sha256="3a147d27bce3217a066c7b690a9d2c8ef7e12e226a61a72bd008d000568034ce" serial="!none" />
 	</game>
-	<game name="Nushi Zuri 64 (Japan)" cloneof="Nushi Zuri 64 (Japan) (Rev 1)">
+	<game name="Nuclear Strike 64 (USA) (Beta) (Earlier)" id="1108" cloneofid="0519">
+		<category>Games</category>
+		<rom name="Nuclear Strike 64 (USA) (Beta) (Earlier).n64" />
+		<description>Nuclear Strike 64 (USA) (Beta) (Earlier)</description>
+		<rom name="Nuclear Strike 64 (USA) (Beta) (Earlier).z64" size="33554432" crc="b213152c" md5="db01748f770db0085a80d8c9d3d2efa2" sha1="b0f30fadf076c8ea9ab34a4d19834d86eac8487c" sha256="49074f2ba1b9010d35bcf437e0338a90033e5089d4e04bab98ffad07e7ced499" serial="!none" />
+	</game>
+	<game name="Nushi Zuri 64 (Japan)" id="0522" cloneofid="0885">
 		<description>Nushi Zuri 64 (Japan)</description>
 		<rom name="Nushi Zuri 64 (Japan).n64" />
-		<rom name="Nushi Zuri 64 (Japan).z64" size="16777216" crc="a6800ec0" md5="50c10082d0c077fdb5658ef5a6e3f54f" sha1="5f20d41669458e1c981292f17cd8b29032406287" />
+		<rom name="Nushi Zuri 64 (Japan).z64" size="16777216" crc="a6800ec0" md5="50c10082d0c077fdb5658ef5a6e3f54f" sha1="5f20d41669458e1c981292f17cd8b29032406287" sha256="7f422da0e0b90eb7a518c73897ffd08fd8d6dfc0d50498de01d7f3fb4008b9a9" status="verified" serial="NUTJ" />
 	</game>
-	<game name="Nushi Zuri 64 - Shiokaze ni Notte (Japan)">
+	<game name="Nushi Zuri 64 (Japan) (Rev 1)" id="0885">
+		<description>Nushi Zuri 64 (Japan) (Rev 1)</description>
+		<rom name="Nushi Zuri 64 (Japan) (Rev 1).n64" />
+		<rom name="Nushi Zuri 64 (Japan) (Rev 1).z64" size="16777216" crc="16414ae4" md5="d2af6993e4d657d00520c2cce741480e" sha1="a33d47bf0007467c7380c9a37d9a0c30abc67df5" serial="NUTJ" />
+	</game>
+	<game name="Nushi Zuri 64 - Shiokaze ni Notte (Japan)" id="0523">
 		<description>Nushi Zuri 64 - Shiokaze ni Notte (Japan)</description>
 		<rom name="Nushi Zuri 64 - Shiokaze ni Notte (Japan).n64" />
-		<release name="Nushi Zuri 64 - Shiokaze ni Notte (Japan)" region="JPN" />
-		<rom name="Nushi Zuri 64 - Shiokaze ni Notte (Japan).z64" size="33554432" crc="f0bcd1ce" md5="eeb69597e42e2f5d2914070acf161b4f" sha1="85d8b412e3045c7a06062d3e155fef9ea918e800" />
+		<rom name="Nushi Zuri 64 - Shiokaze ni Notte (Japan).z64" size="33554432" crc="f0bcd1ce" md5="eeb69597e42e2f5d2914070acf161b4f" sha1="85d8b412e3045c7a06062d3e155fef9ea918e800" sha256="2143c7b960f65171b2675a3c11249e342b30b0e7e0fa2394cff0863502b546b6" status="verified" serial="NUMJ" />
 	</game>
-	<game name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)">
+	<game name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)" id="0524">
 		<description>O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)</description>
 		<rom name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto).n64" />
-		<release name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)" region="EUR" />
-		<rom name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto).z64" size="16777216" crc="7b870026" md5="e2fb4f16a039a0e302d28aca94d5d928" sha1="092fb7c560b40cc3a2a0e6b48a6afc10948c4166" />
+		<rom name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto).z64" size="16777216" crc="7b870026" md5="e2fb4f16a039a0e302d28aca94d5d928" sha1="092fb7c560b40cc3a2a0e6b48a6afc10948c4166" serial="NTDP" />
 	</game>
-	<game name="O.D.T. (USA) (En,Fr,Es) (Proto)" cloneof="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)">
+	<game name="O.D.T. (USA) (En,Fr,Es) (Proto)" id="0525" cloneofid="0524">
 		<description>O.D.T. (USA) (En,Fr,Es) (Proto)</description>
 		<rom name="O.D.T. (USA) (En,Fr,Es) (Proto).n64" />
-		<release name="O.D.T. (USA) (En,Fr,Es) (Proto)" region="USA" />
-		<rom name="O.D.T. (USA) (En,Fr,Es) (Proto).z64" size="16777216" crc="1d4a8659" md5="4116e492168aafff1bd3100c7b0aa28f" sha1="453a7a636b05c8b9dad6aa6fb5e265baae568074" />
+		<rom name="O.D.T. (USA) (En,Fr,Es) (Proto).z64" size="16777216" crc="1d4a8659" md5="4116e492168aafff1bd3100c7b0aa28f" sha1="453a7a636b05c8b9dad6aa6fb5e265baae568074" serial="NTDE" />
 	</game>
-	<game name="Off Road Challenge (Europe)">
+	<game name="Off Road Challenge (Europe)" id="0526">
 		<description>Off Road Challenge (Europe)</description>
 		<rom name="Off Road Challenge (Europe).n64" />
-		<release name="Off Road Challenge (Europe)" region="EUR" />
-		<rom name="Off Road Challenge (Europe).z64" size="16777216" crc="d9fe9ee7" md5="e96fecba52905db14addad7cfd61091f" sha1="3476e0eb4048c76107bd2b404d19a136bfc15ad9" />
+		<rom name="Off Road Challenge (Europe).z64" size="16777216" crc="d9fe9ee7" md5="e96fecba52905db14addad7cfd61091f" sha1="3476e0eb4048c76107bd2b404d19a136bfc15ad9" sha256="fa8bcf7ca006714b7cd7fa7d91f10e3abadce17ac187c5e8d64699fd7ac9cbe3" status="verified" serial="NOFP" />
 	</game>
-	<game name="Off Road Challenge (USA)" cloneof="Off Road Challenge (Europe)">
+	<game name="Off Road Challenge (USA)" id="0527" cloneofid="0526">
 		<description>Off Road Challenge (USA)</description>
 		<rom name="Off Road Challenge (USA).n64" />
-		<release name="Off Road Challenge (USA)" region="USA" />
-		<rom name="Off Road Challenge (USA).z64" size="16777216" crc="1a45c5ab" md5="af7083fc0abcfd5a2c6a5e971453d831" sha1="9e754ca37d69424e9f82a421d5e69d4ad73046c1" />
+		<rom name="Off Road Challenge (USA).z64" size="16777216" crc="1a45c5ab" md5="af7083fc0abcfd5a2c6a5e971453d831" sha1="9e754ca37d69424e9f82a421d5e69d4ad73046c1" serial="NOFE" />
 	</game>
-	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
-		<description>Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)</description>
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1).n64" />
-		<release name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)" region="USA" />
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1).z64" size="41943040" crc="410f6510" md5="ebb4b4d2808df427aaa3085a41b8a954" sha1="d26b14bee422a09581ce438d45ba9fec9783fbb8" />
-	</game>
-	<game name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1)" cloneof="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
+	<game name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1)" id="0528" cloneofid="0904">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1)</description>
 		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1).n64" />
-		<release name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1)" region="JPN" />
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1).z64" size="41943040" crc="845b8711" md5="a45c39767d33ac21956a3d4e6c03cfa1" sha1="244a92df46863964ec507c78b72c226f48754967" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1).z64" size="41943040" crc="845b8711" md5="a45c39767d33ac21956a3d4e6c03cfa1" sha1="244a92df46863964ec507c78b72c226f48754967" sha256="3747527389273e3bf8de77d9379e60b40ef448115c6c3ccdcf70cc1e8368e957" status="verified" serial="NOBJ" />
 	</game>
-	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA)" cloneof="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
+	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA)" id="0529" cloneofid="0904">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (USA)</description>
 		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA).n64" />
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA).z64" size="41943040" crc="a05aea85" md5="f666e020218392e52662fddfa1ea4f21" sha1="9cd0cfb50b883edb068e0c30d213193b9cf89895" status="verified" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA).z64" size="41943040" crc="a05aea85" md5="f666e020218392e52662fddfa1ea4f21" sha1="9cd0cfb50b883edb068e0c30d213193b9cf89895" sha256="571e83396bc81e70da4c0a20313d82dbd7dfe685f2c37418c8e27f927e2cc67a" status="verified" serial="NOBE" />
 	</game>
-	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console)" cloneof="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
+	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)" id="0904">
+		<description>Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)</description>
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1).n64" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1).z64" size="41943040" crc="410f6510" md5="ebb4b4d2808df427aaa3085a41b8a954" sha1="d26b14bee422a09581ce438d45ba9fec9783fbb8" sha256="3bfbaf0af968795102f6d136713665e347c22723b4ca75bd5494fdc97df5919e" status="verified" serial="NOBE" />
+	</game>
+	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console)" id="1001" cloneofid="0904">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console)</description>
 		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console).n64" />
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console).z64" size="41943040" crc="19337b04" md5="f04c8f511b678301b21c54a27cb08bb9" sha1="604c5bc450d0c33b536c185f53725c2baf622f3b" status="verified" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console).z64" size="41943040" crc="19337b04" md5="f04c8f511b678301b21c54a27cb08bb9" sha1="604c5bc450d0c33b536c185f53725c2baf622f3b" status="verified" serial="NOBE" />
 	</game>
-	<game name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console)" cloneof="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
+	<game name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console)" id="1031" cloneofid="0904">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console)</description>
 		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console).n64" />
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console).z64" size="41943040" crc="991f569c" md5="55cd360f12be8063c9e7b6f59f268170" sha1="127b7a9fdca399494db8409a99874672ca200cb6" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console).z64" size="41943040" crc="991f569c" md5="55cd360f12be8063c9e7b6f59f268170" sha1="127b7a9fdca399494db8409a99874672ca200cb6" serial="NOBJ" />
 	</game>
-	<game name="Olympic Hockey 98 (Europe) (En,Fr,De,Es)">
+	<game name="Olympic Hockey 98 (Europe) (En,Fr,De,Es)" id="0530">
 		<description>Olympic Hockey 98 (Europe) (En,Fr,De,Es)</description>
 		<rom name="Olympic Hockey 98 (Europe) (En,Fr,De,Es).n64" />
-		<release name="Olympic Hockey 98 (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Olympic Hockey 98 (Europe) (En,Fr,De,Es).z64" size="8388608" crc="5a805c2e" md5="465dfd27ddab4f5488f4dadc09b7f938" sha1="e01404fac7e9afc02d48bf889aba51f843165b7c" />
+		<rom name="Olympic Hockey 98 (Europe) (En,Fr,De,Es).z64" size="8388608" crc="5a805c2e" md5="465dfd27ddab4f5488f4dadc09b7f938" sha1="e01404fac7e9afc02d48bf889aba51f843165b7c" sha256="ed472da7692df1685d4ad8938e7d305ec109fe7a5a5072d8a9c03ed6707a8da8" status="verified" serial="NHNP" />
 	</game>
-	<game name="Olympic Hockey 98 (Japan)" cloneof="Olympic Hockey 98 (Europe) (En,Fr,De,Es)">
+	<game name="Olympic Hockey 98 (Japan)" id="0531" cloneofid="0530">
 		<description>Olympic Hockey 98 (Japan)</description>
 		<rom name="Olympic Hockey 98 (Japan).n64" />
-		<release name="Olympic Hockey 98 (Japan)" region="JPN" />
-		<rom name="Olympic Hockey 98 (Japan).z64" size="8388608" crc="9e98fce8" md5="8a964671c5a4f4fc62787f1f25edd70d" sha1="a5359e35839b40c414eae498ca633b28176629aa" />
+		<rom name="Olympic Hockey 98 (Japan).z64" size="8388608" crc="9e98fce8" md5="8a964671c5a4f4fc62787f1f25edd70d" sha1="a5359e35839b40c414eae498ca633b28176629aa" serial="NHNJ" />
 	</game>
-	<game name="Olympic Hockey 98 (USA)" cloneof="Olympic Hockey 98 (Europe) (En,Fr,De,Es)">
+	<game name="Olympic Hockey 98 (USA)" id="0532" cloneofid="0530">
 		<description>Olympic Hockey 98 (USA)</description>
 		<rom name="Olympic Hockey 98 (USA).n64" />
-		<release name="Olympic Hockey 98 (USA)" region="USA" />
-		<rom name="Olympic Hockey 98 (USA).z64" size="8388608" crc="2d777652" md5="9c99c6d9ea98a960056c531cb78eb35b" sha1="02310067defd4c7eac235dff5e71ef0566ce916c" />
+		<rom name="Olympic Hockey 98 (USA).z64" size="8388608" crc="2d777652" md5="9c99c6d9ea98a960056c531cb78eb35b" sha1="02310067defd4c7eac235dff5e71ef0566ce916c" serial="NHNE" />
 	</game>
-	<game name="Onegai Monsters (Japan)">
+	<game name="Onegai Monsters (Japan)" id="0533">
 		<description>Onegai Monsters (Japan)</description>
 		<rom name="Onegai Monsters (Japan).n64" />
-		<release name="Onegai Monsters (Japan)" region="JPN" />
-		<rom name="Onegai Monsters (Japan).z64" size="16777216" crc="ac72a1c7" md5="3796829f54958ce103dcf5e3e8eb80b4" sha1="7592f4c16b8e040539b5dcc201fab2965a5e8c8d" />
+		<rom name="Onegai Monsters (Japan).z64" size="16777216" crc="ac72a1c7" md5="3796829f54958ce103dcf5e3e8eb80b4" sha1="7592f4c16b8e040539b5dcc201fab2965a5e8c8d" serial="NOMJ" />
 	</game>
-	<game name="Operation WinBack (Europe) (En,Fr,De,Es,It)">
+	<game name="Operation WinBack (Europe) (En,Fr,De,Es,It)" id="0534">
 		<description>Operation WinBack (Europe) (En,Fr,De,Es,It)</description>
 		<rom name="Operation WinBack (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Operation WinBack (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Operation WinBack (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="fb96f166" md5="91cf1982f309bd73822165087dad4371" sha1="133f17162b2734286f9e94f64acb1538b11506b2" />
+		<rom name="Operation WinBack (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="fb96f166" md5="91cf1982f309bd73822165087dad4371" sha1="133f17162b2734286f9e94f64acb1538b11506b2" sha256="9f655b00de6a69aefe1f3f66d2e599be2789cc2551746fafc21e1483daf457b6" status="verified" serial="NWDP" />
 	</game>
-	<game name="WinBack (Japan)" cloneof="Operation WinBack (Europe) (En,Fr,De,Es,It)">
-		<description>WinBack (Japan)</description>
-		<rom name="WinBack (Japan).n64" />
-		<rom name="WinBack (Japan).z64" size="16777216" crc="d35360b0" md5="ee3d3550acc463ca57408bf14e541f68" sha1="d6db9e2509b760403f5db330142055af842fb52c" />
-	</game>
-	<game name="WinBack (Japan) (Rev 1)" cloneof="Operation WinBack (Europe) (En,Fr,De,Es,It)">
-		<description>WinBack (Japan) (Rev 1)</description>
-		<rom name="WinBack (Japan) (Rev 1).n64" />
-		<release name="WinBack (Japan) (Rev 1)" region="JPN" />
-		<rom name="WinBack (Japan) (Rev 1).z64" size="16777216" crc="927383bb" md5="9789a48e1d9e42c2f69c59964371089f" sha1="660f8778bc816046e1bcc11e1a975fed5db17410" />
-	</game>
-	<game name="WinBack - Covert Operations (USA)" cloneof="Operation WinBack (Europe) (En,Fr,De,Es,It)">
-		<description>WinBack - Covert Operations (USA)</description>
-		<rom name="WinBack - Covert Operations (USA).n64" />
-		<release name="WinBack - Covert Operations (USA)" region="USA" />
-		<rom name="WinBack - Covert Operations (USA).z64" size="16777216" crc="64c817c5" md5="48da6cdcab838153caa2ecc3dd592a65" sha1="fa04477b321a95e1f7a2edcac5c09bfa6ef72041" />
-	</game>
-	<game name="Pachinko 365 Nichi (Japan)">
+	<game name="Pachinko 365 Nichi (Japan)" id="0535">
 		<description>Pachinko 365 Nichi (Japan)</description>
 		<rom name="Pachinko 365 Nichi (Japan).n64" />
-		<release name="Pachinko 365 Nichi (Japan)" region="JPN" />
-		<rom name="Pachinko 365 Nichi (Japan).z64" size="12582912" crc="42d06e32" md5="d60046c23400bfebd5b051f89e7f2f07" sha1="b8f29e8efcf51ee9a6a16e2a1e60442b4f304950" />
+		<rom name="Pachinko 365 Nichi (Japan).z64" size="12582912" crc="42d06e32" md5="d60046c23400bfebd5b051f89e7f2f07" sha1="b8f29e8efcf51ee9a6a16e2a1e60442b4f304950" sha256="f4af1b9a7a1612722302e7ee7c4b9bce48277c2cdaaedec56aa30b65c079311e" status="verified" serial="NPCJ" />
 	</game>
-	<game name="Paper Mario (Europe) (En,Fr,De,Es)">
+	<game name="Paper Mario (Europe) (En,Fr,De,Es)" id="0536">
 		<description>Paper Mario (Europe) (En,Fr,De,Es)</description>
 		<rom name="Paper Mario (Europe) (En,Fr,De,Es).n64" />
-		<release name="Paper Mario (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Paper Mario (Europe) (En,Fr,De,Es).z64" size="50331648" crc="9fc00ce3" md5="3b5c99f5e7dba06bf8237e58f6d4196b" sha1="1273275142b79f7443f55bd35679a19670adfe3a" status="verified" />
+		<rom name="Paper Mario (Europe) (En,Fr,De,Es).z64" size="50331648" crc="9fc00ce3" md5="3b5c99f5e7dba06bf8237e58f6d4196b" sha1="1273275142b79f7443f55bd35679a19670adfe3a" sha256="5540ccd817201a3f5174295dde7fce7e2a6f79f081209a4b6b7eec7d9c4b88e4" status="verified" serial="NMQP" />
 	</game>
-	<game name="Mario Story (Japan)" cloneof="Paper Mario (Europe) (En,Fr,De,Es)">
-		<description>Mario Story (Japan)</description>
-		<rom name="Mario Story (Japan).n64" />
-		<release name="Mario Story (Japan)" region="JPN" />
-		<rom name="Mario Story (Japan).z64" size="41943040" crc="bd60ca66" md5="df54f17fb84fb5b5bcf6aa9af65b0942" sha1="b9cca3ff260b9ff427d981626b82f96de73586d3" status="verified" />
-	</game>
-	<game name="Paper Mario (USA)" cloneof="Paper Mario (Europe) (En,Fr,De,Es)">
+	<game name="Paper Mario (USA)" id="0537" cloneofid="0536">
 		<description>Paper Mario (USA)</description>
 		<rom name="Paper Mario (USA).n64" />
-		<release name="Paper Mario (USA)" region="USA" />
-		<rom name="Paper Mario (USA).z64" size="41943040" crc="a7f5cd7e" md5="a722f8161ff489943191330bf8416496" sha1="3837f44cda784b466c9a2d99df70d77c322b97a0" status="verified" />
+		<rom name="Paper Mario (USA).z64" size="41943040" crc="a7f5cd7e" md5="a722f8161ff489943191330bf8416496" sha1="3837f44cda784b466c9a2d99df70d77c322b97a0" sha256="9ec6d2a5c2fca81ab86312328779fd042b5f3b920bf65df9f6b87b376883cb5b" status="verified" serial="NMQE" />
 	</game>
-	<game name="Zhi Pian Mario (China) (iQue)" cloneof="Paper Mario (Europe) (En,Fr,De,Es)">
-		<description>Zhi Pian Mario (China) (iQue)</description>
-		<rom name="Zhi Pian Mario (China) (iQue).n64" />
-		<rom name="Zhi Pian Mario (China) (iQue).z64" size="41943040" crc="18c02ad5" md5="8f8f50ab00c4089ae32c6b9fefd69543" sha1="5c724685085eba796537573dd6f84aaddedc8582" />
+	<game name="Paper Mario (USA) (LodgeNet)" id="1152" cloneofid="0536">
+		<category>Games</category>
+		<rom name="Paper Mario (USA) (LodgeNet).n64" />
+		<description>Paper Mario (USA) (LodgeNet)</description>
+		<rom name="Paper Mario (USA) (LodgeNet).i64" size="64" crc="cb9f0acf" md5="9becdb9fb1f0891acf65e8ecd0afecdd" sha1="c0b890b570121defd863c1e01ef076091e0f5b44" />
+		<rom name="Paper Mario (USA) (LodgeNet).z64" size="67108864" crc="f845af4e" md5="09d387fb3898bc993a267dad4b523fb0" sha1="c54905138e67daaddc6def94e76f626c4fbc81f7" />
 	</game>
-	<game name="Paperboy (Europe)">
+	<game name="Paperboy (Europe)" id="0538">
 		<description>Paperboy (Europe)</description>
 		<rom name="Paperboy (Europe).n64" />
-		<release name="Paperboy (Europe)" region="EUR" />
-		<rom name="Paperboy (Europe).z64" size="12582912" crc="f00c5053" md5="b7f2eb7989c9c00096655d087d72ec51" sha1="7db4808042b9651b47592e814ac4c125b51d4d2f" />
+		<rom name="Paperboy (Europe).z64" size="12582912" crc="f00c5053" md5="b7f2eb7989c9c00096655d087d72ec51" sha1="7db4808042b9651b47592e814ac4c125b51d4d2f" sha256="d4fab7f0a04d4c7dfc21ec66d3ae83a65c857bb346549e4a41ee6f2008086efa" status="verified" serial="NYPP" />
 	</game>
-	<game name="Paperboy (USA)" cloneof="Paperboy (Europe)">
+	<game name="Paperboy (USA)" id="0539" cloneofid="0538">
 		<description>Paperboy (USA)</description>
 		<rom name="Paperboy (USA).n64" />
-		<release name="Paperboy (USA)" region="USA" />
-		<rom name="Paperboy (USA).z64" size="12582912" crc="f27114e6" md5="c4cbcb54b010a5a71fe5caa391e5c25f" sha1="b043c47b9758fa6bb289ca7dba2068bda6cafa3a" />
+		<rom name="Paperboy (USA).z64" size="12582912" crc="f27114e6" md5="c4cbcb54b010a5a71fe5caa391e5c25f" sha1="b043c47b9758fa6bb289ca7dba2068bda6cafa3a" sha256="12cc5490a22e4af0fee6d40d15fda0281049860c61a5e30d864a071083191819" serial="NYPE" />
 	</game>
-	<game name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)">
+	<game name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)" id="0540">
 		<description>Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)</description>
 		<rom name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan).n64" />
-		<release name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)" region="JPN" />
-		<rom name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan).z64" size="12582912" crc="a33146e0" md5="d78e10c6b3e98f3b32fe0f23ed72db42" sha1="9887a0e4bfe3c5e85e31638853574069f6c41cd3" />
+		<rom name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan).z64" size="16777216" crc="c5dc4795" md5="0656bb43b3ec505cfa5ae5f93408db8d" sha1="2e4e9d9087cee014cd9d3d048ae50fb22c6d50f1" sha256="bd0a1843c934edadd92e62b7a44793b8c2ce156b6b5688ae7d644a45c2065dea" serial="NPPJ" />
 	</game>
-	<game name="PD Ultraman Battle Collection 64 (Japan)">
+	<game name="PD Ultraman Battle Collection 64 (Japan)" id="0541">
 		<description>PD Ultraman Battle Collection 64 (Japan)</description>
 		<rom name="PD Ultraman Battle Collection 64 (Japan).n64" />
-		<release name="PD Ultraman Battle Collection 64 (Japan)" region="JPN" />
-		<rom name="PD Ultraman Battle Collection 64 (Japan).z64" size="33554432" crc="86cc80b5" md5="52f4f3320607f3e8dd1a16a2f1bfbdb0" sha1="16783d9de1ff772e215f47441612d6805aa98c67" />
+		<rom name="PD Ultraman Battle Collection 64 (Japan).z64" size="33554432" crc="86cc80b5" md5="52f4f3320607f3e8dd1a16a2f1bfbdb0" sha1="16783d9de1ff772e215f47441612d6805aa98c67" serial="NUBJ" />
 	</game>
-	<game name="Penny Racers (Europe)">
+	<game name="Penny Racers (Europe)" id="0542">
 		<description>Penny Racers (Europe)</description>
 		<rom name="Penny Racers (Europe).n64" />
-		<release name="Penny Racers (Europe)" region="EUR" />
-		<rom name="Penny Racers (Europe).z64" size="8388608" crc="a1d6eb5b" md5="20da62ece553ede84d02283174becc8f" sha1="9848cc288b388d23e0ae026ef58da8fc936d7605" />
+		<rom name="Penny Racers (Europe).z64" size="8388608" crc="a1d6eb5b" md5="20da62ece553ede84d02283174becc8f" sha1="9848cc288b388d23e0ae026ef58da8fc936d7605" sha256="c2f4887ee2c9129ac9d550b0e8877fcf9066f56474a82967362df4b561f72487" status="verified" serial="NCRP" />
 	</game>
-	<game name="Choro Q 64 (Japan)" cloneof="Penny Racers (Europe)">
-		<description>Choro Q 64 (Japan)</description>
-		<rom name="Choro Q 64 (Japan).n64" />
-		<release name="Choro Q 64 (Japan)" region="JPN" />
-		<rom name="Choro Q 64 (Japan).z64" size="8388608" crc="231f9284" md5="8287a908e36e79b2d3af0bd22c43ecd9" sha1="288cdbabe30349b70ddd68931e697af03e0d2ee8" />
-	</game>
-	<game name="Penny Racers (USA)" cloneof="Penny Racers (Europe)">
+	<game name="Penny Racers (USA)" id="0543" cloneofid="0542">
 		<description>Penny Racers (USA)</description>
 		<rom name="Penny Racers (USA).n64" />
-		<release name="Penny Racers (USA)" region="USA" />
-		<rom name="Penny Racers (USA).z64" size="8388608" crc="c1e57337" md5="518b14054a667a3b9e0b72d3bf784e41" sha1="1d4fce8ad6b1f0072d89aeb4c3187bc853b750a0" />
+		<rom name="Penny Racers (USA).z64" size="8388608" crc="c1e57337" md5="518b14054a667a3b9e0b72d3bf784e41" sha1="1d4fce8ad6b1f0072d89aeb4c3187bc853b750a0" serial="NCRE" />
 	</game>
-	<game name="Perfect Dark (Europe) (En,Fr,De,Es,It)">
+	<game name="Perfect Dark (Europe) (En,Fr,De,Es,It)" id="0544">
 		<description>Perfect Dark (Europe) (En,Fr,De,Es,It)</description>
 		<rom name="Perfect Dark (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Perfect Dark (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Perfect Dark (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="7718a714" md5="d9b5cd305d228424891ce38e71bc9213" sha1="a663d3f4eee0b198471132db92e9639a9edd1985" status="verified" />
+		<rom name="Perfect Dark (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="7718a714" md5="d9b5cd305d228424891ce38e71bc9213" sha1="a663d3f4eee0b198471132db92e9639a9edd1985" sha256="8e432b1a5f4ca512e2c22a1c3a5bb878ff6e92de2ddfebb1ba98e8d00e0394ff" status="verified" serial="NPDP" />
 	</game>
-	<game name="Perfect Dark (Japan)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
+	<game name="Perfect Dark (Japan)" id="0545" cloneofid="0544">
 		<description>Perfect Dark (Japan)</description>
 		<rom name="Perfect Dark (Japan).n64" />
-		<release name="Perfect Dark (Japan)" region="JPN" />
-		<rom name="Perfect Dark (Japan).z64" size="33554432" crc="639c0da9" md5="538d2b75945eae069b29c46193e74790" sha1="99bcaaa4841b09c845e1094006df8f637862f02e" />
+		<rom name="Perfect Dark (Japan).z64" size="33554432" crc="639c0da9" md5="538d2b75945eae069b29c46193e74790" sha1="99bcaaa4841b09c845e1094006df8f637862f02e" serial="NPDJ" />
 	</game>
-	<game name="Perfect Dark (USA)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
+	<game name="Perfect Dark (USA)" id="0546" cloneofid="0544">
 		<description>Perfect Dark (USA)</description>
 		<rom name="Perfect Dark (USA).n64" />
-		<rom name="Perfect Dark (USA).z64" size="33554432" crc="68446ad4" md5="7f4171b0c8d17815be37913f535e4e93" sha1="60dfe17923c03875b499b3cd3200f05cb538b7ad" />
+		<rom name="Perfect Dark (USA).z64" size="33554432" crc="68446ad4" md5="7f4171b0c8d17815be37913f535e4e93" sha1="60dfe17923c03875b499b3cd3200f05cb538b7ad" sha256="b4173ee90ba6e3514b17d7f340c6c248e2a4c429fdc3c671dd82bbf5afcbb152" status="verified" serial="NPDE" />
 	</game>
-	<game name="Perfect Dark (USA) (Rev 1)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
+	<game name="Perfect Dark (USA) (Rev 1)" id="0547" cloneofid="0544">
 		<description>Perfect Dark (USA) (Rev 1)</description>
 		<rom name="Perfect Dark (USA) (Rev 1).n64" />
-		<release name="Perfect Dark (USA) (Rev 1)" region="USA" />
-		<rom name="Perfect Dark (USA) (Rev 1).z64" size="33554432" crc="4c1677f7" md5="e03b088b6ac9e0080440efed07c1e40f" sha1="af8788ac4d1a57260eae9c53ffe851fcf2a3319b" status="verified" />
+		<rom name="Perfect Dark (USA) (Rev 1).z64" size="33554432" crc="4c1677f7" md5="e03b088b6ac9e0080440efed07c1e40f" sha1="af8788ac4d1a57260eae9c53ffe851fcf2a3319b" sha256="4e51142acac686d96861cecc58cf7cb7c3b06b21733b7f8ed609a709dc039a21" status="verified" serial="NPDE" />
 	</game>
-	<game name="Perfect Dark (Europe) (Debug Version) (2000-04-26)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
-		<description>Perfect Dark (Europe) (Debug Version) (2000-04-26)</description>
-		<rom name="Perfect Dark (Europe) (Debug Version) (2000-04-26).n64" />
-		<rom name="Perfect Dark (Europe) (Debug Version) (2000-04-26).z64" size="33554432" crc="b33c4a54" md5="ad2de210a3455ba5ec541f0c78d91444" sha1="79e3213bbac19b8e196e97e6348006c0506b27a9" />
+	<game name="Perfect Dark (Europe) (2000-04-26) (Debug)" id="1016" cloneofid="0544">
+		<description>Perfect Dark (Europe) (2000-04-26) (Debug)</description>
+		<rom name="Perfect Dark (Europe) (2000-04-26) (Debug).n64" />
+		<rom name="Perfect Dark (Europe) (2000-04-26) (Debug).z64" size="33554432" crc="b33c4a54" md5="ad2de210a3455ba5ec541f0c78d91444" sha1="79e3213bbac19b8e196e97e6348006c0506b27a9" serial="NPDP" />
 	</game>
-	<game name="Perfect Dark (USA) (Debug Version) (2000-03-22)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
-		<description>Perfect Dark (USA) (Debug Version) (2000-03-22)</description>
-		<rom name="Perfect Dark (USA) (Debug Version) (2000-03-22).n64" />
-		<rom name="Perfect Dark (USA) (Debug Version) (2000-03-22).z64" size="33554432" crc="b568a9fe" md5="aa93f4df16fceada399a749f5ad2f273" sha1="c831dc3d3068e0f2098db55889da0d6a08f26080" />
+	<game name="Perfect Dark (USA) (2000-03-22) (Debug)" id="1017" cloneofid="0544">
+		<description>Perfect Dark (USA) (2000-03-22) (Debug)</description>
+		<rom name="Perfect Dark (USA) (2000-03-22) (Debug).n64" />
+		<rom name="Perfect Dark (USA) (2000-03-22) (Debug).z64" size="33554432" crc="b568a9fe" md5="aa93f4df16fceada399a749f5ad2f273" sha1="c831dc3d3068e0f2098db55889da0d6a08f26080" serial="NPDE" />
 	</game>
-	<game name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It)">
-		<description>PGA European Tour Golf (Europe) (En,Fr,De,Es,It)</description>
-		<rom name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="6b5ff959" md5="0112ffaada116d172abce136e9043a93" sha1="f9e838cf5cfd0fa493d5e5f7a7d450a80787c814" />
-	</game>
-	<game name="PGA European Tour (USA)" cloneof="PGA European Tour Golf (Europe) (En,Fr,De,Es,It)">
+	<game name="PGA European Tour (USA)" id="0548" cloneofid="0549">
 		<description>PGA European Tour (USA)</description>
 		<rom name="PGA European Tour (USA).n64" />
-		<release name="PGA European Tour (USA)" region="USA" />
-		<rom name="PGA European Tour (USA).z64" size="16777216" crc="7cdfcdaa" md5="617ceca1d2beffce943ef832326898bf" sha1="6e8dfccfe93318a597e99c9186d5e8cdca3be987" />
+		<rom name="PGA European Tour (USA).z64" size="16777216" crc="7cdfcdaa" md5="617ceca1d2beffce943ef832326898bf" sha1="6e8dfccfe93318a597e99c9186d5e8cdca3be987" sha256="ae6ab96248d077b12d994d36e31ba585860e1563641811c0338efe209c0efd13" serial="NEAE" />
 	</game>
-	<game name="Pilotwings 64 (Europe) (En,Fr,De)">
+	<game name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It)" id="0549">
+		<description>PGA European Tour Golf (Europe) (En,Fr,De,Es,It)</description>
+		<rom name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It).n64" />
+		<rom name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="6b5ff959" md5="0112ffaada116d172abce136e9043a93" sha1="f9e838cf5cfd0fa493d5e5f7a7d450a80787c814" status="verified" serial="NEAP" />
+	</game>
+	<game name="PGA European Tour Golf (Europe) (En,De) (Version B.29) (Beta)" id="1184" cloneofid="0549">
+		<category>Games</category>
+		<rom name="PGA European Tour Golf (Europe) (En,De) (Version B.29) (Beta).n64" />
+		<category>Preproduction</category>
+		<description>PGA European Tour Golf (Europe) (En,De) (Version B.29) (Beta)</description>
+		<rom name="PGA European Tour Golf (Europe) (En,De) (Version B.29) (Beta).z64" size="16777216" crc="920e1149" md5="e3c51937289cfa212cf21cc60acb8528" sha1="dbea5d4d043b738d3bab4d9d3c66cc6d51c0a6a3" sha256="b7cf5ee5bfb389a78417ad455df0cd44d356ce4ea141d67d6aa7ff97830bc317" serial="NEAP" />
+	</game>
+	<game name="Pikachuu Genki de Chuu (Japan) (Beta)" id="1192" cloneofid="0283">
+		<description>Pikachuu Genki de Chuu (Japan) (Beta)</description>
+		<rom name="Pikachuu Genki de Chuu (Japan) (Beta).n64" />
+		<rom name="Pikachuu Genki de Chuu (Japan) (Beta).z64" size="16777216" crc="bb313242" md5="e0901d23a7e24e938fa62975856bd7f0" sha1="a6b2845c2c6e34b34ea2e039b4a3131abd752ba8" sha256="863ebec5ec450b2936bb81df8abf85d3abda5b81a93457a1f25adc0b5eba67d1" />
+	</game>
+	<game name="Pikachuu Genki de Chuu (Japan)" id="0550" cloneofid="0283">
+		<description>Pikachuu Genki de Chuu (Japan)</description>
+		<rom name="Pikachuu Genki de Chuu (Japan).n64" />
+		<rom name="Pikachuu Genki de Chuu (Japan).z64" size="16777216" crc="3f6245ae" md5="e0bcb2758edf0ac6ab7db36d98e1e57c" sha1="a28c689e58f58b4a2a672d3d010436661d247476" sha256="99eb713ed5cea0c86652f813b4e313e3080dd063722a1338bc453366bf46819b" status="verified" serial="NPGJ" />
+	</game>
+	<game name="Pilotwings 64 (Europe) (En,Fr,De)" id="0551">
 		<description>Pilotwings 64 (Europe) (En,Fr,De)</description>
 		<rom name="Pilotwings 64 (Europe) (En,Fr,De).n64" />
-		<release name="Pilotwings 64 (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Pilotwings 64 (Europe) (En,Fr,De).z64" size="8388608" crc="c902e57c" md5="3fcd4969f9a080bd2bcb913ec5d7a3bd" sha1="fa4e0a1941eea83e09ca00197569e2464d70ecb0" />
+		<rom name="Pilotwings 64 (Europe) (En,Fr,De).z64" size="8388608" crc="c902e57c" md5="3fcd4969f9a080bd2bcb913ec5d7a3bd" sha1="fa4e0a1941eea83e09ca00197569e2464d70ecb0" sha256="afe1c8ea27446b6dcf98d8eed92338db0031edf95419bccf4c95be292166fd84" status="verified" serial="NPWP" />
 	</game>
-	<game name="Pilotwings 64 (Japan)" cloneof="Pilotwings 64 (Europe) (En,Fr,De)">
+	<game name="Pilotwings 64 (Japan)" id="0552" cloneofid="0551">
 		<description>Pilotwings 64 (Japan)</description>
 		<rom name="Pilotwings 64 (Japan).n64" />
-		<release name="Pilotwings 64 (Japan)" region="JPN" />
-		<rom name="Pilotwings 64 (Japan).z64" size="8388608" crc="3d3a84a9" md5="e8e6ec0692009009f5dca6827b21f59a" sha1="892a5472d9a6811b881d093020de81f72baeeec9" status="verified" />
+		<rom name="Pilotwings 64 (Japan).z64" size="8388608" crc="3d3a84a9" md5="e8e6ec0692009009f5dca6827b21f59a" sha1="892a5472d9a6811b881d093020de81f72baeeec9" status="verified" serial="NPWJ" />
 	</game>
-	<game name="Pilotwings 64 (USA)" cloneof="Pilotwings 64 (Europe) (En,Fr,De)">
+	<game name="Pilotwings 64 (USA)" id="0553" cloneofid="0551">
 		<description>Pilotwings 64 (USA)</description>
 		<rom name="Pilotwings 64 (USA).n64" />
-		<release name="Pilotwings 64 (USA)" region="USA" />
-		<rom name="Pilotwings 64 (USA).z64" size="8388608" crc="728807e7" md5="8b346182730ceaffe5e2ccf6d223c5ef" sha1="ec771aedf54ee1b214c25404fb4ec51cfd43191a" />
+		<rom name="Pilotwings 64 (USA).z64" size="8388608" crc="728807e7" md5="8b346182730ceaffe5e2ccf6d223c5ef" sha1="ec771aedf54ee1b214c25404fb4ec51cfd43191a" serial="NPWE" />
 	</game>
-	<game name="Pokemon Puzzle League (Europe)">
+	<game name="Pilotwings 64 (USA) (LodgeNet)" id="1153" cloneofid="0551">
+		<category>Games</category>
+		<rom name="Pilotwings 64 (USA) (LodgeNet).n64" />
+		<description>Pilotwings 64 (USA) (LodgeNet)</description>
+		<rom name="Pilotwings 64 (USA) (LodgeNet).i64" size="64" crc="8756a34a" md5="3e7a3a778585a1ed02e1d887e4a377bd" sha1="7b623ec9ae5c7be5dd2830ba5d2d7c30f98ea57b" />
+		<rom name="Pilotwings 64 (USA) (LodgeNet).z64" size="8388608" crc="29fa9832" md5="84ff2eb492778fdc3b734ad18bab38c6" sha1="580d65f3d5cae595bf7c62456ff6ea60a4595798" />
+	</game>
+	<game name="Pokemon Puzzle League (Europe)" id="0558">
 		<description>Pokemon Puzzle League (Europe)</description>
 		<rom name="Pokemon Puzzle League (Europe).n64" />
-		<release name="Pokemon Puzzle League (Europe)" region="EUR" />
-		<rom name="Pokemon Puzzle League (Europe).z64" size="33554432" crc="75839254" md5="2ef9fa16de2a09ea15b6289447f40490" sha1="184f0cac8fdfad47590c515fc637076d2ded58d7" />
+		<rom name="Pokemon Puzzle League (Europe).z64" size="33554432" crc="75839254" md5="2ef9fa16de2a09ea15b6289447f40490" sha1="184f0cac8fdfad47590c515fc637076d2ded58d7" serial="NPNP" />
 	</game>
-	<game name="Pokemon Puzzle League (France)" cloneof="Pokemon Puzzle League (Europe)">
+	<game name="Pokemon Puzzle League (France)" id="0559" cloneofid="0558">
 		<description>Pokemon Puzzle League (France)</description>
 		<rom name="Pokemon Puzzle League (France).n64" />
-		<release name="Pokemon Puzzle League (France)" region="FRA" />
-		<rom name="Pokemon Puzzle League (France).z64" size="33554432" crc="c3aa0074" md5="a3ba044dfc00bb766b4b2bfb9d4b5be9" sha1="72760a2d87ed3e70756a4aa689b9b26786669a52" />
+		<rom name="Pokemon Puzzle League (France).z64" size="33554432" crc="c3aa0074" md5="a3ba044dfc00bb766b4b2bfb9d4b5be9" sha1="72760a2d87ed3e70756a4aa689b9b26786669a52" sha256="82a63e75c3cc76eb59c7dcbbca2229128cf4a8ece143551e90bbfc4ad65341c2" status="verified" serial="NPNF" />
 	</game>
-	<game name="Pokemon Puzzle League (Germany)" cloneof="Pokemon Puzzle League (Europe)">
+	<game name="Pokemon Puzzle League (Germany)" id="0560" cloneofid="0558">
 		<description>Pokemon Puzzle League (Germany)</description>
 		<rom name="Pokemon Puzzle League (Germany).n64" />
-		<release name="Pokemon Puzzle League (Germany)" region="GER" />
-		<rom name="Pokemon Puzzle League (Germany).z64" size="33554432" crc="ac543150" md5="000364bac80e41d9060a31a5923874b7" sha1="dbc9d0de131f3604a9115b58368e9050f1a6303f" />
+		<rom name="Pokemon Puzzle League (Germany).z64" size="33554432" crc="ac543150" md5="000364bac80e41d9060a31a5923874b7" sha1="dbc9d0de131f3604a9115b58368e9050f1a6303f" serial="NPND" />
 	</game>
-	<game name="Pokemon Puzzle League (USA)" cloneof="Pokemon Puzzle League (Europe)">
+	<game name="Pokemon Puzzle League (USA)" id="0561" cloneofid="0558">
 		<description>Pokemon Puzzle League (USA)</description>
 		<rom name="Pokemon Puzzle League (USA).n64" />
-		<release name="Pokemon Puzzle League (USA)" region="USA" />
-		<rom name="Pokemon Puzzle League (USA).z64" size="33554432" crc="8b9c598f" md5="e722576a15182cfed6782379ce4bc8be" sha1="8173866fc8c7652abd44c48efcab85441c6806a1" />
+		<rom name="Pokemon Puzzle League (USA).z64" size="33554432" crc="8b9c598f" md5="e722576a15182cfed6782379ce4bc8be" sha1="8173866fc8c7652abd44c48efcab85441c6806a1" sha256="2987fb9d618305319809f4d5125eacc4ec8787a743712f526b022ec94a5d2bc4" serial="NPNE" />
 	</game>
-	<game name="Pokemon Puzzle League (Europe) (Wii Virtual Console)" cloneof="Pokemon Puzzle League (Europe)">
+	<game name="Pokemon Puzzle League (Europe) (Wii Virtual Console)" id="1005" cloneofid="0558">
 		<description>Pokemon Puzzle League (Europe) (Wii Virtual Console)</description>
 		<rom name="Pokemon Puzzle League (Europe) (Wii Virtual Console).n64" />
-		<rom name="Pokemon Puzzle League (Europe) (Wii Virtual Console).z64" size="33554432" crc="13f996b2" md5="fbf566693bca3145d86df34d18dcdd43" sha1="7ecc46ee186118d49b174ad4bc1367d343130330" />
+		<rom name="Pokemon Puzzle League (Europe) (Wii Virtual Console).z64" size="33554432" crc="13f996b2" md5="fbf566693bca3145d86df34d18dcdd43" sha1="7ecc46ee186118d49b174ad4bc1367d343130330" serial="NPNP" />
 	</game>
-	<game name="Pokemon Puzzle League (France) (Wii Virtual Console)" cloneof="Pokemon Puzzle League (Europe)">
+	<game name="Pokemon Puzzle League (France) (Wii Virtual Console)" id="1006" cloneofid="0558">
 		<description>Pokemon Puzzle League (France) (Wii Virtual Console)</description>
 		<rom name="Pokemon Puzzle League (France) (Wii Virtual Console).n64" />
-		<rom name="Pokemon Puzzle League (France) (Wii Virtual Console).z64" size="33554432" crc="8671137d" md5="866d401c51cc05a3188c9a2d4e7bfee5" sha1="94742de682f1b52f3fe45c3a7235eb9bcbc4abbc" />
+		<rom name="Pokemon Puzzle League (France) (Wii Virtual Console).z64" size="33554432" crc="8671137d" md5="866d401c51cc05a3188c9a2d4e7bfee5" sha1="94742de682f1b52f3fe45c3a7235eb9bcbc4abbc" serial="NPNF" />
 	</game>
-	<game name="Pokemon Puzzle League (Germany) (Wii Virtual Console)" cloneof="Pokemon Puzzle League (Europe)">
+	<game name="Pokemon Puzzle League (Germany) (Wii Virtual Console)" id="1007" cloneofid="0558">
 		<description>Pokemon Puzzle League (Germany) (Wii Virtual Console)</description>
 		<rom name="Pokemon Puzzle League (Germany) (Wii Virtual Console).n64" />
-		<rom name="Pokemon Puzzle League (Germany) (Wii Virtual Console).z64" size="33554432" crc="00e73008" md5="45b507aaaf0ccdb6efe3cd717f0ddb95" sha1="5ec354fdc1469c1e8a89b31d6ee5e59af37dee16" />
+		<rom name="Pokemon Puzzle League (Germany) (Wii Virtual Console).z64" size="33554432" crc="00e73008" md5="45b507aaaf0ccdb6efe3cd717f0ddb95" sha1="5ec354fdc1469c1e8a89b31d6ee5e59af37dee16" serial="NPND" />
 	</game>
-	<game name="Pokemon Puzzle League (USA) (Wii Virtual Console)" cloneof="Pokemon Puzzle League (Europe)">
+	<game name="Pokemon Puzzle League (USA) (Wii Virtual Console)" id="1008" cloneofid="0558">
 		<description>Pokemon Puzzle League (USA) (Wii Virtual Console)</description>
 		<rom name="Pokemon Puzzle League (USA) (Wii Virtual Console).n64" />
-		<rom name="Pokemon Puzzle League (USA) (Wii Virtual Console).z64" size="33554432" crc="91623130" md5="d6f58b98115e78d841089074401ae524" sha1="f0837f92a16b2226d9b72ff60a924404536c051e" />
+		<rom name="Pokemon Puzzle League (USA) (Wii Virtual Console).z64" size="33554432" crc="91623130" md5="d6f58b98115e78d841089074401ae524" sha1="f0837f92a16b2226d9b72ff60a924404536c051e" serial="NPNE" />
 	</game>
-	<game name="Pokemon Snap (Europe)">
-		<description>Pokemon Snap (Europe)</description>
-		<rom name="Pokemon Snap (Europe).n64" />
-		<release name="Pokemon Snap (Europe)" region="EUR" />
-		<rom name="Pokemon Snap (Europe).z64" size="16777216" crc="f824a057" md5="f2a8106403d2bf9350bfeab08689d54a" sha1="d575b393812a0a59fbb52f3ce55ce4d7bc5f3225" status="verified" />
-	</game>
-	<game name="Pokemon Snap (Japan)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (Japan)" id="0554" cloneofid="0563">
 		<description>Pokemon Snap (Japan)</description>
 		<rom name="Pokemon Snap (Japan).n64" />
-		<release name="Pokemon Snap (Japan)" region="JPN" />
-		<rom name="Pokemon Snap (Japan).z64" size="16777216" crc="a091bd56" md5="fbdd74ed68e6a0cd734562d56ccb752d" sha1="5d7b3b8d4bb64da5b7ae5e1f132b26a282c33909" />
+		<rom name="Pokemon Snap (Japan).z64" size="16777216" crc="a091bd56" md5="fbdd74ed68e6a0cd734562d56ccb752d" sha1="5d7b3b8d4bb64da5b7ae5e1f132b26a282c33909" sha256="f13e6bf81048af5618ddc35f0fbe6c9a4e3345cc53d7360355c5bb87b0b9afa4" status="verified" serial="NPFJ" />
 	</game>
-	<game name="Pokemon Snap (Australia)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (Australia)" id="0562" cloneofid="0563">
 		<description>Pokemon Snap (Australia)</description>
 		<rom name="Pokemon Snap (Australia).n64" />
-		<release name="Pokemon Snap (Australia)" region="AUS" />
-		<rom name="Pokemon Snap (Australia).z64" size="16777216" crc="cdea6d4c" md5="e5a0ca3dc54b38ea7fcd927e3cffad3b" sha1="eb388731bb7530f60e3ad4a1652f79296b5063ec" />
+		<rom name="Pokemon Snap (Australia).z64" size="16777216" crc="cdea6d4c" md5="e5a0ca3dc54b38ea7fcd927e3cffad3b" sha1="eb388731bb7530f60e3ad4a1652f79296b5063ec" serial="NPFU" />
 	</game>
-	<game name="Pokemon Snap (France)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (Europe)" id="0563">
+		<description>Pokemon Snap (Europe)</description>
+		<rom name="Pokemon Snap (Europe).n64" />
+		<rom name="Pokemon Snap (Europe).z64" size="16777216" crc="f824a057" md5="f2a8106403d2bf9350bfeab08689d54a" sha1="d575b393812a0a59fbb52f3ce55ce4d7bc5f3225" sha256="5fe996f65900f83376ff96cb54fcad2da40010700fe4e36cb006a59737f969f1" status="verified" serial="NPFP" />
+	</game>
+	<game name="Pokemon Snap (France)" id="0564" cloneofid="0563">
 		<description>Pokemon Snap (France)</description>
 		<rom name="Pokemon Snap (France).n64" />
-		<release name="Pokemon Snap (France)" region="FRA" />
-		<rom name="Pokemon Snap (France).z64" size="16777216" crc="ec843586" md5="e9028f9ccc307806695dd81742d05d5d" sha1="9ee1ed91ad6e00cc50e1a1513a256ccceb9a41df" status="verified" />
+		<rom name="Pokemon Snap (France).z64" size="16777216" crc="ec843586" md5="e9028f9ccc307806695dd81742d05d5d" sha1="9ee1ed91ad6e00cc50e1a1513a256ccceb9a41df" sha256="ddafdca5aeaef7f00aa3a844baf4e950d212c0ccb213664c8ae1a2266b3612ae" status="verified" serial="NPFF" />
 	</game>
-	<game name="Pokemon Snap (Germany)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (Germany)" id="0565" cloneofid="0563">
 		<description>Pokemon Snap (Germany)</description>
 		<rom name="Pokemon Snap (Germany).n64" />
-		<release name="Pokemon Snap (Germany)" region="GER" />
-		<rom name="Pokemon Snap (Germany).z64" size="16777216" crc="10c27b3c" md5="144b8906dc40534cfbef6d7b994a982b" sha1="f1fe20e26c3803c0e4ea33711be5e0edf8e9c4be" status="verified" />
+		<rom name="Pokemon Snap (Germany).z64" size="16777216" crc="10c27b3c" md5="144b8906dc40534cfbef6d7b994a982b" sha1="f1fe20e26c3803c0e4ea33711be5e0edf8e9c4be" status="verified" serial="NPFD" />
 	</game>
-	<game name="Pokemon Snap (Italy)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (Italy)" id="0566" cloneofid="0563">
 		<description>Pokemon Snap (Italy)</description>
 		<rom name="Pokemon Snap (Italy).n64" />
-		<release name="Pokemon Snap (Italy)" region="ITA" />
-		<rom name="Pokemon Snap (Italy).z64" size="16777216" crc="df56e922" md5="8e1968191dd27655c03be812cf041a95" sha1="a4dae7f86e463fe5351b3e74a1d044a95f3cbf41" status="verified" />
+		<rom name="Pokemon Snap (Italy).z64" size="16777216" crc="df56e922" md5="8e1968191dd27655c03be812cf041a95" sha1="a4dae7f86e463fe5351b3e74a1d044a95f3cbf41" serial="NPFI" />
 	</game>
-	<game name="Pokemon Snap (Spain)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (Spain)" id="0567" cloneofid="0563">
 		<description>Pokemon Snap (Spain)</description>
 		<rom name="Pokemon Snap (Spain).n64" />
-		<release name="Pokemon Snap (Spain)" region="SPA" />
-		<rom name="Pokemon Snap (Spain).z64" size="16777216" crc="371b787f" md5="a45d7115be5a06fd1567f9f913c3bdf8" sha1="24da787140662d1fb40d8e17199ce6412d72dedc" status="verified" />
+		<rom name="Pokemon Snap (Spain).z64" size="16777216" crc="371b787f" md5="a45d7115be5a06fd1567f9f913c3bdf8" sha1="24da787140662d1fb40d8e17199ce6412d72dedc" status="verified" serial="NPFS" />
 	</game>
-	<game name="Pokemon Snap (USA)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (USA)" id="0568" cloneofid="0563">
 		<description>Pokemon Snap (USA)</description>
 		<rom name="Pokemon Snap (USA).n64" />
-		<release name="Pokemon Snap (USA)" region="USA" />
-		<rom name="Pokemon Snap (USA).z64" size="16777216" crc="86a69756" md5="fc3c9329b7cdd67cf7650abf63b9a580" sha1="edc7c49cc568c045fe48be0d18011c30f393cbaf" status="verified" />
+		<rom name="Pokemon Snap (USA).z64" size="16777216" crc="86a69756" md5="fc3c9329b7cdd67cf7650abf63b9a580" sha1="edc7c49cc568c045fe48be0d18011c30f393cbaf" sha256="a1d5d816db7f8557ee04c35a011326d058b2c1fbca76b57b352b1d705a1ec1cc" status="verified" serial="NPFE" />
 	</game>
-	<game name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console)" id="1029" cloneofid="0563">
 		<description>Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console)</description>
 		<rom name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console).n64" />
-		<rom name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console).z64" size="16777216" crc="a761daef" md5="33fdab9712d9fea793a3ae44293999c3" sha1="635be62b427be4c2dab9617aa9f58cddea9d4155" />
+		<rom name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console).z64" size="16777216" crc="a761daef" md5="33fdab9712d9fea793a3ae44293999c3" sha1="635be62b427be4c2dab9617aa9f58cddea9d4155" sha256="c74abe931a6d6e915143bfec863a05a300715941df0a83167847fcd0e0c96d04" status="verified" serial="NPFJ" />
 	</game>
-	<game name="Pokemon Snap Station (USA) (Demo) (Kiosk)" cloneof="Pokemon Snap (Europe)">
+	<game name="Pokemon Snap (USA) (LodgeNet)" id="1154" cloneofid="0563">
+		<category>Games</category>
+		<rom name="Pokemon Snap (USA) (LodgeNet).n64" />
+		<description>Pokemon Snap (USA) (LodgeNet)</description>
+		<rom name="Pokemon Snap (USA) (LodgeNet).i64" size="64" crc="a72187f0" md5="3e1272f5eadbcae31abb0c91eef86dea" sha1="7017d71fce3e1f9e55a143f530288caaa9ca0bb9" />
+		<rom name="Pokemon Snap (USA) (LodgeNet).z64" size="16777216" crc="8347c9bc" md5="031775e93a108f310c8242f3e7e1e8b0" sha1="b624c57e4d9e7851b422475a200fe72a300e3b1c" />
+	</game>
+	<game name="Pokemon Snap Station (USA) (Demo) (Kiosk)" id="0569" cloneofid="0563">
 		<description>Pokemon Snap Station (USA) (Demo) (Kiosk)</description>
 		<rom name="Pokemon Snap Station (USA) (Demo) (Kiosk).n64" />
-		<rom name="Pokemon Snap Station (USA) (Demo) (Kiosk).z64" size="16777216" crc="e22a00d0" md5="a9c272687dabd59c5144774b53bcc35a" sha1="1e16c19ff303f9283d7b53545c4d575c6df43158" />
+		<rom name="Pokemon Snap Station (USA) (Demo) (Kiosk).z64" size="16777216" crc="e22a00d0" md5="a9c272687dabd59c5144774b53bcc35a" sha1="1e16c19ff303f9283d7b53545c4d575c6df43158" serial="NPHE" />
 	</game>
-	<game name="Pokemon Stadium (Japan)">
+	<game name="Pokemon Stadium (Japan)" id="0555">
 		<description>Pokemon Stadium (Japan)</description>
 		<rom name="Pokemon Stadium (Japan).n64" />
-		<release name="Pokemon Stadium (Japan)" region="JPN" />
-		<rom name="Pokemon Stadium (Japan).z64" size="16777216" crc="3139189c" md5="c46e087d966a35095df96799b0b4ffae" sha1="8bc8d2ff7df25b26bd0c353d2adfe83e4e3a7a87" />
+		<rom name="Pokemon Stadium (Japan).z64" size="16777216" crc="3139189c" md5="c46e087d966a35095df96799b0b4ffae" sha1="8bc8d2ff7df25b26bd0c353d2adfe83e4e3a7a87" sha256="ed9f7cd7da795467c1e2b08ed1f878ff5aed906eae9ffe252074aef7a6703d8b" status="verified" serial="CPSJ" />
 	</game>
-	<game name="Pokemon Stadium (Europe) (Rev 1)">
-		<description>Pokemon Stadium (Europe) (Rev 1)</description>
-		<rom name="Pokemon Stadium (Europe) (Rev 1).n64" />
-		<release name="Pokemon Stadium (Europe) (Rev 1)" region="EUR" />
-		<rom name="Pokemon Stadium (Europe) (Rev 1).z64" size="33554432" crc="da889668" md5="31ee2de8e65e30f5934c450dbaa924f0" sha1="9470f899ad0107677b7dfd24e1dd567723a5f84f" />
-	</game>
-	<game name="Pokemon Stadium (Europe)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium (Europe)" id="0570" cloneofid="0571">
 		<description>Pokemon Stadium (Europe)</description>
 		<rom name="Pokemon Stadium (Europe).n64" />
-		<rom name="Pokemon Stadium (Europe).z64" size="33554432" crc="dc57508d" md5="2859090d78581e0925a3af8045e81e4b" sha1="6f26e3c8b35c3232058375e30d19665facb23123" />
+		<rom name="Pokemon Stadium (Europe).z64" size="33554432" crc="dc57508d" md5="2859090d78581e0925a3af8045e81e4b" sha1="6f26e3c8b35c3232058375e30d19665facb23123" serial="NPOP" />
 	</game>
-	<game name="Pokemon Stadium (France)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium (Europe) (Rev 1)" id="0571">
+		<description>Pokemon Stadium (Europe) (Rev 1)</description>
+		<rom name="Pokemon Stadium (Europe) (Rev 1).n64" />
+		<rom name="Pokemon Stadium (Europe) (Rev 1).z64" size="33554432" crc="da889668" md5="31ee2de8e65e30f5934c450dbaa924f0" sha1="9470f899ad0107677b7dfd24e1dd567723a5f84f" serial="NPOP" />
+	</game>
+	<game name="Pokemon Stadium (France)" id="0572" cloneofid="0571">
 		<description>Pokemon Stadium (France)</description>
 		<rom name="Pokemon Stadium (France).n64" />
-		<release name="Pokemon Stadium (France)" region="FRA" />
-		<rom name="Pokemon Stadium (France).z64" size="33554432" crc="5dd92d4c" md5="0e85a098d0f0e8a7eb572a69612a6873" sha1="4f7267ccaba4a8a9b0ae2cb89e191bc69b153ddc" />
+		<rom name="Pokemon Stadium (France).z64" size="33554432" crc="5dd92d4c" md5="0e85a098d0f0e8a7eb572a69612a6873" sha1="4f7267ccaba4a8a9b0ae2cb89e191bc69b153ddc" sha256="fdc743a54113b670b55ef84bda4eb8b25f5ef0de50ff1563f9a6de8a1f5fca08" status="verified" serial="NPOF" />
 	</game>
-	<game name="Pokemon Stadium (Germany)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium (Germany)" id="0573" cloneofid="0571">
 		<description>Pokemon Stadium (Germany)</description>
 		<rom name="Pokemon Stadium (Germany).n64" />
-		<release name="Pokemon Stadium (Germany)" region="GER" />
-		<rom name="Pokemon Stadium (Germany).z64" size="33554432" crc="9f22a945" md5="24be2ccb0dea0755908c02bf67e22fe5" sha1="6a25903e733f071e7d6ea54529b7fd60b760cda3" status="verified" />
+		<rom name="Pokemon Stadium (Germany).z64" size="33554432" crc="9f22a945" md5="24be2ccb0dea0755908c02bf67e22fe5" sha1="6a25903e733f071e7d6ea54529b7fd60b760cda3" status="verified" serial="NPOD" />
 	</game>
-	<game name="Pokemon Stadium (Italy)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium (Italy)" id="0574" cloneofid="0571">
 		<description>Pokemon Stadium (Italy)</description>
 		<rom name="Pokemon Stadium (Italy).n64" />
-		<release name="Pokemon Stadium (Italy)" region="ITA" />
-		<rom name="Pokemon Stadium (Italy).z64" size="33554432" crc="f155c465" md5="a81321759af38beb30a40fdaca2ea22a" sha1="db5f2797c377fa8957b97465fc5738d6999ff240" />
+		<rom name="Pokemon Stadium (Italy).z64" size="33554432" crc="f155c465" md5="a81321759af38beb30a40fdaca2ea22a" sha1="db5f2797c377fa8957b97465fc5738d6999ff240" serial="NPOI" />
 	</game>
-	<game name="Pokemon Stadium (Spain)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium (Spain)" id="0575" cloneofid="0571">
 		<description>Pokemon Stadium (Spain)</description>
 		<rom name="Pokemon Stadium (Spain).n64" />
-		<release name="Pokemon Stadium (Spain)" region="SPA" />
-		<rom name="Pokemon Stadium (Spain).z64" size="33554432" crc="f02cd5eb" md5="d14a499bc4e324974eae3e42dec58625" sha1="f39911ad0bedccc3e44d4338507c73bfa97856bf" />
+		<rom name="Pokemon Stadium (Spain).z64" size="33554432" crc="f02cd5eb" md5="d14a499bc4e324974eae3e42dec58625" sha1="f39911ad0bedccc3e44d4338507c73bfa97856bf" serial="NPOS" />
 	</game>
-	<game name="Pokemon Stadium (USA)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium (USA)" id="0576" cloneofid="0571">
 		<description>Pokemon Stadium (USA)</description>
 		<rom name="Pokemon Stadium (USA).n64" />
-		<rom name="Pokemon Stadium (USA).z64" size="33554432" crc="72f66f05" md5="ed1378bc12115f71209a77844965ba50" sha1="ed7bef5a306f88c0a6e96b15e71fee2ef32058f3" />
+		<rom name="Pokemon Stadium (USA).z64" size="33554432" crc="72f66f05" md5="ed1378bc12115f71209a77844965ba50" sha1="ed7bef5a306f88c0a6e96b15e71fee2ef32058f3" sha256="502f6082a6436012a8b61419435dec1388869a90ed870e87e2d7bee88f831519" status="verified" serial="NPOE" />
 	</game>
-	<game name="Pokemon Stadium (USA) (Rev 1)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium (USA) (Rev 1)" id="0577" cloneofid="0571">
 		<description>Pokemon Stadium (USA) (Rev 1)</description>
 		<rom name="Pokemon Stadium (USA) (Rev 1).n64" />
-		<rom name="Pokemon Stadium (USA) (Rev 1).z64" size="33554432" crc="4b1bc2ac" md5="40e03eda831c01e0a12294287fd240e2" sha1="488bb6d112427823d77fcecdd9297fd86875263d" status="verified" />
+		<rom name="Pokemon Stadium (USA) (Rev 1).z64" size="33554432" crc="4b1bc2ac" md5="40e03eda831c01e0a12294287fd240e2" sha1="488bb6d112427823d77fcecdd9297fd86875263d" sha256="290ccf333af450af59487563c1050c831cc9316975d5e0c7bac2e56a74732c53" status="verified" serial="NPOE" />
 	</game>
-	<game name="Pokemon Stadium (USA) (Rev 2)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium (USA) (Rev 2)" id="0937" cloneofid="0571">
 		<description>Pokemon Stadium (USA) (Rev 2)</description>
 		<rom name="Pokemon Stadium (USA) (Rev 2).n64" />
-		<release name="Pokemon Stadium (USA) (Rev 2)" region="USA" />
-		<rom name="Pokemon Stadium (USA) (Rev 2).z64" size="33554432" crc="235b1842" md5="6dc6820cef755fc1253d06df45c9bd2a" sha1="0d3b1d740c6ee6da6923550bf24ad827262fd8c0" status="verified" />
+		<rom name="Pokemon Stadium (USA) (Rev 2).z64" size="33554432" crc="235b1842" md5="6dc6820cef755fc1253d06df45c9bd2a" sha1="0d3b1d740c6ee6da6923550bf24ad827262fd8c0" status="verified" serial="NPOE" />
 	</game>
-	<game name="Pokemon Stadium 2 (Japan)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
+	<game name="Pokemon Stadium 2 (Japan)" id="0556" cloneofid="0571">
 		<description>Pokemon Stadium 2 (Japan)</description>
 		<rom name="Pokemon Stadium 2 (Japan).n64" />
-		<release name="Pokemon Stadium 2 (Japan)" region="JPN" />
-		<rom name="Pokemon Stadium 2 (Japan).z64" size="33554432" crc="40aa4874" md5="2449bb712a64e3363a6cbd56f5adeda5" sha1="074582744c71d7f0569ce960964a7bbe947efd3c" />
+		<rom name="Pokemon Stadium 2 (Japan).z64" size="33554432" crc="40aa4874" md5="2449bb712a64e3363a6cbd56f5adeda5" sha1="074582744c71d7f0569ce960964a7bbe947efd3c" sha256="ba3dda9d33c047ed4902b9cb534c06195e5708972b7db16202087fcbd7c7a0e4" status="verified" serial="CP2J" />
 	</game>
-	<game name="Pokemon Stadium 2 (Europe)">
+	<game name="Pokemon Stadium 2 (Europe)" id="0578">
 		<description>Pokemon Stadium 2 (Europe)</description>
 		<rom name="Pokemon Stadium 2 (Europe).n64" />
-		<release name="Pokemon Stadium 2 (Europe)" region="EUR" />
-		<rom name="Pokemon Stadium 2 (Europe).z64" size="67108864" crc="6b3096c4" md5="b1271db50d6ef8f6b53cc640c3743e4f" sha1="f6a7e8146433a48bf101722e30bf86311a641f7b" />
+		<rom name="Pokemon Stadium 2 (Europe).z64" size="67108864" crc="6b3096c4" md5="b1271db50d6ef8f6b53cc640c3743e4f" sha1="f6a7e8146433a48bf101722e30bf86311a641f7b" serial="NP3P" />
 	</game>
-	<game name="Pokemon Stadium 2 (France)" cloneof="Pokemon Stadium 2 (Europe)">
+	<game name="Pokemon Stadium 2 (France)" id="0579" cloneofid="0578">
 		<description>Pokemon Stadium 2 (France)</description>
 		<rom name="Pokemon Stadium 2 (France).n64" />
-		<release name="Pokemon Stadium 2 (France)" region="FRA" />
-		<rom name="Pokemon Stadium 2 (France).z64" size="67108864" crc="e2a78066" md5="4748d96916ae2bcc5fc1630515ee2561" sha1="d7e13535b671024a92822db01507e87bd42f68ec" />
+		<rom name="Pokemon Stadium 2 (France).z64" size="67108864" crc="e2a78066" md5="4748d96916ae2bcc5fc1630515ee2561" sha1="d7e13535b671024a92822db01507e87bd42f68ec" sha256="b661d92a94eb3c7a00cd27acc1e93d1e52299bf85a76397ee38e998a84af68ea" status="verified" serial="NP3F" />
 	</game>
-	<game name="Pokemon Stadium 2 (Germany)" cloneof="Pokemon Stadium 2 (Europe)">
+	<game name="Pokemon Stadium 2 (Germany)" id="0580" cloneofid="0578">
 		<description>Pokemon Stadium 2 (Germany)</description>
 		<rom name="Pokemon Stadium 2 (Germany).n64" />
-		<release name="Pokemon Stadium 2 (Germany)" region="GER" />
-		<rom name="Pokemon Stadium 2 (Germany).z64" size="67108864" crc="1146a43a" md5="484f3e696c94980acf3d7068f9acc98f" sha1="6de05180d77e73dcf32d57af7c8c1529c7acda59" status="verified" />
+		<rom name="Pokemon Stadium 2 (Germany).z64" size="67108864" crc="1146a43a" md5="484f3e696c94980acf3d7068f9acc98f" sha1="6de05180d77e73dcf32d57af7c8c1529c7acda59" status="verified" serial="NP3D" />
 	</game>
-	<game name="Pokemon Stadium 2 (Italy)" cloneof="Pokemon Stadium 2 (Europe)">
+	<game name="Pokemon Stadium 2 (Italy)" id="0581" cloneofid="0578">
 		<description>Pokemon Stadium 2 (Italy)</description>
 		<rom name="Pokemon Stadium 2 (Italy).n64" />
-		<release name="Pokemon Stadium 2 (Italy)" region="ITA" />
-		<rom name="Pokemon Stadium 2 (Italy).z64" size="67108864" crc="9fa5c095" md5="5a04d7f1ab9c6b080176567aa7168d3a" sha1="4926db649c76521f61ae51c13e452a2c8001354c" />
+		<rom name="Pokemon Stadium 2 (Italy).z64" size="67108864" crc="9fa5c095" md5="5a04d7f1ab9c6b080176567aa7168d3a" sha1="4926db649c76521f61ae51c13e452a2c8001354c" serial="NP3I" />
 	</game>
-	<game name="Pokemon Stadium 2 (Spain)" cloneof="Pokemon Stadium 2 (Europe)">
+	<game name="Pokemon Stadium 2 (Spain)" id="0582" cloneofid="0578">
 		<description>Pokemon Stadium 2 (Spain)</description>
 		<rom name="Pokemon Stadium 2 (Spain).n64" />
-		<release name="Pokemon Stadium 2 (Spain)" region="SPA" />
-		<rom name="Pokemon Stadium 2 (Spain).z64" size="67108864" crc="283e7641" md5="b26aafd452c9816e1b7aa0954e75825f" sha1="ab1cdf753bed70487923ea3129278e45d6325773" />
+		<rom name="Pokemon Stadium 2 (Spain).z64" size="67108864" crc="283e7641" md5="b26aafd452c9816e1b7aa0954e75825f" sha1="ab1cdf753bed70487923ea3129278e45d6325773" serial="NP3S" />
 	</game>
-	<game name="Pokemon Stadium 2 (USA)" cloneof="Pokemon Stadium 2 (Europe)">
+	<game name="Pokemon Stadium 2 (USA)" id="0583" cloneofid="0578">
 		<description>Pokemon Stadium 2 (USA)</description>
 		<rom name="Pokemon Stadium 2 (USA).n64" />
-		<release name="Pokemon Stadium 2 (USA)" region="USA" />
-		<rom name="Pokemon Stadium 2 (USA).z64" size="67108864" crc="a9998e09" md5="1561c75d11cedf356a8ddb1a4a5f9d5d" sha1="d8343e69a7dc63b869cf6361d87cde64444281d3" status="verified" />
+		<rom name="Pokemon Stadium 2 (USA).z64" size="67108864" crc="a9998e09" md5="1561c75d11cedf356a8ddb1a4a5f9d5d" sha1="d8343e69a7dc63b869cf6361d87cde64444281d3" sha256="8160abe7d4b9734317000c44e9f882efefe4cc6359eacded98be62f2811e40a9" status="verified" serial="NP3E" />
 	</game>
-	<game name="Pokemon Stadium Kin Gin (Japan)" cloneof="Pokemon Stadium 2 (Europe)">
+	<game name="Pokemon Stadium Kin Gin (Japan)" id="0557" cloneofid="0578">
 		<description>Pokemon Stadium Kin Gin (Japan)</description>
 		<rom name="Pokemon Stadium Kin Gin (Japan).n64" />
-		<release name="Pokemon Stadium Kin Gin (Japan)" region="JPN" />
-		<rom name="Pokemon Stadium Kin Gin (Japan).z64" size="67108864" crc="cbc3b935" md5="a17aadcc962393d476edc321e59c504b" sha1="05682e60b13479ca1c54656e5a5b1ee6d099c1a4" />
+		<rom name="Pokemon Stadium Kin Gin (Japan).z64" size="67108864" crc="cbc3b935" md5="a17aadcc962393d476edc321e59c504b" sha1="05682e60b13479ca1c54656e5a5b1ee6d099c1a4" sha256="e0ce95bbebb775181497cbf6414845d2dbf19b5d95840f0ab3baa8d61bb6f618" status="verified" serial="NP3J" />
 	</game>
-	<game name="Polaris SnoCross (USA)">
+	<game name="Polaris SnoCross (USA)" id="0584">
 		<description>Polaris SnoCross (USA)</description>
 		<rom name="Polaris SnoCross (USA).n64" />
-		<release name="Polaris SnoCross (USA)" region="USA" />
-		<rom name="Polaris SnoCross (USA).z64" size="12582912" crc="8dd735ef" md5="bbdc4c4f1c474298189312008a1768c4" sha1="cb56812d41fb96d722774b845100ef421fbc318d" />
+		<rom name="Polaris SnoCross (USA).z64" size="12582912" crc="8dd735ef" md5="bbdc4c4f1c474298189312008a1768c4" sha1="cb56812d41fb96d722774b845100ef421fbc318d" serial="NPXE" />
 	</game>
-	<game name="Power League 64 (Japan)">
+	<game name="Power League 64 (Japan)" id="0585">
 		<description>Power League 64 (Japan)</description>
 		<rom name="Power League 64 (Japan).n64" />
-		<release name="Power League 64 (Japan)" region="JPN" />
-		<rom name="Power League 64 (Japan).z64" size="8388608" crc="aec21c28" md5="8cc73c373016070647030dde492fdc8c" sha1="1e0d939c8e278de21c42fa33495e446ed03c027e" />
+		<rom name="Power League 64 (Japan).z64" size="8388608" crc="aec21c28" md5="8cc73c373016070647030dde492fdc8c" sha1="1e0d939c8e278de21c42fa33495e446ed03c027e" serial="NPLJ" />
 	</game>
-	<game name="Power Rangers - Lightspeed Rescue (Europe)">
+	<game name="Power Rangers - Lightspeed Rescue (Europe)" id="0586">
 		<description>Power Rangers - Lightspeed Rescue (Europe)</description>
 		<rom name="Power Rangers - Lightspeed Rescue (Europe).n64" />
-		<release name="Power Rangers - Lightspeed Rescue (Europe)" region="EUR" />
-		<rom name="Power Rangers - Lightspeed Rescue (Europe).z64" size="12582912" crc="36ee5ca8" md5="92bb1bc5e6466f1944943d34d25f2daf" sha1="c7fec2a9d57f656b8d0b4404c8797c46136fd971" />
+		<rom name="Power Rangers - Lightspeed Rescue (Europe).z64" size="12582912" crc="36ee5ca8" md5="92bb1bc5e6466f1944943d34d25f2daf" sha1="c7fec2a9d57f656b8d0b4404c8797c46136fd971" sha256="2749a21383fd2b981e068abddf9d83a372a9b8b31fc5249a85c58fc52ffff69d" status="verified" serial="NPUP" />
 	</game>
-	<game name="Power Rangers - Lightspeed Rescue (USA)" cloneof="Power Rangers - Lightspeed Rescue (Europe)">
+	<game name="Power Rangers - Lightspeed Rescue (USA)" id="0587" cloneofid="0586">
 		<description>Power Rangers - Lightspeed Rescue (USA)</description>
 		<rom name="Power Rangers - Lightspeed Rescue (USA).n64" />
-		<release name="Power Rangers - Lightspeed Rescue (USA)" region="USA" />
-		<rom name="Power Rangers - Lightspeed Rescue (USA).z64" size="12582912" crc="a5033311" md5="91d74621ddef6d37fb845b3bc7059a38" sha1="9c0b970dfa344a8cdea9b775d7f95acec2ccf79f" />
+		<rom name="Power Rangers - Lightspeed Rescue (USA).z64" size="12582912" crc="a5033311" md5="91d74621ddef6d37fb845b3bc7059a38" sha1="9c0b970dfa344a8cdea9b775d7f95acec2ccf79f" serial="NPUE" />
 	</game>
-	<game name="Powerpuff Girls, The - Chemical X-Traction (USA)">
+	<game name="Powerpuff Girls, The - Chemical X-Traction (USA)" id="0588">
 		<description>Powerpuff Girls, The - Chemical X-Traction (USA)</description>
 		<rom name="Powerpuff Girls, The - Chemical X-Traction (USA).n64" />
-		<release name="Powerpuff Girls, The - Chemical X-Traction (USA)" region="USA" />
-		<rom name="Powerpuff Girls, The - Chemical X-Traction (USA).z64" size="8388608" crc="9514da0a" md5="2991bb68eca54813d6b834adbbbacc4c" sha1="88e2032997cb884af31a7380fabac0d0a5360892" />
+		<rom name="Powerpuff Girls, The - Chemical X-Traction (USA).z64" size="8388608" crc="9514da0a" md5="2991bb68eca54813d6b834adbbbacc4c" sha1="88e2032997cb884af31a7380fabac0d0a5360892" serial="NPQE" />
 	</game>
-	<game name="Premier Manager 64 (Europe)">
+	<game name="Powerpuff Girls, The - Chemical X-Traction (USA) (Beta) (2001-09-27)" id="1114" cloneofid="0588">
+		<category>Games</category>
+		<rom name="Powerpuff Girls, The - Chemical X-Traction (USA) (Beta) (2001-09-27).n64" />
+		<description>Powerpuff Girls, The - Chemical X-Traction (USA) (Beta) (2001-09-27)</description>
+		<rom name="Powerpuff Girls, The - Chemical X-Traction (USA) (Beta) (2001-09-27).z64" size="8388608" crc="f53f1c36" md5="11bd90afe31992f1f5e7e25433fe8d52" sha1="6cb8b06bfbbd765103c091a402cdc4053f05fa7a" sha256="697e9388a015a8a3d3823e234048e5e1e48b66c26d4f7bb090fd9bcac614ea12" serial="NPQE" />
+	</game>
+	<game name="Premier Manager 64 (Europe)" id="0589">
 		<description>Premier Manager 64 (Europe)</description>
 		<rom name="Premier Manager 64 (Europe).n64" />
-		<release name="Premier Manager 64 (Europe)" region="EUR" />
-		<rom name="Premier Manager 64 (Europe).z64" size="16777216" crc="81cda888" md5="25bafc84ba4d87854dc44df3ef8764ea" sha1="6affb5b00b1862e233e4d909dc6e4201f9945579" />
+		<rom name="Premier Manager 64 (Europe).z64" size="16777216" crc="81cda888" md5="25bafc84ba4d87854dc44df3ef8764ea" sha1="6affb5b00b1862e233e4d909dc6e4201f9945579" sha256="a3c0a0b8c41c2d8215b253aa330517b91329986d2cc6b2882d638de06e72a4c9" status="verified" serial="NPMP" />
 	</game>
-	<game name="Pro Mahjong Kiwame 64 (Japan) (Rev 1)">
-		<description>Pro Mahjong Kiwame 64 (Japan) (Rev 1)</description>
-		<rom name="Pro Mahjong Kiwame 64 (Japan) (Rev 1).n64" />
-		<release name="Pro Mahjong Kiwame 64 (Japan) (Rev 1)" region="JPN" />
-		<rom name="Pro Mahjong Kiwame 64 (Japan) (Rev 1).z64" size="8388608" crc="b9be7b90" md5="b42f62483f7ca2aac5af911175463db8" sha1="2e0f0ae69eb98a079baab365f99af7ae56099edc" status="verified" />
-	</game>
-	<game name="Pro Mahjong Kiwame 64 (Japan)" cloneof="Pro Mahjong Kiwame 64 (Japan) (Rev 1)">
+	<game name="Pro Mahjong Kiwame 64 (Japan)" id="0590" cloneofid="0883">
 		<description>Pro Mahjong Kiwame 64 (Japan)</description>
 		<rom name="Pro Mahjong Kiwame 64 (Japan).n64" />
-		<rom name="Pro Mahjong Kiwame 64 (Japan).z64" size="8388608" crc="1f5907f9" md5="7995d76f4ce236b0f0289f47ae523d32" sha1="b5be6c3b49ad37c0dd1d6e7dacbcbe03653859d9" />
+		<rom name="Pro Mahjong Kiwame 64 (Japan).z64" size="8388608" crc="1f5907f9" md5="7995d76f4ce236b0f0289f47ae523d32" sha1="b5be6c3b49ad37c0dd1d6e7dacbcbe03653859d9" serial="NKMJ" />
 	</game>
-	<game name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)">
+	<game name="Pro Mahjong Kiwame 64 (Japan) (Rev 1)" id="0883">
+		<description>Pro Mahjong Kiwame 64 (Japan) (Rev 1)</description>
+		<rom name="Pro Mahjong Kiwame 64 (Japan) (Rev 1).n64" />
+		<rom name="Pro Mahjong Kiwame 64 (Japan) (Rev 1).z64" size="8388608" crc="b9be7b90" md5="b42f62483f7ca2aac5af911175463db8" sha1="2e0f0ae69eb98a079baab365f99af7ae56099edc" status="verified" serial="NKMJ" />
+	</game>
+	<game name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)" id="0591">
 		<description>Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)</description>
 		<rom name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan).n64" />
-		<release name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)" region="JPN" />
-		<rom name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan).z64" size="8388608" crc="35461699" md5="f1a2e4dd22adf4f90da4bddca37d5f18" sha1="25bc862bfabdc972459e8ec2f4173bd5d638eff3" />
+		<rom name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan).z64" size="8388608" crc="35461699" md5="f1a2e4dd22adf4f90da4bddca37d5f18" sha1="25bc862bfabdc972459e8ec2f4173bd5d638eff3" status="verified" serial="NNRJ" />
 	</game>
-	<game name="Puyo Puyo Sun 64 (Japan)">
+	<game name="Puyo Puyo Sun 64 (Japan)" id="0593">
 		<description>Puyo Puyo Sun 64 (Japan)</description>
 		<rom name="Puyo Puyo Sun 64 (Japan).n64" />
-		<release name="Puyo Puyo Sun 64 (Japan)" region="JPN" />
-		<rom name="Puyo Puyo Sun 64 (Japan).z64" size="8388608" crc="355ff9de" md5="faaa2094b04dca4c287af9334d22529d" sha1="cf79ec32e7e78b2cad15b5b7dd763f578648b6c6" status="verified" />
+		<rom name="Puyo Puyo Sun 64 (Japan).z64" size="8388608" crc="355ff9de" md5="faaa2094b04dca4c287af9334d22529d" sha1="cf79ec32e7e78b2cad15b5b7dd763f578648b6c6" sha256="198d2a83176784e3b4c457cef631eb2493f3def99f1fd922e9e4c4c9582c140b" status="verified" serial="NPYJ" />
 	</game>
-	<game name="Puyo Puyoon Party (Japan)">
+	<game name="Puyo Puyoon Party (Japan)" id="0592">
 		<description>Puyo Puyoon Party (Japan)</description>
 		<rom name="Puyo Puyoon Party (Japan).n64" />
-		<release name="Puyo Puyoon Party (Japan)" region="JPN" />
-		<rom name="Puyo Puyoon Party (Japan).z64" size="12582912" crc="d59d2794" md5="22b86ab3f320a607899a0516c90a24d0" sha1="d5553182ecda2eba6076e7b04b900ef78b700fc5" />
+		<rom name="Puyo Puyoon Party (Japan).z64" size="12582912" crc="d59d2794" md5="22b86ab3f320a607899a0516c90a24d0" sha1="d5553182ecda2eba6076e7b04b900ef78b700fc5" serial="NPTJ" />
 	</game>
-	<game name="Quake (Europe)">
+	<game name="Puzzle Bobble 64 (Japan)" id="0594" cloneofid="0107">
+		<description>Puzzle Bobble 64 (Japan)</description>
+		<rom name="Puzzle Bobble 64 (Japan).n64" />
+		<rom name="Puzzle Bobble 64 (Japan).z64" size="8388608" crc="ea837423" md5="b478d4af60d43c38ba81de9faea6e057" sha1="9a4cdde04e6c42cf7957bf578a0b15ca90203280" serial="NPBJ" />
+	</game>
+	<game name="Quake (Europe)" id="0595">
 		<description>Quake (Europe)</description>
 		<rom name="Quake (Europe).n64" />
-		<release name="Quake (Europe)" region="EUR" />
-		<rom name="Quake (Europe).z64" size="12582912" crc="28c10844" md5="592ce7718efdd1ff2f077c9b2b5275fb" sha1="c1b4fc22a1699be0bc8cea170ac4f8b6bf8f41d1" status="verified" />
+		<rom name="Quake (Europe).z64" size="12582912" crc="28c10844" md5="592ce7718efdd1ff2f077c9b2b5275fb" sha1="c1b4fc22a1699be0bc8cea170ac4f8b6bf8f41d1" sha256="b6f02382d292f06f3730b8bbe6d308bf9423780e9369a65b4df3cd0a46680f7b" status="verified" serial="NQKP" />
 	</game>
-	<game name="Quake (USA)" cloneof="Quake (Europe)">
+	<game name="Quake (USA)" id="0596" cloneofid="0595">
 		<description>Quake (USA)</description>
 		<rom name="Quake (USA).n64" />
-		<release name="Quake (USA)" region="USA" />
-		<rom name="Quake (USA).z64" size="12582912" crc="761f39d1" md5="097605021951024c3ecb2d502c0c2a9f" sha1="25a7fe0342490d3c23328040bb34f8748995537a" />
+		<rom name="Quake (USA).z64" size="12582912" crc="761f39d1" md5="097605021951024c3ecb2d502c0c2a9f" sha1="25a7fe0342490d3c23328040bb34f8748995537a" sha256="ce43bcb4c11975f0e1720d7617c05bf23f420b1f76ab115ff52ba7344594a4bc" serial="NQKE" />
 	</game>
-	<game name="Quake II (Europe)">
+	<game name="Quake II (Europe)" id="0597">
 		<description>Quake II (Europe)</description>
 		<rom name="Quake II (Europe).n64" />
-		<release name="Quake II (Europe)" region="EUR" />
-		<rom name="Quake II (Europe).z64" size="12582912" crc="82beca21" md5="673d4ba4f41a0fe23650f06af53eec50" sha1="f99cc966965e8fa0beb9fd768c646e6686e19916" />
+		<rom name="Quake II (Europe).z64" size="12582912" crc="82beca21" md5="673d4ba4f41a0fe23650f06af53eec50" sha1="f99cc966965e8fa0beb9fd768c646e6686e19916" sha256="695ca7d96730543d3dac0fa40be7f2a1d365d48700093afd00a42cddff229445" status="verified" serial="NQ2P" />
 	</game>
-	<game name="Quake II (USA)" cloneof="Quake II (Europe)">
+	<game name="Quake II (USA)" id="0598" cloneofid="0597">
 		<description>Quake II (USA)</description>
 		<rom name="Quake II (USA).n64" />
-		<release name="Quake II (USA)" region="USA" />
-		<rom name="Quake II (USA).z64" size="12582912" crc="e6b34387" md5="cc93c30c633ff461c29b54ceabefd701" sha1="2edb00e602e7c2813a5d6a04dfec80487627237a" />
+		<rom name="Quake II (USA).z64" size="12582912" crc="e6b34387" md5="cc93c30c633ff461c29b54ceabefd701" sha1="2edb00e602e7c2813a5d6a04dfec80487627237a" serial="NQ2E" />
 	</game>
-	<game name="Rakugakids (Europe)">
+	<game name="Quest 64 (USA)" id="0599" cloneofid="0285">
+		<description>Quest 64 (USA)</description>
+		<rom name="Quest 64 (USA).n64" />
+		<rom name="Quest 64 (USA).z64" size="16777216" crc="d75b45c6" md5="ea552e33973468233a0712c251abdb6b" sha1="91b96e938c6d91699057fad91d726ee5a23ce33a" sha256="3292d99dd93c3054906887a84a00efdd747ee620cbea4601df2f7f82d5f74c74" status="verified" serial="NETE" />
+	</game>
+	<game name="Racing Simulation 2 (Germany)" id="0600" cloneofid="0449">
+		<description>Racing Simulation 2 (Germany)</description>
+		<rom name="Racing Simulation 2 (Germany).n64" />
+		<rom name="Racing Simulation 2 (Germany).z64" size="16777216" crc="ba73a7e4" md5="aa57d69867f53456f351a289eba08c3d" sha1="08bc64cb8c64db9b048fc1522fd5e808ff63ce1a" sha256="d06dcf5924f201a645988d624b4bc7beddb60d35ddc78f6b9a6b7e11d9f905cd" serial="NMGD" />
+	</game>
+	<game name="Rakugakids (Europe)" id="0601">
 		<description>Rakugakids (Europe)</description>
 		<rom name="Rakugakids (Europe).n64" />
-		<release name="Rakugakids (Europe)" region="EUR" />
-		<rom name="Rakugakids (Europe).z64" size="12582912" crc="483129aa" md5="167a3502f06cf0eef56758533f3d0e52" sha1="a2846cb316dc980dd0040ca95c20abfc8ccce212" />
+		<rom name="Rakugakids (Europe).z64" size="12582912" crc="483129aa" md5="167a3502f06cf0eef56758533f3d0e52" sha1="a2846cb316dc980dd0040ca95c20abfc8ccce212" sha256="c9aa31b4f500c77b49efce28894786df9e75341f297742cc7a681037ad8759d0" status="verified" serial="NKRP" />
 	</game>
-	<game name="Rakugakids (Japan)" cloneof="Rakugakids (Europe)">
+	<game name="Rakugakids (Japan)" id="0602" cloneofid="0601">
 		<description>Rakugakids (Japan)</description>
 		<rom name="Rakugakids (Japan).n64" />
-		<release name="Rakugakids (Japan)" region="JPN" />
-		<rom name="Rakugakids (Japan).z64" size="12582912" crc="b9e53b06" md5="813ad5c00bad7c4d41f8558cecedae51" sha1="43596236cc1a4a4b671d0586fb42518a009427a5" />
+		<rom name="Rakugakids (Japan).z64" size="12582912" crc="b9e53b06" md5="813ad5c00bad7c4d41f8558cecedae51" sha1="43596236cc1a4a4b671d0586fb42518a009427a5" serial="NKRJ" />
 	</game>
-	<game name="Rally Challenge 2000 (USA)">
-		<description>Rally Challenge 2000 (USA)</description>
-		<rom name="Rally Challenge 2000 (USA).n64" />
-		<release name="Rally Challenge 2000 (USA)" region="USA" />
-		<rom name="Rally Challenge 2000 (USA).z64" size="12582912" crc="3edec7b0" md5="0458bc47cd771d8bc66b0ceae6895724" sha1="d42fd8de45755cd70a4d4c252cc1873410db9f3e" />
-	</game>
-	<game name="Rally '99 (Japan)" cloneof="Rally Challenge 2000 (USA)">
+	<game name="Rally '99 (Japan)" id="0603" cloneofid="0604">
 		<description>Rally '99 (Japan)</description>
 		<rom name="Rally '99 (Japan).n64" />
-		<release name="Rally '99 (Japan)" region="JPN" />
-		<rom name="Rally '99 (Japan).z64" size="8388608" crc="ffa625fe" md5="0630226f63561a05916edcfbc8d96c04" sha1="8d3659925433b9d4c37d06abd2e1c4662aa80e1f" />
+		<rom name="Rally '99 (Japan).z64" size="12582912" crc="99f25365" md5="21100a964605f7d0849417ad9a3c1590" sha1="1419653ad8cf5e9f5fa5cb8166760c3fd4c1b149" sha256="cd7b68d4eadc48d7182d18ba7a6fa5afe6aacba1f99d310d5f7874fcf312ee25" serial="NRAJ" />
 	</game>
-	<game name="Rampage - World Tour (Europe)">
+	<game name="Rally Challenge 2000 (USA)" id="0604">
+		<description>Rally Challenge 2000 (USA)</description>
+		<rom name="Rally Challenge 2000 (USA).n64" />
+		<rom name="Rally Challenge 2000 (USA).z64" size="12582912" crc="3edec7b0" md5="0458bc47cd771d8bc66b0ceae6895724" sha1="d42fd8de45755cd70a4d4c252cc1873410db9f3e" serial="NWQE" />
+	</game>
+	<game name="Rampage - World Tour (Europe)" id="0605">
 		<description>Rampage - World Tour (Europe)</description>
 		<rom name="Rampage - World Tour (Europe).n64" />
-		<release name="Rampage - World Tour (Europe)" region="EUR" />
-		<rom name="Rampage - World Tour (Europe).z64" size="12582912" crc="cdc458ec" md5="08e02f52e0547686a9bfac7cbb03c129" sha1="c8db2a3669b08050f42af47bae9fd5146b8c87bb" />
+		<rom name="Rampage - World Tour (Europe).z64" size="12582912" crc="cdc458ec" md5="08e02f52e0547686a9bfac7cbb03c129" sha1="c8db2a3669b08050f42af47bae9fd5146b8c87bb" sha256="3667dd20e8ef97659e5d09d718bbd5efe2f517d8afcab7be76688abb11e64008" status="verified" serial="NRPP" />
 	</game>
-	<game name="Rampage - World Tour (USA)" cloneof="Rampage - World Tour (Europe)">
+	<game name="Rampage - World Tour (USA)" id="0606" cloneofid="0605">
 		<description>Rampage - World Tour (USA)</description>
 		<rom name="Rampage - World Tour (USA).n64" />
-		<release name="Rampage - World Tour (USA)" region="USA" />
-		<rom name="Rampage - World Tour (USA).z64" size="12582912" crc="211119dd" md5="4645672a0cf00ada9b5e37cfde8b024e" sha1="7a6c8758e67fd3da99e3420983c0d6df83e41c6b" />
+		<rom name="Rampage - World Tour (USA).z64" size="12582912" crc="211119dd" md5="4645672a0cf00ada9b5e37cfde8b024e" sha1="7a6c8758e67fd3da99e3420983c0d6df83e41c6b" sha256="a06da4bf6342670df551738c07ed2d1c91ee12c29df73c0c3f8eeae2ea1016ea" serial="NRPE" />
 	</game>
-	<game name="Rampage 2 - Universal Tour (Europe)">
+	<game name="Rampage 2 - Universal Tour (Europe)" id="0607">
 		<description>Rampage 2 - Universal Tour (Europe)</description>
 		<rom name="Rampage 2 - Universal Tour (Europe).n64" />
-		<release name="Rampage 2 - Universal Tour (Europe)" region="EUR" />
-		<rom name="Rampage 2 - Universal Tour (Europe).z64" size="12582912" crc="fa6e097b" md5="1492806f12d33c3ea0edb6848d43b1cc" sha1="0c18a10807a5f910ce7337812770b4fe18994a60" />
+		<rom name="Rampage 2 - Universal Tour (Europe).z64" size="12582912" crc="fa6e097b" md5="1492806f12d33c3ea0edb6848d43b1cc" sha1="0c18a10807a5f910ce7337812770b4fe18994a60" sha256="ef59e77d8444785c4ca4b6aedc744e8d57edde65f3a4cee24cf48bf153a33a63" status="verified" serial="N2PP" />
 	</game>
-	<game name="Rampage 2 - Universal Tour (USA)" cloneof="Rampage 2 - Universal Tour (Europe)">
+	<game name="Rampage 2 - Universal Tour (USA)" id="0608" cloneofid="0607">
 		<description>Rampage 2 - Universal Tour (USA)</description>
 		<rom name="Rampage 2 - Universal Tour (USA).n64" />
-		<release name="Rampage 2 - Universal Tour (USA)" region="USA" />
-		<rom name="Rampage 2 - Universal Tour (USA).z64" size="12582912" crc="7614ee0d" md5="8113d0ea2008402d4631f241f625d16b" sha1="36d1b741f6ea896b05ab7ceeac8b78684cbdac6b" />
+		<rom name="Rampage 2 - Universal Tour (USA).z64" size="12582912" crc="7614ee0d" md5="8113d0ea2008402d4631f241f625d16b" sha1="36d1b741f6ea896b05ab7ceeac8b78684cbdac6b" serial="N2PE" />
 	</game>
-	<game name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Rampage 2 - Universal Tour (USA) (LodgeNet)" id="1155" cloneofid="0607">
+		<category>Games</category>
+		<rom name="Rampage 2 - Universal Tour (USA) (LodgeNet).n64" />
+		<description>Rampage 2 - Universal Tour (USA) (LodgeNet)</description>
+		<rom name="Rampage 2 - Universal Tour (USA) (LodgeNet).i64" size="64" crc="86a3477e" md5="5822ef3f72c1683b42b2bf7e686dc7be" sha1="5aff7233b78eb203563353089be032037c9af651" />
+		<rom name="Rampage 2 - Universal Tour (USA) (LodgeNet).z64" size="12582912" crc="c28afc5e" md5="6fc669845efbcef9ae45d67ba38d2fa6" sha1="0a6c390b7d1a96b93fc28faa3b11cf18400b1773" />
+	</game>
+	<game name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl)" id="0609">
 		<description>Rat Attack (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="dd4fa798" md5="bc66239c12ae8696926e50c2b6ed9c49" sha1="b27e328f7600b7a2e175e4a36d8c85073eaf4d0e" />
+		<rom name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="dd4fa798" md5="bc66239c12ae8696926e50c2b6ed9c49" sha1="b27e328f7600b7a2e175e4a36d8c85073eaf4d0e" serial="NRTP" />
 	</game>
-	<game name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl)" cloneof="Rat Attack (Europe) (En,Fr,De,Es,It,Nl)">
-		<description>Rat Attack! (USA) (En,Fr,De,Es,It,Nl)</description>
-		<rom name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl)" region="USA" />
-		<rom name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="2315fea7" md5="f661889fdf65ddcd212e9fb53b2c8f50" sha1="0682b6745832984f43652c0589e4ecf37f937790" />
+	<game name="Rat Attack! (USA)" id="0610" cloneofid="0609">
+		<category>Games</category>
+		<rom name="Rat Attack! (USA).n64" />
+		<description>Rat Attack! (USA)</description>
+		<rom name="Rat Attack! (USA).z64" size="8388608" crc="2315fea7" md5="f661889fdf65ddcd212e9fb53b2c8f50" sha1="0682b6745832984f43652c0589e4ecf37f937790" serial="NRTE" />
 	</game>
-	<game name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)">
+	<game name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)" id="0611">
 		<description>Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)</description>
 		<rom name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="169a5037" md5="5dbbfd5ace8222fa8fe51be113453c13" sha1="619ab27ea1645399439ad324566361d3e7ff020e" />
+		<rom name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="169a5037" md5="5dbbfd5ace8222fa8fe51be113453c13" sha1="619ab27ea1645399439ad324566361d3e7ff020e" sha256="c80b063de6afe80bb47281efe76406654070e942d5a733fee2668c8e11a2581b" status="verified" serial="NY2P" />
 	</game>
-	<game name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)" cloneof="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)">
+	<game name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)" id="0612" cloneofid="0611">
 		<description>Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)</description>
 		<rom name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It).n64" />
-		<release name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)" region="USA" />
-		<rom name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It).z64" size="33554432" crc="02bb4409" md5="03aa4d09fde77eed9b95be68e603d233" sha1="50558356b059ad3fbaf5fe95380512b9dceaaf52" />
+		<rom name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It).z64" size="33554432" crc="02bb4409" md5="03aa4d09fde77eed9b95be68e603d233" sha1="50558356b059ad3fbaf5fe95380512b9dceaaf52" sha256="e9a71380b43e25b998f638480b309e300ad9b8a0439ff36e0a8b5fc4ac132e8a" status="verified" serial="NY2E" />
 	</game>
-	<game name="Razor Freestyle Scooter (USA)">
+	<game name="Razmoket, Les - La Chasse aux Tresors (France)" id="0613" cloneofid="0638">
+		<description>Razmoket, Les - La Chasse aux Tresors (France)</description>
+		<rom name="Razmoket, Les - La Chasse aux Tresors (France).n64" />
+		<rom name="Razmoket, Les - La Chasse aux Tresors (France).z64" size="16777216" crc="66766469" md5="55685d6324efde5bc9d26c98706b0b8a" sha1="69c06b2d31bc6bc66cd028705d81024f21a7654c" sha256="ec6d2cbe4db8c2a8dbc6d7f80e302f45e0752ec4a8745ebc6da8b8bf7609b12f" serial="NRGF" />
+	</game>
+	<game name="Razor Freestyle Scooter (USA)" id="0614">
 		<description>Razor Freestyle Scooter (USA)</description>
 		<rom name="Razor Freestyle Scooter (USA).n64" />
-		<release name="Razor Freestyle Scooter (USA)" region="USA" />
-		<rom name="Razor Freestyle Scooter (USA).z64" size="8388608" crc="927ce621" md5="406b08987ab92d73d72b597ec6b11bd9" sha1="d107e8d28a262a60ba50de4c227343ebc3587784" />
+		<rom name="Razor Freestyle Scooter (USA).z64" size="8388608" crc="927ce621" md5="406b08987ab92d73d72b597ec6b11bd9" sha1="d107e8d28a262a60ba50de4c227343ebc3587784" sha256="bdb827e672625c795e1c8be7645c8a4ea3fd5c6ed41cdd16b16980d86481f5f4" serial="NFQE" />
 	</game>
-	<game name="Re-Volt (Europe) (En,Fr,De,Es)">
+	<game name="Re-Volt (Europe) (En,Fr,De,Es)" id="0615">
 		<description>Re-Volt (Europe) (En,Fr,De,Es)</description>
 		<rom name="Re-Volt (Europe) (En,Fr,De,Es).n64" />
-		<release name="Re-Volt (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Re-Volt (Europe) (En,Fr,De,Es).z64" size="12582912" crc="81d13a11" md5="faa64abb0d222fcc0c6e2515d3805d9f" sha1="5ed3cd3888fec080d44ffe345dd50d75e471ff8f" />
+		<rom name="Re-Volt (Europe) (En,Fr,De,Es).z64" size="12582912" crc="81d13a11" md5="faa64abb0d222fcc0c6e2515d3805d9f" sha1="5ed3cd3888fec080d44ffe345dd50d75e471ff8f" sha256="ce619ae064bc608d9a139f95e6bbc9f17fe3898d242943bc92fd0d6fc74915b0" status="verified" serial="NRVP" />
 	</game>
-	<game name="Re-Volt (USA)" cloneof="Re-Volt (Europe) (En,Fr,De,Es)">
+	<game name="Re-Volt (USA)" id="0616" cloneofid="0615">
 		<description>Re-Volt (USA)</description>
 		<rom name="Re-Volt (USA).n64" />
-		<release name="Re-Volt (USA)" region="USA" />
-		<rom name="Re-Volt (USA).z64" size="12582912" crc="fc0c86d0" md5="3fc4d3187435443455f8355b2d3f8934" sha1="667fdc39112599bd904f5e7d8d692973e554bd88" />
+		<rom name="Re-Volt (USA).z64" size="12582912" crc="fc0c86d0" md5="3fc4d3187435443455f8355b2d3f8934" sha1="667fdc39112599bd904f5e7d8d692973e554bd88" serial="NRVE" />
 	</game>
-	<game name="Ready 2 Rumble Boxing (Europe) (En,Fr,De)">
+	<game name="Ready 2 Rumble Boxing (Europe) (En,Fr,De)" id="0617">
 		<description>Ready 2 Rumble Boxing (Europe) (En,Fr,De)</description>
 		<rom name="Ready 2 Rumble Boxing (Europe) (En,Fr,De).n64" />
-		<release name="Ready 2 Rumble Boxing (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Ready 2 Rumble Boxing (Europe) (En,Fr,De).z64" size="33554432" crc="a69df7b3" md5="adc95ae01855fa305b13f8b22427e597" sha1="e18477d858c623a834f24dc2717d0ef340e63364" />
+		<rom name="Ready 2 Rumble Boxing (Europe) (En,Fr,De).z64" size="33554432" crc="a69df7b3" md5="adc95ae01855fa305b13f8b22427e597" sha1="e18477d858c623a834f24dc2717d0ef340e63364" sha256="2546b5f00c6f0188a31f9ba3782abe059c7dd83fcfee8ff738542eb06a4aafc3" status="verified" serial="NRDP" />
 	</game>
-	<game name="Ready 2 Rumble Boxing (USA)" cloneof="Ready 2 Rumble Boxing (Europe) (En,Fr,De)">
+	<game name="Ready 2 Rumble Boxing (USA)" id="0618" cloneofid="0617">
 		<description>Ready 2 Rumble Boxing (USA)</description>
 		<rom name="Ready 2 Rumble Boxing (USA).n64" />
-		<release name="Ready 2 Rumble Boxing (USA)" region="USA" />
-		<rom name="Ready 2 Rumble Boxing (USA).z64" size="33554432" crc="2a554048" md5="a42f6f14f7ea10abeb3b55ffd42eb572" sha1="e60fedd535a72fda5c424b846421bbdad17c6caa" />
+		<rom name="Ready 2 Rumble Boxing (USA).z64" size="33554432" crc="2a554048" md5="a42f6f14f7ea10abeb3b55ffd42eb572" sha1="e60fedd535a72fda5c424b846421bbdad17c6caa" sha256="649e9f45d7386c3ff5f196d4053d6f458fa5d105264ee88c5937ffd92c7a1bf7" serial="NRDE" />
 	</game>
-	<game name="Ready 2 Rumble Boxing - Round 2 (USA)">
+	<game name="Ready 2 Rumble Boxing (USA) (LodgeNet)" id="1156" cloneofid="0617">
+		<category>Games</category>
+		<rom name="Ready 2 Rumble Boxing (USA) (LodgeNet).n64" />
+		<description>Ready 2 Rumble Boxing (USA) (LodgeNet)</description>
+		<rom name="Ready 2 Rumble Boxing (USA) (LodgeNet).i64" size="64" crc="eda5e440" md5="f480833164cca521ee70517baf1f83d6" sha1="c8f691d1e88ddf1423685b593d3b6496728448ad" />
+		<rom name="Ready 2 Rumble Boxing (USA) (LodgeNet).z64" size="33248096" crc="6d8dab04" md5="ba7a6054cedf7851b1d8f20efecb02a7" sha1="2ad70a3243a20cd02d24103a2717c90654c173ac" />
+	</game>
+	<game name="Ready 2 Rumble Boxing - Round 2 (USA)" id="0619">
 		<description>Ready 2 Rumble Boxing - Round 2 (USA)</description>
 		<rom name="Ready 2 Rumble Boxing - Round 2 (USA).n64" />
-		<release name="Ready 2 Rumble Boxing - Round 2 (USA)" region="USA" />
-		<rom name="Ready 2 Rumble Boxing - Round 2 (USA).z64" size="33554432" crc="052a0e04" md5="df4446a2b55c4d8d67e9c0c19e0fd9fb" sha1="42ad558c20dda72e9383323960cd1fd591122052" />
+		<rom name="Ready 2 Rumble Boxing - Round 2 (USA).z64" size="33554432" crc="052a0e04" md5="df4446a2b55c4d8d67e9c0c19e0fd9fb" sha1="42ad558c20dda72e9383323960cd1fd591122052" sha256="a075e7ca185b3800639d333359a04100e087db297fd2f5eab88f7dcd90ab5563" serial="N22E" />
 	</game>
-	<game name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual)">
-		<description>Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual)</description>
-		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual).n64" />
-		<release name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual)" region="CHN" />
-		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual).z64" size="294912" crc="007f3759" md5="3abc2d34ad3ce623f4ed8f126d30cc80" sha1="85fd084f9b34c5f2b90f5fdb73847e47df9f5667" />
-	</game>
-	<game name="Resident Evil 2 (Europe) (En,Fr)">
+	<game name="Resident Evil 2 (Europe) (En,Fr)" id="0620">
 		<description>Resident Evil 2 (Europe) (En,Fr)</description>
 		<rom name="Resident Evil 2 (Europe) (En,Fr).n64" />
-		<release name="Resident Evil 2 (Europe) (En,Fr)" region="EUR" />
-		<rom name="Resident Evil 2 (Europe) (En,Fr).z64" size="67108864" crc="7c8ee011" md5="b04f298721223a22e1150cebc712ee6a" sha1="d54561791bc41f1b743f8abe769a6e8cbf435326" status="verified" />
+		<rom name="Resident Evil 2 (Europe) (En,Fr).z64" size="67108864" crc="7c8ee011" md5="b04f298721223a22e1150cebc712ee6a" sha1="d54561791bc41f1b743f8abe769a6e8cbf435326" sha256="52093e994c89848b17c8e6f26546d66374cf47c9b471ec15da7f322b7ee17ab8" status="verified" serial="NREP" />
 	</game>
-	<game name="Biohazard 2 (Japan)" cloneof="Resident Evil 2 (Europe) (En,Fr)">
-		<description>Biohazard 2 (Japan)</description>
-		<rom name="Biohazard 2 (Japan).n64" />
-		<release name="Biohazard 2 (Japan)" region="JPN" />
-		<rom name="Biohazard 2 (Japan).z64" size="67108864" crc="4f9d569f" md5="f77d70959222276491222f31ebff3bf1" sha1="7492139f237c547ef32955c7cc6b9a5e6dcaa55d" />
-	</game>
-	<game name="Resident Evil 2 (USA) (Rev 1)" cloneof="Resident Evil 2 (Europe) (En,Fr)">
+	<game name="Resident Evil 2 (USA) (Rev 1)" id="0621" cloneofid="0620">
 		<description>Resident Evil 2 (USA) (Rev 1)</description>
 		<rom name="Resident Evil 2 (USA) (Rev 1).n64" />
-		<release name="Resident Evil 2 (USA) (Rev 1)" region="USA" />
-		<rom name="Resident Evil 2 (USA) (Rev 1).z64" size="67108864" crc="848fbc0d" md5="1add2c0217662b307cdfd876b35fbf7a" sha1="62ec19bead748c12d38f6c5a7ab0831edbd3d44b" />
+		<rom name="Resident Evil 2 (USA) (Rev 1).z64" size="67108864" crc="848fbc0d" md5="1add2c0217662b307cdfd876b35fbf7a" sha1="62ec19bead748c12d38f6c5a7ab0831edbd3d44b" sha256="71f3f779613bf1f0e2050bfa600425385d2c257a647d2e40f63be1a7986e9aac" status="verified" serial="NREE" />
 	</game>
-	<game name="Resident Evil 2 (USA)" cloneof="Resident Evil 2 (Europe) (En,Fr)">
+	<game name="Resident Evil 2 (USA)" id="0902" cloneofid="0620">
 		<description>Resident Evil 2 (USA)</description>
 		<rom name="Resident Evil 2 (USA).n64" />
-		<rom name="Resident Evil 2 (USA).z64" size="67108864" crc="832ea1da" md5="dd21150cbc21c05420304599ec57411c" sha1="93187c4145cad272a255c17657cd9a1011b3fb3a" />
+		<rom name="Resident Evil 2 (USA).z64" size="67108864" crc="832ea1da" md5="dd21150cbc21c05420304599ec57411c" sha1="93187c4145cad272a255c17657cd9a1011b3fb3a" serial="NREE" />
 	</game>
-	<game name="Road Rash 64 (Europe)">
+	<game name="Road Rash 64 (Europe)" id="0622">
 		<description>Road Rash 64 (Europe)</description>
 		<rom name="Road Rash 64 (Europe).n64" />
-		<release name="Road Rash 64 (Europe)" region="EUR" />
-		<rom name="Road Rash 64 (Europe).z64" size="33554432" crc="3c664a7b" md5="ad922dae446a301e1aafe1dfbad75a2e" sha1="816824cb5dc62ee54dc52c0ebb9b2564ecb88133" />
+		<rom name="Road Rash 64 (Europe).z64" size="33554432" crc="3c664a7b" md5="ad922dae446a301e1aafe1dfbad75a2e" sha1="816824cb5dc62ee54dc52c0ebb9b2564ecb88133" sha256="bfc3324c7689d6b76fbda6e4a431ae5eeb017da9707240d1d21109fda3a1e610" status="verified" serial="NROP" />
 	</game>
-	<game name="Road Rash 64 (USA)" cloneof="Road Rash 64 (Europe)">
+	<game name="Road Rash 64 (USA)" id="0623" cloneofid="0622">
 		<description>Road Rash 64 (USA)</description>
 		<rom name="Road Rash 64 (USA).n64" />
-		<release name="Road Rash 64 (USA)" region="USA" />
-		<rom name="Road Rash 64 (USA).z64" size="33554432" crc="600b3988" md5="28c2373f6d831eec81f6146a809e701b" sha1="87727a298f583ec8325f5655088ff21e37b335b2" />
+		<rom name="Road Rash 64 (USA).z64" size="33554432" crc="600b3988" md5="28c2373f6d831eec81f6146a809e701b" sha1="87727a298f583ec8325f5655088ff21e37b335b2" serial="NROE" />
 	</game>
-	<game name="Road Rash 64 (Europe) (Beta) (1999-10-12)" cloneof="Road Rash 64 (Europe)">
+	<game name="Road Rash 64 (Europe) (Beta) (1999-10-12)" id="1055" cloneofid="0622">
 		<description>Road Rash 64 (Europe) (Beta) (1999-10-12)</description>
 		<rom name="Road Rash 64 (Europe) (Beta) (1999-10-12).n64" />
-		<rom name="Road Rash 64 (Europe) (Beta) (1999-10-12).z64" size="33554432" crc="4fb98385" md5="436f93c0d8b1650bc308ccf344c08c93" sha1="615fed220a13096bb6fc4c5d7902c66fc5a044d7" />
+		<rom name="Road Rash 64 (Europe) (Beta) (1999-10-12).z64" size="33554432" crc="4fb98385" md5="436f93c0d8b1650bc308ccf344c08c93" sha1="615fed220a13096bb6fc4c5d7902c66fc5a044d7" sha256="7d0047fe373a032756bb97468c4db59929468abf3a42b45544e31cc5cbfdbc80" serial="NROP" />
 	</game>
-	<game name="Roadsters (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Road Rash 64 (USA) (Beta 1)" id="1109" cloneofid="0622">
+		<category>Games</category>
+		<rom name="Road Rash 64 (USA) (Beta 1).n64" />
+		<description>Road Rash 64 (USA) (Beta 1)</description>
+		<rom name="Road Rash 64 (USA) (Beta 1).z64" size="33554432" crc="47884c05" md5="4d1d8b2bb146a98a66e23189b67ec12f" sha1="61d9fffea1565703d656a4468108d45af7199c09" sha256="93dcac74d4d4462d555feac7324c4b9ccdb5b12d86e843b10919bd009d727fa1" serial="!none" />
+	</game>
+	<game name="Road Rash 64 (USA) (Beta 2)" id="1110" cloneofid="0622">
+		<category>Games</category>
+		<rom name="Road Rash 64 (USA) (Beta 2).n64" />
+		<description>Road Rash 64 (USA) (Beta 2)</description>
+		<rom name="Road Rash 64 (USA) (Beta 2).z64" size="33554432" crc="e5079d96" md5="4a2400af877b161fc7a265e46be53251" sha1="cd4d68ceb61a663175bcea7f7492d95c27268838" sha256="70822f8b0a6ae09e8eed5789b584c4f4c1622777c621d402ab1797ddbc1e261b" serial="NROE" />
+	</game>
+	<game name="Roadsters (Europe) (En,Fr,De,Es,It,Nl)" id="0624">
 		<description>Roadsters (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Roadsters (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Roadsters (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Roadsters (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="997ed5af" md5="41f67b5c8bb8daeffd989123846fc063" sha1="2ad3bccd29dc879a873c926af03002e36582525a" />
+		<rom name="Roadsters (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="997ed5af" md5="41f67b5c8bb8daeffd989123846fc063" sha1="2ad3bccd29dc879a873c926af03002e36582525a" sha256="ba3307883fe81ddeb81ed6a51cb1d4cd9d3353c73ca9007c02212c777b572e2e" status="verified" serial="NRRP" />
 	</game>
-	<game name="Roadsters (USA) (En,Fr,Es)" cloneof="Roadsters (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Roadsters (USA) (En,Fr,Es)" id="0625" cloneofid="0624">
 		<description>Roadsters (USA) (En,Fr,Es)</description>
 		<rom name="Roadsters (USA) (En,Fr,Es).n64" />
-		<release name="Roadsters (USA) (En,Fr,Es)" region="USA" />
-		<rom name="Roadsters (USA) (En,Fr,Es).z64" size="12582912" crc="e4337b92" md5="d3644b398c090528e0ed9eb3c140366e" sha1="d896ffcba44696bdb7e2048841f287ea5951ad2a" />
+		<rom name="Roadsters (USA) (En,Fr,Es).z64" size="12582912" crc="e4337b92" md5="d3644b398c090528e0ed9eb3c140366e" sha1="d896ffcba44696bdb7e2048841f287ea5951ad2a" serial="NRRE" />
 	</game>
-	<game name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)">
+	<game name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)" id="0626">
 		<description>Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)</description>
 		<rom name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan).n64" />
-		<release name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)" region="JPN" />
-		<rom name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan).z64" size="33554432" crc="3b0f8061" md5="444f70a655ac89ca900f6fafaf926b16" sha1="9bc6130916d8a1d8bcec5f38fbbff066444838cd" />
+		<rom name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan).z64" size="33554432" crc="3b0f8061" md5="444f70a655ac89ca900f6fafaf926b16" sha1="9bc6130916d8a1d8bcec5f38fbbff066444838cd" serial="NR7J" />
 	</game>
-	<game name="Robotech - Crystal Dreams (USA) (Proto 2)">
+	<game name="Robotech - Crystal Dreams (USA) (Proto 2)" id="0627">
 		<description>Robotech - Crystal Dreams (USA) (Proto 2)</description>
 		<rom name="Robotech - Crystal Dreams (USA) (Proto 2).n64" />
-		<release name="Robotech - Crystal Dreams (USA) (Proto 2)" region="USA" />
 		<rom name="Robotech - Crystal Dreams (USA) (Proto 2).z64" size="16777216" crc="f9a7904e" md5="b39592c6c9a3121258bdb62485956880" sha1="8051c03135447a92b21aface5b00111c3b4af773" />
 	</game>
-	<game name="Robotech - Crystal Dreams (USA) (Proto 1)" cloneof="Robotech - Crystal Dreams (USA) (Proto 2)">
+	<game name="Robotech - Crystal Dreams (USA) (Proto 1)" id="1036" cloneofid="0627">
 		<description>Robotech - Crystal Dreams (USA) (Proto 1)</description>
 		<rom name="Robotech - Crystal Dreams (USA) (Proto 1).n64" />
 		<rom name="Robotech - Crystal Dreams (USA) (Proto 1).z64" size="16777216" crc="baa8646d" md5="e40ba4761ce977f3fb02151354812d99" sha1="6fde818ae618a92eb9008769d9459b2eaf927246" />
 	</game>
-	<game name="Robotron 64 (Europe)">
+	<game name="Robotron 64 (Europe)" id="0628">
 		<description>Robotron 64 (Europe)</description>
 		<rom name="Robotron 64 (Europe).n64" />
-		<release name="Robotron 64 (Europe)" region="EUR" />
-		<rom name="Robotron 64 (Europe).z64" size="8388608" crc="23bf4956" md5="2abcd1ad41b3356fbc1018ecb121283e" sha1="d86a7ed2f203ba9df0ce5b18d9e4e2e2d9b62a3f" />
+		<rom name="Robotron 64 (Europe).z64" size="8388608" crc="23bf4956" md5="2abcd1ad41b3356fbc1018ecb121283e" sha1="d86a7ed2f203ba9df0ce5b18d9e4e2e2d9b62a3f" sha256="18e582cfc79c8659d06664459bee45d5892291a9264ffda0652cb36c0d548aa6" status="verified" serial="NRXP" />
 	</game>
-	<game name="Robotron 64 (USA)" cloneof="Robotron 64 (Europe)">
+	<game name="Robotron 64 (USA)" id="0629" cloneofid="0628">
 		<description>Robotron 64 (USA)</description>
 		<rom name="Robotron 64 (USA).n64" />
-		<release name="Robotron 64 (USA)" region="USA" />
-		<rom name="Robotron 64 (USA).z64" size="8388608" crc="b2cbae58" md5="5698757883a6f46fe5b4c9b6e780b480" sha1="44d158bc2aeefb111a620b61e043b2703e6c5808" />
+		<rom name="Robotron 64 (USA).z64" size="8388608" crc="3c95e84c" md5="c4a9bbf989ddfaf5f389e4adc6195dbc" sha1="285c720f642649790faaaa02c33636cf1b33d7db" sha256="3ef7690f97d3957af7294eab4432fa1673a15bba0435664cc9fa2fd757168804" serial="NRXE" />
 	</game>
-	<game name="Rocket - Robot on Wheels (Europe) (En,Fr,De)">
+	<game name="Rocket - Robot on Wheels (Europe) (En,Fr,De)" id="0630">
 		<description>Rocket - Robot on Wheels (Europe) (En,Fr,De)</description>
 		<rom name="Rocket - Robot on Wheels (Europe) (En,Fr,De).n64" />
-		<release name="Rocket - Robot on Wheels (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Rocket - Robot on Wheels (Europe) (En,Fr,De).z64" size="12582912" crc="7de5d20d" md5="427c5457d4a29a222811f0caa9cca7b9" sha1="a1aa086f0826bee4be71c16bc67468b8d8a49065" />
+		<rom name="Rocket - Robot on Wheels (Europe) (En,Fr,De).z64" size="12582912" crc="7de5d20d" md5="427c5457d4a29a222811f0caa9cca7b9" sha1="a1aa086f0826bee4be71c16bc67468b8d8a49065" sha256="1ecb0f1620413c8b219856f78255a18f53b03efd25cb065fa1c7e172aa099d4f" status="verified" serial="NSUP" />
 	</game>
-	<game name="Rocket - Robot on Wheels (USA)" cloneof="Rocket - Robot on Wheels (Europe) (En,Fr,De)">
+	<game name="Rocket - Robot on Wheels (USA)" id="0631" cloneofid="0630">
 		<description>Rocket - Robot on Wheels (USA)</description>
 		<rom name="Rocket - Robot on Wheels (USA).n64" />
-		<release name="Rocket - Robot on Wheels (USA)" region="USA" />
-		<rom name="Rocket - Robot on Wheels (USA).z64" size="12582912" crc="e0399f23" md5="c2907eb2f9a350793317ece878a3b8e3" sha1="622d71a44da0b81ea68092cac9198c66154a4f4a" />
+		<rom name="Rocket - Robot on Wheels (USA).z64" size="12582912" crc="e0399f23" md5="c2907eb2f9a350793317ece878a3b8e3" sha1="622d71a44da0b81ea68092cac9198c66154a4f4a" serial="NSUE" />
 	</game>
-	<game name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29)" cloneof="Rocket - Robot on Wheels (Europe) (En,Fr,De)">
+	<game name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29)" id="1047" cloneofid="0630">
 		<description>Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29)</description>
 		<rom name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29).n64" />
-		<rom name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29).z64" size="25165824" crc="7d766772" md5="c33561d58dc04cee752a3a4bd1fb4797" sha1="0786e5be0ea6522a1e9f1a9052dacaf01169298e" />
+		<rom name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29).z64" size="25165824" crc="7d766772" md5="c33561d58dc04cee752a3a4bd1fb4797" sha1="0786e5be0ea6522a1e9f1a9052dacaf01169298e" sha256="1ab8ac8c5f7c904f2202b5f820be5f782b4a5485fbf588a46e566c34e9c36373" serial="NSUP" />
 	</game>
-	<game name="RR64 - Ridge Racer 64 (Europe)">
+	<game name="Rockman Dash - Hagane no Boukenshin (Japan)" id="0632" cloneofid="0428">
+		<description>Rockman Dash - Hagane no Boukenshin (Japan)</description>
+		<rom name="Rockman Dash - Hagane no Boukenshin (Japan).n64" />
+		<rom name="Rockman Dash - Hagane no Boukenshin (Japan).z64" size="33554432" crc="61eaee83" md5="0c74b44680276ffe808cfa6045329819" sha1="e807ed78db0b3440f76b445bf989a943bc05e0ad" serial="NRHJ" />
+	</game>
+	<game name="RR64 - Ridge Racer 64 (Europe)" id="0633">
 		<description>RR64 - Ridge Racer 64 (Europe)</description>
 		<rom name="RR64 - Ridge Racer 64 (Europe).n64" />
-		<release name="RR64 - Ridge Racer 64 (Europe)" region="EUR" />
-		<rom name="RR64 - Ridge Racer 64 (Europe).z64" size="33554432" crc="dd9ae3a8" md5="4561840840760ffa7b59f03a5f416a5c" sha1="faa21c8e0282d21eac2d1b35b020f40381e18fc4" status="verified" />
+		<rom name="RR64 - Ridge Racer 64 (Europe).z64" size="33554432" crc="dd9ae3a8" md5="4561840840760ffa7b59f03a5f416a5c" sha1="faa21c8e0282d21eac2d1b35b020f40381e18fc4" sha256="6ab08cdaebaa41248560e24d4727c45d5ccb372c8f8909fed3d3e6a56dba71be" status="verified" serial="NRZP" />
 	</game>
-	<game name="RR64 - Ridge Racer 64 (USA)" cloneof="RR64 - Ridge Racer 64 (Europe)">
+	<game name="RR64 - Ridge Racer 64 (USA)" id="0634" cloneofid="0633">
 		<description>RR64 - Ridge Racer 64 (USA)</description>
 		<rom name="RR64 - Ridge Racer 64 (USA).n64" />
-		<release name="RR64 - Ridge Racer 64 (USA)" region="USA" />
-		<rom name="RR64 - Ridge Racer 64 (USA).z64" size="33554432" crc="3c2c2d1c" md5="990f97d56456fc23e52bd263e709e21e" sha1="5f079cd9827b24d12af4961482a0fcc679e53042" />
+		<rom name="RR64 - Ridge Racer 64 (USA).z64" size="33554432" crc="3c2c2d1c" md5="990f97d56456fc23e52bd263e709e21e" sha1="5f079cd9827b24d12af4961482a0fcc679e53042" serial="NRZE" />
 	</game>
-	<game name="Rugrats - Treasure Hunt (Europe)">
-		<description>Rugrats - Treasure Hunt (Europe)</description>
-		<rom name="Rugrats - Treasure Hunt (Europe).n64" />
-		<release name="Rugrats - Treasure Hunt (Europe)" region="EUR" />
-		<rom name="Rugrats - Treasure Hunt (Europe).z64" size="16777216" crc="3338b7c8" md5="55185016031cdc73c0fd471527c35706" sha1="5ff0b82077559dd4c206a7a7d13eabeabc82e9c4" />
+	<game name="RTL World League Soccer 2000 (Germany)" id="0635" cloneofid="0430">
+		<description>RTL World League Soccer 2000 (Germany)</description>
+		<rom name="RTL World League Soccer 2000 (Germany).n64" />
+		<rom name="RTL World League Soccer 2000 (Germany).z64" size="16777216" crc="0a17da7b" md5="a1082a6676455c040843fd75e92de1a3" sha1="a68294e47c82639c9bcdae1b7306ac2a2e2f47b5" sha256="caac491eab833b97a5d1432e2670847e69d484eb3708275a59982116494956d1" status="verified" serial="NWKD" />
 	</game>
-	<game name="Razmoket, Les - La Chasse aux Tresors (France)" cloneof="Rugrats - Treasure Hunt (Europe)">
-		<description>Razmoket, Les - La Chasse aux Tresors (France)</description>
-		<rom name="Razmoket, Les - La Chasse aux Tresors (France).n64" />
-		<release name="Razmoket, Les - La Chasse aux Tresors (France)" region="FRA" />
-		<rom name="Razmoket, Les - La Chasse aux Tresors (France).z64" size="16777216" crc="66766469" md5="55685d6324efde5bc9d26c98706b0b8a" sha1="69c06b2d31bc6bc66cd028705d81024f21a7654c" />
-	</game>
-	<game name="Rugrats - Die grosse Schatzsuche (Germany)" cloneof="Rugrats - Treasure Hunt (Europe)">
+	<game name="Rugrats - Die grosse Schatzsuche (Germany)" id="0636" cloneofid="0638">
 		<description>Rugrats - Die grosse Schatzsuche (Germany)</description>
 		<rom name="Rugrats - Die grosse Schatzsuche (Germany).n64" />
-		<release name="Rugrats - Die grosse Schatzsuche (Germany)" region="GER" />
-		<rom name="Rugrats - Die grosse Schatzsuche (Germany).z64" size="16777216" crc="23aed3a2" md5="dec4598a39728c28cd0ceba45a173ce1" sha1="32caba1042cabbf366852d629d3fee1a5186bce3" />
+		<rom name="Rugrats - Die grosse Schatzsuche (Germany).z64" size="16777216" crc="23aed3a2" md5="dec4598a39728c28cd0ceba45a173ce1" sha1="32caba1042cabbf366852d629d3fee1a5186bce3" serial="NRGD" />
 	</game>
-	<game name="Rugrats - Scavenger Hunt (USA)" cloneof="Rugrats - Treasure Hunt (Europe)">
+	<game name="Rugrats - Scavenger Hunt (USA)" id="0637" cloneofid="0638">
 		<description>Rugrats - Scavenger Hunt (USA)</description>
 		<rom name="Rugrats - Scavenger Hunt (USA).n64" />
-		<release name="Rugrats - Scavenger Hunt (USA)" region="USA" />
-		<rom name="Rugrats - Scavenger Hunt (USA).z64" size="16777216" crc="a87faf82" md5="8c432235a57d34bc4a9b8b290e21e01e" sha1="fb2a62f1625630d6f0beb5fd00a32e12155d50e8" />
+		<rom name="Rugrats - Scavenger Hunt (USA).z64" size="16777216" crc="a87faf82" md5="8c432235a57d34bc4a9b8b290e21e01e" sha1="fb2a62f1625630d6f0beb5fd00a32e12155d50e8" sha256="d2dab1d3e46d6da4d0b98b2ce26494388e10392bf0fc70255802c4184105439e" serial="NRGE" />
 	</game>
-	<game name="Rugrats in Paris - The Movie (Europe)">
+	<game name="Rugrats - Scavenger Hunt (USA) (Beta) (1999-04-02)" id="1106" cloneofid="0638">
+		<category>Games</category>
+		<rom name="Rugrats - Scavenger Hunt (USA) (Beta) (1999-04-02).n64" />
+		<description>Rugrats - Scavenger Hunt (USA) (Beta) (1999-04-02)</description>
+		<rom name="Rugrats - Scavenger Hunt (USA) (Beta) (1999-04-02).z64" size="16777216" crc="b839ea50" md5="a0e5edf2e5841578325e91470e0b84df" sha1="4b359040d63801f89b0f583b13384a529e393f94" sha256="949e669fdd33a8a26bd592200254a6c0c49265fd72b753efff3b816e13df7033" />
+	</game>
+	<game name="Rugrats - Treasure Hunt (Europe)" id="0638">
+		<description>Rugrats - Treasure Hunt (Europe)</description>
+		<rom name="Rugrats - Treasure Hunt (Europe).n64" />
+		<rom name="Rugrats - Treasure Hunt (Europe).z64" size="16777216" crc="3338b7c8" md5="55185016031cdc73c0fd471527c35706" sha1="5ff0b82077559dd4c206a7a7d13eabeabc82e9c4" serial="NRGP" />
+	</game>
+	<game name="Rugrats in Paris - The Movie (Europe)" id="0639">
 		<description>Rugrats in Paris - The Movie (Europe)</description>
 		<rom name="Rugrats in Paris - The Movie (Europe).n64" />
-		<release name="Rugrats in Paris - The Movie (Europe)" region="EUR" />
-		<rom name="Rugrats in Paris - The Movie (Europe).z64" size="16777216" crc="cd74b07e" md5="229089089661f517c863242d6bb77746" sha1="fdda27e7c418728391a5ec53f62fdb5e1b21a0df" />
+		<rom name="Rugrats in Paris - The Movie (Europe).z64" size="16777216" crc="cd74b07e" md5="229089089661f517c863242d6bb77746" sha1="fdda27e7c418728391a5ec53f62fdb5e1b21a0df" sha256="b7858f9af16060440f2dd8377d9f2601c2d46a27f05bc849e5c7bc7d7145e0ca" status="verified" serial="NRKP" />
 	</game>
-	<game name="Rugrats in Paris - The Movie (USA)" cloneof="Rugrats in Paris - The Movie (Europe)">
+	<game name="Rugrats in Paris - The Movie (USA)" id="0640" cloneofid="0639">
 		<description>Rugrats in Paris - The Movie (USA)</description>
 		<rom name="Rugrats in Paris - The Movie (USA).n64" />
-		<release name="Rugrats in Paris - The Movie (USA)" region="USA" />
-		<rom name="Rugrats in Paris - The Movie (USA).z64" size="16777216" crc="a9cc2419" md5="207efe58c7c221dbdfff285ab80126c1" sha1="7a80199973c42b08490da1f6255b5f17569ba15e" />
+		<rom name="Rugrats in Paris - The Movie (USA).z64" size="16777216" crc="a9cc2419" md5="207efe58c7c221dbdfff285ab80126c1" sha1="7a80199973c42b08490da1f6255b5f17569ba15e" serial="NRKE" />
 	</game>
-	<game name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)" id="0641">
 		<description>Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="30f21f89" md5="681df5a32e857e77194106b35304d6b5" sha1="090a027612140e90ffbbd7c48dec77005f7b0a69" />
+		<rom name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="30f21f89" md5="681df5a32e857e77194106b35304d6b5" sha1="090a027612140e90ffbbd7c48dec77005f7b0a69" sha256="fbc02c5a58f42f88de3ae595ddce3ebbfd6d866f1c39ea346addcedca997cd2a" status="verified" serial="NR2P" />
 	</game>
-	<game name="Rush 2 - Extreme Racing USA (USA)" cloneof="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Rush 2 - Extreme Racing USA (USA)" id="0642" cloneofid="0641">
 		<description>Rush 2 - Extreme Racing USA (USA)</description>
 		<rom name="Rush 2 - Extreme Racing USA (USA).n64" />
-		<release name="Rush 2 - Extreme Racing USA (USA)" region="USA" />
-		<rom name="Rush 2 - Extreme Racing USA (USA).z64" size="12582912" crc="9eb14ea8" md5="6a925ab624ee3b343231d799733ba898" sha1="01b0a31b1accc18061e8c85f6c5edf0dbd79f097" />
+		<rom name="Rush 2 - Extreme Racing USA (USA).z64" size="12582912" crc="9eb14ea8" md5="6a925ab624ee3b343231d799733ba898" sha1="01b0a31b1accc18061e8c85f6c5edf0dbd79f097" sha256="a59e65822d46775ca91d98b1220bcdea9acb54e48e56a7b5c026a3a877c08eb5" serial="NR2E" />
 	</game>
-	<game name="S.C.A.R.S. (Europe) (En,Fr,De)">
+	<game name="Rush 2 - Extreme Racing USA (USA) (LodgeNet)" id="1158" cloneofid="0641">
+		<category>Games</category>
+		<rom name="Rush 2 - Extreme Racing USA (USA) (LodgeNet).n64" />
+		<description>Rush 2 - Extreme Racing USA (USA) (LodgeNet)</description>
+		<rom name="Rush 2 - Extreme Racing USA (USA) (LodgeNet).i64" size="64" crc="889f42d1" md5="22439a2bf28be1a56872bc0dce16392d" sha1="78dff0630eba88816d0ddb45bb2af101e00b7f63" />
+		<rom name="Rush 2 - Extreme Racing USA (USA) (LodgeNet).z64" size="12582912" crc="c7e9d391" md5="50600a350427bf3e34f33c3b8a4c4470" sha1="1556edd66c54bf6ec200915ac4265f078c1555a2" />
+	</game>
+	<game name="S.C.A.R.S. (Europe) (En,Fr,De)" id="0643">
 		<description>S.C.A.R.S. (Europe) (En,Fr,De)</description>
 		<rom name="S.C.A.R.S. (Europe) (En,Fr,De).n64" />
-		<release name="S.C.A.R.S. (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="S.C.A.R.S. (Europe) (En,Fr,De).z64" size="8388608" crc="4e37b6f2" md5="7ed3f10bc32cf76f172d8c31d15a2799" sha1="8b4ebad8b7f50381ba2e16d0c475332837bb5780" />
+		<rom name="S.C.A.R.S. (Europe) (En,Fr,De).z64" size="8388608" crc="4e37b6f2" md5="7ed3f10bc32cf76f172d8c31d15a2799" sha1="8b4ebad8b7f50381ba2e16d0c475332837bb5780" sha256="3a11dc6bd22531527a452dab24c1d9146e4bf6228f4aace1a897ad447482df8a" status="verified" serial="NCSP" />
 	</game>
-	<game name="S.C.A.R.S. (USA)" cloneof="S.C.A.R.S. (Europe) (En,Fr,De)">
+	<game name="S.C.A.R.S. (USA)" id="0644" cloneofid="0643">
 		<description>S.C.A.R.S. (USA)</description>
 		<rom name="S.C.A.R.S. (USA).n64" />
-		<release name="S.C.A.R.S. (USA)" region="USA" />
-		<rom name="S.C.A.R.S. (USA).z64" size="8388608" crc="22916735" md5="d0aa9d20a4b85fe514d2a3150d0133ea" sha1="1e87e7bc5b7bc877abc790ebff122ed6e2be828e" />
+		<rom name="S.C.A.R.S. (USA).z64" size="8388608" crc="22916735" md5="d0aa9d20a4b85fe514d2a3150d0133ea" sha1="1e87e7bc5b7bc877abc790ebff122ed6e2be828e" serial="NCSE" />
 	</game>
-	<game name="Saikyou Habu Shougi (Japan)">
+	<game name="Saikyou Habu Shougi (Japan)" id="0645">
 		<description>Saikyou Habu Shougi (Japan)</description>
 		<rom name="Saikyou Habu Shougi (Japan).n64" />
-		<release name="Saikyou Habu Shougi (Japan)" region="JPN" />
-		<rom name="Saikyou Habu Shougi (Japan).z64" size="8388608" crc="01794d62" md5="c4e47228706bc724d7fbd811231d20c9" sha1="b7c977fcd8224595e84714c3fa84221374e1838e" />
+		<rom name="Saikyou Habu Shougi (Japan).z64" size="8388608" crc="01794d62" md5="c4e47228706bc724d7fbd811231d20c9" sha1="b7c977fcd8224595e84714c3fa84221374e1838e" serial="NSHJ" />
 	</game>
-	<game name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)">
+	<game name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)" id="0646">
 		<description>San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)</description>
 		<rom name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De).n64" />
-		<release name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De).z64" size="8388608" crc="e064962a" md5="81b1122ee15f7b50a341ae62e9c5716b" sha1="bc8d37e3a3b9edb4c8465ed7e477c6434c31b47d" />
+		<rom name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De).z64" size="8388608" crc="e064962a" md5="81b1122ee15f7b50a341ae62e9c5716b" sha1="bc8d37e3a3b9edb4c8465ed7e477c6434c31b47d" sha256="344a58277fd5f833b7c5dbae8c6f947fba391c2fd74e56c9604640fd68dc553b" status="verified" serial="NSFP" />
 	</game>
-	<game name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De)" cloneof="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)">
+	<game name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De)" id="0647" cloneofid="0646">
 		<description>San Francisco Rush - Extreme Racing (USA) (En,Fr,De)</description>
 		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De).n64" />
-		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De).z64" size="8388608" crc="3e20070b" md5="f015fc28e1d62a36b4ebf4c79ca8f285" sha1="cc62539cb30b180c3c7e0aa927786ed061d8d9ab" />
+		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De).z64" size="8388608" crc="3e20070b" md5="f015fc28e1d62a36b4ebf4c79ca8f285" sha1="cc62539cb30b180c3c7e0aa927786ed061d8d9ab" sha256="493960054c6749048d9a1f9f01df5f99a8a5983f19e033606ae4b85beffb3841" serial="NSFE" />
 	</game>
-	<game name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1)" cloneof="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)">
+	<game name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1)" id="0936" cloneofid="0646">
 		<description>San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1)</description>
 		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1).n64" />
-		<release name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1)" region="USA" />
-		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1).z64" size="8388608" crc="886c5753" md5="5b127e6b090a0b3f68a114d4d89323d4" sha1="8ac2dc63afde2da90811ce1a3a951b8c0b19a0e7" />
+		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1).z64" size="8388608" crc="886c5753" md5="5b127e6b090a0b3f68a114d4d89323d4" sha1="8ac2dc63afde2da90811ce1a3a951b8c0b19a0e7" serial="NSFE" />
 	</game>
-	<game name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)" id="0648">
 		<description>San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="e63b86c5" md5="02b16ac23998f78f09af6513f4acb664" sha1="61373d4758eca3fa831beac27b4d4c250845f80c" />
+		<rom name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="e63b86c5" md5="02b16ac23998f78f09af6513f4acb664" sha1="61373d4758eca3fa831beac27b4d4c250845f80c" serial="NRUP" />
 	</game>
-	<game name="San Francisco Rush 2049 (USA)" cloneof="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="San Francisco Rush 2049 (USA)" id="0649" cloneofid="0648">
 		<description>San Francisco Rush 2049 (USA)</description>
 		<rom name="San Francisco Rush 2049 (USA).n64" />
-		<release name="San Francisco Rush 2049 (USA)" region="USA" />
-		<rom name="San Francisco Rush 2049 (USA).z64" size="12582912" crc="10941439" md5="af5be0adff51a8e9c6d771282c295810" sha1="3f99351d7bb61656614bdb2aa1a90cfe55d1922c" />
+		<rom name="San Francisco Rush 2049 (USA).z64" size="12582912" crc="10941439" md5="af5be0adff51a8e9c6d771282c295810" sha1="3f99351d7bb61656614bdb2aa1a90cfe55d1922c" serial="NRUE" />
 	</game>
-	<game name="Scooby-Doo! - Classic Creep Capers (Europe)">
+	<game name="Scooby-Doo! - Classic Creep Capers (Europe)" id="0650">
 		<description>Scooby-Doo! - Classic Creep Capers (Europe)</description>
 		<rom name="Scooby-Doo! - Classic Creep Capers (Europe).n64" />
-		<release name="Scooby-Doo! - Classic Creep Capers (Europe)" region="EUR" />
-		<rom name="Scooby-Doo! - Classic Creep Capers (Europe).z64" size="16777216" crc="0d737e6f" md5="3b6dd7b60437234895500beff28df6d6" sha1="fa2d39392750e160f2c41733777c64d8df1127af" />
+		<rom name="Scooby-Doo! - Classic Creep Capers (Europe).z64" size="16777216" crc="0d737e6f" md5="3b6dd7b60437234895500beff28df6d6" sha1="fa2d39392750e160f2c41733777c64d8df1127af" sha256="19e6b675083aa6b0c54d17f7d5b5a909e71f8d6e36eeff57f4dd143c038677f7" status="verified" serial="NSYP" />
 	</game>
-	<game name="Scooby-Doo! - Classic Creep Capers (USA)" cloneof="Scooby-Doo! - Classic Creep Capers (Europe)">
+	<game name="Scooby-Doo! - Classic Creep Capers (USA)" id="0651" cloneofid="0650">
 		<description>Scooby-Doo! - Classic Creep Capers (USA)</description>
 		<rom name="Scooby-Doo! - Classic Creep Capers (USA).n64" />
-		<rom name="Scooby-Doo! - Classic Creep Capers (USA).z64" size="16777216" crc="39068228" md5="16cc6db10a56331b56f374b4fb254d5e" sha1="fa22bd1216094124c84987414dde1b50af90d928" />
+		<rom name="Scooby-Doo! - Classic Creep Capers (USA).z64" size="16777216" crc="39068228" md5="16cc6db10a56331b56f374b4fb254d5e" sha1="fa22bd1216094124c84987414dde1b50af90d928" serial="NSYE" />
 	</game>
-	<game name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1)" cloneof="Scooby-Doo! - Classic Creep Capers (Europe)">
+	<game name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1)" id="0920" cloneofid="0650">
 		<description>Scooby-Doo! - Classic Creep Capers (USA) (Rev 1)</description>
 		<rom name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1).n64" />
-		<release name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1)" region="USA" />
-		<rom name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1).z64" size="16777216" crc="cdf86f5e" md5="01cd9938dae5dcdd4b264ae7f26c6d4d" sha1="44dc4f2a148e56fe8088805cb5a860dbc3a638e2" />
+		<rom name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1).z64" size="16777216" crc="cdf86f5e" md5="01cd9938dae5dcdd4b264ae7f26c6d4d" sha1="44dc4f2a148e56fe8088805cb5a860dbc3a638e2" serial="NSYE" />
 	</game>
-	<game name="SD Hiryuu no Ken Densetsu (Japan)">
+	<game name="SD Hiryuu no Ken Densetsu (Japan)" id="0652">
 		<description>SD Hiryuu no Ken Densetsu (Japan)</description>
 		<rom name="SD Hiryuu no Ken Densetsu (Japan).n64" />
-		<release name="SD Hiryuu no Ken Densetsu (Japan)" region="JPN" />
-		<rom name="SD Hiryuu no Ken Densetsu (Japan).z64" size="12582912" crc="cc083e34" md5="637a7ea2a39f20c5b20834187230d89d" sha1="79cfb5a29b2cbd4f35966f209385b389233cf8cf" />
+		<rom name="SD Hiryuu no Ken Densetsu (Japan).z64" size="12582912" crc="cc083e34" md5="637a7ea2a39f20c5b20834187230d89d" sha1="79cfb5a29b2cbd4f35966f209385b389233cf8cf" sha256="9f499647daa608266637d3a06446311a7fa9b23132df8d28eda613cc41d5a7b1" status="verified" serial="NDCJ" />
 	</game>
-	<game name="Sesame Street - Elmo's Letter Adventure (USA)">
+	<game name="Sesame Street - Elmo's Letter Adventure (USA)" id="0202">
 		<description>Sesame Street - Elmo's Letter Adventure (USA)</description>
 		<rom name="Sesame Street - Elmo's Letter Adventure (USA).n64" />
-		<release name="Sesame Street - Elmo's Letter Adventure (USA)" region="USA" />
-		<rom name="Sesame Street - Elmo's Letter Adventure (USA).z64" size="8388608" crc="92c3ba6f" md5="15df97a59b2354b130dec3fb86bba513" sha1="97777ca06f4e8aff8f1e95033cc8d3833be40f76" />
+		<rom name="Sesame Street - Elmo's Letter Adventure (USA).z64" size="8388608" crc="92c3ba6f" md5="15df97a59b2354b130dec3fb86bba513" sha1="97777ca06f4e8aff8f1e95033cc8d3833be40f76" sha256="eadfd24dd54f56343dd228cddfce67dd8af450a2e8d0040f6a1ed87ea81fdef5" serial="NELE" />
 	</game>
-	<game name="Sesame Street - Elmo's Number Journey (USA)">
+	<game name="Sesame Street - Elmo's Number Journey (USA)" id="0203">
 		<description>Sesame Street - Elmo's Number Journey (USA)</description>
 		<rom name="Sesame Street - Elmo's Number Journey (USA).n64" />
-		<release name="Sesame Street - Elmo's Number Journey (USA)" region="USA" />
-		<rom name="Sesame Street - Elmo's Number Journey (USA).z64" size="8388608" crc="ea3b92d8" md5="f733453ed26afa0aca8d3eb3b5b6d8ea" sha1="7195ea96d9fe5de065af61f70d55c92c8ee905e6" />
+		<rom name="Sesame Street - Elmo's Number Journey (USA).z64" size="8388608" crc="ea3b92d8" md5="f733453ed26afa0aca8d3eb3b5b6d8ea" sha1="7195ea96d9fe5de065af61f70d55c92c8ee905e6" serial="NENE" />
 	</game>
-	<game name="Shadow Man (Europe) (En,Es,It)">
+	<game name="Shadow Man (Europe) (En,Es,It)" id="0653">
 		<description>Shadow Man (Europe) (En,Es,It)</description>
 		<rom name="Shadow Man (Europe) (En,Es,It).n64" />
-		<release name="Shadow Man (Europe) (En,Es,It)" region="EUR" />
-		<rom name="Shadow Man (Europe) (En,Es,It).z64" size="33554432" crc="8d230306" md5="a485a6e9e30b7d55d23d8dd043770c64" sha1="39ece3f37c1f54af4274a9733419eb693eac1740" />
+		<rom name="Shadow Man (Europe) (En,Es,It).z64" size="33554432" crc="8d230306" md5="a485a6e9e30b7d55d23d8dd043770c64" sha1="39ece3f37c1f54af4274a9733419eb693eac1740" sha256="322603e871ebf8556c565f291bb3642d42fbd27bcda03e7c0ecf4d2aec86a5a7" status="verified" serial="NSDP" />
 	</game>
-	<game name="Shadow Man (France)" cloneof="Shadow Man (Europe) (En,Es,It)">
+	<game name="Shadow Man (France)" id="0654" cloneofid="0653">
 		<description>Shadow Man (France)</description>
 		<rom name="Shadow Man (France).n64" />
-		<release name="Shadow Man (France)" region="FRA" />
-		<rom name="Shadow Man (France).z64" size="33554432" crc="6812d3a7" md5="235511bbdb21af5a767bdb7502a80f06" sha1="1f0b03c80c6449de78ee8403cfa84fe8cf759341" />
+		<rom name="Shadow Man (France).z64" size="33554432" crc="6812d3a7" md5="235511bbdb21af5a767bdb7502a80f06" sha1="1f0b03c80c6449de78ee8403cfa84fe8cf759341" sha256="4b38312c467b825ee0472746fe572a13d5520e8db3638299ae33c98110bc72e0" serial="NSDF" />
 	</game>
-	<game name="Shadow Man (Germany)" cloneof="Shadow Man (Europe) (En,Es,It)">
+	<game name="Shadow Man (Germany)" id="0655" cloneofid="0653">
 		<description>Shadow Man (Germany)</description>
 		<rom name="Shadow Man (Germany).n64" />
-		<release name="Shadow Man (Germany)" region="GER" />
-		<rom name="Shadow Man (Germany).z64" size="33554432" crc="eaf6add1" md5="af40ef12ce923ff1c26e76cc9d9b9ed9" sha1="8768f0ec0b7a0b4f5ff0da6f4d790edef5e3fe9c" />
+		<rom name="Shadow Man (Germany).z64" size="33554432" crc="eaf6add1" md5="af40ef12ce923ff1c26e76cc9d9b9ed9" sha1="8768f0ec0b7a0b4f5ff0da6f4d790edef5e3fe9c" serial="NSDD" />
 	</game>
-	<game name="Shadow Man (USA)" cloneof="Shadow Man (Europe) (En,Es,It)">
+	<game name="Shadow Man (USA)" id="0656" cloneofid="0653">
 		<description>Shadow Man (USA)</description>
 		<rom name="Shadow Man (USA).n64" />
-		<release name="Shadow Man (USA)" region="USA" />
-		<rom name="Shadow Man (USA).z64" size="33554432" crc="5e20cc63" md5="b457298b87b85bbf950f24867daa9475" sha1="cfb99dd949fdb2b2a0002ef595ab1813fe865b2c" />
+		<rom name="Shadow Man (USA).z64" size="33554432" crc="5e20cc63" md5="b457298b87b85bbf950f24867daa9475" sha1="cfb99dd949fdb2b2a0002ef595ab1813fe865b2c" sha256="da1a8af84f16ff385271704ca31673b0aa2343f40bc9cd95eac0bdf20676ca27" serial="NSDE" />
 	</game>
-	<game name="Shadow Man (Brazil)" cloneof="Shadow Man (Europe) (En,Es,It)">
+	<game name="Shadow Man (Brazil)" id="0906" cloneofid="0653">
 		<description>Shadow Man (Brazil)</description>
 		<rom name="Shadow Man (Brazil).n64" />
-		<release name="Shadow Man (Brazil)" region="BRA" />
-		<rom name="Shadow Man (Brazil).z64" size="33554432" crc="61e6642c" md5="fe2605193736a128ad65db1c9835a130" sha1="93b2f3423c0af3510e36785622a6dde425dd136c" />
+		<rom name="Shadow Man (Brazil).z64" size="33554432" crc="61e6642c" md5="fe2605193736a128ad65db1c9835a130" sha1="93b2f3423c0af3510e36785622a6dde425dd136c" serial="NSDB" />
 	</game>
-	<game name="Shadowgate 64 - Trials of the Four Towers (Europe)">
+	<game name="Shadowgate 64 - Trials of the Four Towers (Europe)" id="0657">
 		<description>Shadowgate 64 - Trials of the Four Towers (Europe)</description>
 		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe).n64" />
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe)" region="EUR" />
-		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe).z64" size="16777216" crc="ff7d7df0" md5="e8955c3b743fddfe403e52e769e9853f" sha1="f2844b3421779a997c96231d25275da4e2d1018b" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe).z64" size="16777216" crc="ff7d7df0" md5="e8955c3b743fddfe403e52e769e9853f" sha1="f2844b3421779a997c96231d25275da4e2d1018b" serial="NSGP" />
 	</game>
-	<game name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" cloneof="Shadowgate 64 - Trials of the Four Towers (Europe)">
+	<game name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" id="0658" cloneofid="0657">
 		<description>Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)</description>
 		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It).n64" />
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" region="ITA" />
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" region="SPA" />
-		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It).z64" size="16777216" crc="87f00472" md5="a06e757cf1930b29fa4c0b5c9f31335f" sha1="9f1a413f686032dda73be3312f452991a4e29ec9" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It).z64" size="16777216" crc="87f00472" md5="a06e757cf1930b29fa4c0b5c9f31335f" sha1="9f1a413f686032dda73be3312f452991a4e29ec9" serial="NSGY" />
 	</game>
-	<game name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" cloneof="Shadowgate 64 - Trials of the Four Towers (Europe)">
+	<game name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" id="0659" cloneofid="0657">
 		<description>Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)</description>
 		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl).n64" />
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" region="FRA" />
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" region="GER" />
-		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl).z64" size="16777216" crc="eedc0bea" md5="11169a32d449ec3a8903ca8a9d69a6aa" sha1="31de2e29dce21341e1958b32a7d8b1b03fc56e3b" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl).z64" size="16777216" crc="eedc0bea" md5="11169a32d449ec3a8903ca8a9d69a6aa" sha1="31de2e29dce21341e1958b32a7d8b1b03fc56e3b" sha256="d62ae6df6ef2d5d8bc91a5ab3e229bbfb7ef297c6b9364a736c0d60bafa4a675" status="verified" serial="NSGX" />
 	</game>
-	<game name="Shadowgate 64 - Trials of the Four Towers (Japan)" cloneof="Shadowgate 64 - Trials of the Four Towers (Europe)">
+	<game name="Shadowgate 64 - Trials of the Four Towers (Japan)" id="0660" cloneofid="0657">
 		<description>Shadowgate 64 - Trials of the Four Towers (Japan)</description>
 		<rom name="Shadowgate 64 - Trials of the Four Towers (Japan).n64" />
-		<release name="Shadowgate 64 - Trials of the Four Towers (Japan)" region="JPN" />
-		<rom name="Shadowgate 64 - Trials of the Four Towers (Japan).z64" size="16777216" crc="9f74a58c" md5="1960a3879fadf2c5eff5beb47e0e1441" sha1="706524aff9bd84972d4e095afd0317d5bacc525f" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Japan).z64" size="16777216" crc="9f74a58c" md5="1960a3879fadf2c5eff5beb47e0e1441" sha1="706524aff9bd84972d4e095afd0317d5bacc525f" serial="NSGJ" />
 	</game>
-	<game name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)" cloneof="Shadowgate 64 - Trials of the Four Towers (Europe)">
+	<game name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)" id="0661" cloneofid="0657">
 		<description>Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)</description>
 		<rom name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es).n64" />
-		<release name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)" region="USA" />
-		<rom name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es).z64" size="16777216" crc="69983cc3" md5="407a1a18bd7dbe0485329296c3f84eb8" sha1="4397729f8143ea9a39f319e1f31f2e0b84335a24" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es).z64" size="16777216" crc="69983cc3" md5="407a1a18bd7dbe0485329296c3f84eb8" sha1="4397729f8143ea9a39f319e1f31f2e0b84335a24" sha256="bddefa567e6cae05126d9c29053eaeec3e78e088e4ea1cfd50ca3223a85f0871" serial="NSGE" />
 	</game>
-	<game name="Shen You Mario (China) (v6) (iQue) (Manual)">
-		<description>Shen You Mario (China) (v6) (iQue) (Manual)</description>
-		<rom name="Shen You Mario (China) (v6) (iQue) (Manual).n64" />
-		<release name="Shen You Mario (China) (v6) (iQue) (Manual)" region="CHN" />
-		<rom name="Shen You Mario (China) (v6) (iQue) (Manual).z64" size="409600" crc="a5b65a64" md5="b4bd31b13e474df29922150e1ef3f328" sha1="a7f90ffbbffa26919e23d24057bcb504ef8a8aa0" />
+	<game name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es) (Beta)" id="1125" cloneofid="0657">
+		<category>Games</category>
+		<rom name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es) (Beta).n64" />
+		<category>Preproduction</category>
+		<description>Shadowgate 64 - Trials of the Four Towers (USA) (En,Es) (Beta)</description>
+		<rom name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es) (Beta).z64" size="16777216" crc="45231b9f" md5="1cf28070533ff9e0006ee932d8b39fb9" sha1="b6fdb4bff2a6983a5d84e285a2f427bbd5f63d93" sha256="77ce7d9ae142be989a5b77ddf0609bbdc2157b74dc86d9df9d87cf23cd306909" serial="NSGE" />
 	</game>
-	<game name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)">
+	<game name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)" id="0662">
 		<description>Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)</description>
 		<rom name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan).n64" />
-		<release name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)" region="JPN" />
-		<rom name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan).z64" size="12582912" crc="e892ed43" md5="13d9514a4d208dc6c7b0c833f68114d2" sha1="8e87dd6baf0d8d27e60c3257b145ef439b17b7a0" />
+		<rom name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan).z64" size="12582912" crc="e892ed43" md5="13d9514a4d208dc6c7b0c833f68114d2" sha1="8e87dd6baf0d8d27e60c3257b145ef439b17b7a0" serial="NTOJ" />
 	</game>
-	<game name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)">
+	<game name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)" id="0663">
 		<description>Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)</description>
 		<rom name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan).n64" />
-		<release name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)" region="JPN" />
-		<rom name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan).z64" size="33554432" crc="deac787f" md5="113044b16b75f98792bf9c20c6b6282b" sha1="bdfa3c47264196bd91d0487d3c9b3531bdace8ea" />
+		<rom name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan).z64" size="33554432" crc="deac787f" md5="113044b16b75f98792bf9c20c6b6282b" sha1="bdfa3c47264196bd91d0487d3c9b3531bdace8ea" serial="NT3J" />
 	</game>
-	<game name="Shuishang Motuo (China) (v4) (iQue) (Manual)">
-		<description>Shuishang Motuo (China) (v4) (iQue) (Manual)</description>
-		<rom name="Shuishang Motuo (China) (v4) (iQue) (Manual).n64" />
-		<release name="Shuishang Motuo (China) (v4) (iQue) (Manual)" region="CHN" />
-		<rom name="Shuishang Motuo (China) (v4) (iQue) (Manual).z64" size="491520" crc="3ef9368e" md5="926b1495565435da0af29bb660532da3" sha1="fc2d8b6a2b64104681940ad2557703df44bb9e97" />
-	</game>
-	<game name="Shuishang Motuo (China) (v2) (iQue) (Manual)" cloneof="Shuishang Motuo (China) (v4) (iQue) (Manual)">
-		<description>Shuishang Motuo (China) (v2) (iQue) (Manual)</description>
-		<rom name="Shuishang Motuo (China) (v2) (iQue) (Manual).n64" />
-		<rom name="Shuishang Motuo (China) (v2) (iQue) (Manual).z64" size="311296" crc="b7547f54" md5="a66fee7af89d58b24a25c346a0e90172" sha1="536ed6c8f1ef5a66581efa3c4ae43a2fb7d6dc58" />
-	</game>
-	<game name="SimCity 2000 (Japan)">
+	<game name="SimCity 2000 (Japan)" id="0664">
 		<description>SimCity 2000 (Japan)</description>
 		<rom name="SimCity 2000 (Japan).n64" />
-		<release name="SimCity 2000 (Japan)" region="JPN" />
-		<rom name="SimCity 2000 (Japan).z64" size="12582912" crc="57767e45" md5="244bea64ea209990e9c69a830b507135" sha1="f728bd9990b9674533a04cd2fe275236b5cab32f" />
+		<rom name="SimCity 2000 (Japan).z64" size="12582912" crc="57767e45" md5="244bea64ea209990e9c69a830b507135" sha1="f728bd9990b9674533a04cd2fe275236b5cab32f" serial="NS2J" />
 	</game>
-	<game name="Snowboard Kids (Europe)">
-		<description>Snowboard Kids (Europe)</description>
-		<rom name="Snowboard Kids (Europe).n64" />
-		<release name="Snowboard Kids (Europe)" region="EUR" />
-		<rom name="Snowboard Kids (Europe).z64" size="8388608" crc="5619a70d" md5="ab4382e583ae139eedbafce5fa87e4c8" sha1="b26802748f4cc15f44492bcc6941a487e75bbca6" status="verified" />
+	<game name="SimCopter 64 (USA) (Proto)" id="1111">
+		<category>Games</category>
+		<rom name="SimCopter 64 (USA) (Proto).n64" />
+		<category>Preproduction</category>
+		<description>SimCopter 64 (USA) (Proto)</description>
+		<rom name="SimCopter 64 (USA) (Proto).z64" size="16777216" crc="b3718454" md5="3777ddb4a7494a0f39f78f25756890d1" sha1="79782d3cbbcf07148c109d0c381f4ffc1c2e0bfc" sha256="387df53451abcb5a1ad24723cd7aaf64e676d47a80ef43f59e5af5f07ead6e90" serial="!none" />
 	</game>
-	<game name="Snobo Kids (Japan)" cloneof="Snowboard Kids (Europe)">
+	<game name="Snobo Kids (Japan)" id="0665" cloneofid="0667">
 		<description>Snobo Kids (Japan)</description>
 		<rom name="Snobo Kids (Japan).n64" />
-		<release name="Snobo Kids (Japan)" region="JPN" />
-		<rom name="Snobo Kids (Japan).z64" size="8388608" crc="213bf381" md5="b8d4b92e66a312708626b3216de07a3a" sha1="96480c8fa7285d9e850f6ba002e56bcb7ada9796" />
+		<rom name="Snobo Kids (Japan).z64" size="8388608" crc="213bf381" md5="b8d4b92e66a312708626b3216de07a3a" sha1="96480c8fa7285d9e850f6ba002e56bcb7ada9796" serial="NSKJ" />
 	</game>
-	<game name="Snowboard Kids (USA)" cloneof="Snowboard Kids (Europe)">
+	<game name="Snow Speeder (Japan)" id="0666" cloneofid="0074">
+		<description>Snow Speeder (Japan)</description>
+		<rom name="Snow Speeder (Japan).n64" />
+		<rom name="Snow Speeder (Japan).z64" size="12582912" crc="30ea3fd7" md5="f7e66da23c8bb8e59f641a636a9cae82" sha1="0e7df6a6f053f37a168ec33af8ce5240cb18f0ee" serial="NSNJ" />
+	</game>
+	<game name="Snowboard Kids (Europe, Australia)" id="0667">
+		<description>Snowboard Kids (Europe, Australia)</description>
+		<rom name="Snowboard Kids (Europe, Australia).n64" />
+		<rom name="Snowboard Kids (Europe, Australia).z64" size="8388608" crc="5619a70d" md5="ab4382e583ae139eedbafce5fa87e4c8" sha1="b26802748f4cc15f44492bcc6941a487e75bbca6" sha256="9034eb5f375ccd8fa101e3638ddde8c1110437581db111a81c9c586fee11ebcf" status="verified" serial="NSKP" />
+	</game>
+	<game name="Snowboard Kids (USA)" id="0668" cloneofid="0667">
 		<description>Snowboard Kids (USA)</description>
 		<rom name="Snowboard Kids (USA).n64" />
-		<release name="Snowboard Kids (USA)" region="USA" />
-		<rom name="Snowboard Kids (USA).z64" size="8388608" crc="020fb906" md5="eb31f4f9c1fe26a3a663f74e9790516e" sha1="1583bacc9046a360df8ea4d536942155247e154c" />
+		<rom name="Snowboard Kids (USA).z64" size="8388608" crc="020fb906" md5="eb31f4f9c1fe26a3a663f74e9790516e" sha1="1583bacc9046a360df8ea4d536942155247e154c" sha256="58870ea67d49f778e7a7607eb270ad1d3a081a4733b337b2d607de2606dcfb3c" serial="NSKE" />
 	</game>
-	<game name="Snowboard Kids 2 (USA)">
-		<description>Snowboard Kids 2 (USA)</description>
-		<rom name="Snowboard Kids 2 (USA).n64" />
-		<release name="Snowboard Kids 2 (USA)" region="USA" />
-		<rom name="Snowboard Kids 2 (USA).z64" size="16777216" crc="d0dc8a8e" md5="08e1152e9d9742e9bbf6c224b6958f2d" sha1="5ce896fd64276948bc2b8cccd8cd51c25a9f32aa" />
-	</game>
-	<game name="Chou Snobo Kids (Japan)" cloneof="Snowboard Kids 2 (USA)">
-		<description>Chou Snobo Kids (Japan)</description>
-		<rom name="Chou Snobo Kids (Japan).n64" />
-		<release name="Chou Snobo Kids (Japan)" region="JPN" />
-		<rom name="Chou Snobo Kids (Japan).z64" size="16777216" crc="dd4e84e4" md5="9181b35a758ef17d1e2dc595df55ee3c" sha1="a411b2fc46d6953b32897f99ffc5146f385dfd5b" />
-	</game>
-	<game name="Snowboard Kids 2 (Australia)" cloneof="Snowboard Kids 2 (USA)">
+	<game name="Snowboard Kids 2 (Australia)" id="0669" cloneofid="0670">
 		<description>Snowboard Kids 2 (Australia)</description>
 		<rom name="Snowboard Kids 2 (Australia).n64" />
-		<release name="Snowboard Kids 2 (Australia)" region="AUS" />
-		<rom name="Snowboard Kids 2 (Australia).z64" size="16777216" crc="3a0b6214" md5="47b5e3955d54f969941533f26691ab38" sha1="e807f0fa1d6fde619a83f0926b2294123f34501c" />
+		<rom name="Snowboard Kids 2 (Australia).z64" size="16777216" crc="3a0b6214" md5="47b5e3955d54f969941533f26691ab38" sha1="e807f0fa1d6fde619a83f0926b2294123f34501c" serial="NK2P" />
 	</game>
-	<game name="South Park (Europe) (En,Fr,Es)">
+	<game name="Snowboard Kids 2 (USA)" id="0670">
+		<description>Snowboard Kids 2 (USA)</description>
+		<rom name="Snowboard Kids 2 (USA).n64" />
+		<rom name="Snowboard Kids 2 (USA).z64" size="16777216" crc="d0dc8a8e" md5="08e1152e9d9742e9bbf6c224b6958f2d" sha1="5ce896fd64276948bc2b8cccd8cd51c25a9f32aa" serial="NK2E" />
+	</game>
+	<game name="Sonic Wings Assault (Japan)" id="0671" cloneofid="0021">
+		<description>Sonic Wings Assault (Japan)</description>
+		<rom name="Sonic Wings Assault (Japan).n64" />
+		<rom name="Sonic Wings Assault (Japan).z64" size="8388608" crc="fc73fb79" md5="7d47911b5c3d91a303ef19e764f3c02b" sha1="978936613096d1ebe49fec3ef50e3c870ce165b6" serial="NSAJ" />
+	</game>
+	<game name="South Park (Europe) (En,Fr,Es)" id="0672">
 		<description>South Park (Europe) (En,Fr,Es)</description>
 		<rom name="South Park (Europe) (En,Fr,Es).n64" />
-		<release name="South Park (Europe) (En,Fr,Es)" region="EUR" />
-		<rom name="South Park (Europe) (En,Fr,Es).z64" size="16777216" crc="b2c3e123" md5="40cc2085a5c12456bef830b047068326" sha1="c70c9fd6ebf1ae9f79155f9384ab1c4b29dc6882" />
+		<rom name="South Park (Europe) (En,Fr,Es).z64" size="16777216" crc="b2c3e123" md5="40cc2085a5c12456bef830b047068326" sha1="c70c9fd6ebf1ae9f79155f9384ab1c4b29dc6882" sha256="e0cdb6f2c756febffc10266a5bf93ee853a0393de2f18353174e569303d3252c" status="verified" serial="NDTP" />
 	</game>
-	<game name="South Park (Germany)" cloneof="South Park (Europe) (En,Fr,Es)">
+	<game name="South Park (Germany)" id="0673" cloneofid="0672">
 		<description>South Park (Germany)</description>
 		<rom name="South Park (Germany).n64" />
-		<release name="South Park (Germany)" region="GER" />
-		<rom name="South Park (Germany).z64" size="16777216" crc="5711e197" md5="2c94a246e701d667ba807dab6c9771e2" sha1="3260db8fbc90370603fc07ab2e48e02c029573fb" />
+		<rom name="South Park (Germany).z64" size="16777216" crc="5711e197" md5="2c94a246e701d667ba807dab6c9771e2" sha1="3260db8fbc90370603fc07ab2e48e02c029573fb" serial="NDTD" />
 	</game>
-	<game name="South Park (USA)" cloneof="South Park (Europe) (En,Fr,Es)">
+	<game name="South Park (USA)" id="0674" cloneofid="0672">
 		<description>South Park (USA)</description>
 		<rom name="South Park (USA).n64" />
-		<release name="South Park (USA)" region="USA" />
-		<rom name="South Park (USA).z64" size="16777216" crc="7d666b9e" md5="1730119b0455ef89c4e495dec8e950a5" sha1="42d7350d1f9040c5546f481c4d650b99a23aadbc" />
+		<rom name="South Park (USA).z64" size="16777216" crc="7d666b9e" md5="1730119b0455ef89c4e495dec8e950a5" sha1="42d7350d1f9040c5546f481c4d650b99a23aadbc" sha256="68e87dbae05414026a126cb6e0c632e7660668a0003e1e1c975df8296e2a36a6" serial="NDTE" />
 	</game>
-	<game name="South Park (Brazil)" cloneof="South Park (Europe) (En,Fr,Es)">
+	<game name="South Park (Brazil)" id="0913" cloneofid="0672">
 		<description>South Park (Brazil)</description>
 		<rom name="South Park (Brazil).n64" />
-		<release name="South Park (Brazil)" region="BRA" />
-		<rom name="South Park (Brazil).z64" size="16777216" crc="235caec6" md5="d313af5f8af4d19f732a1a2c4d4d66bb" sha1="26623418f8c6f271ba36b68eaecb18db19563b2b" />
+		<rom name="South Park (Brazil).z64" size="16777216" crc="235caec6" md5="d313af5f8af4d19f732a1a2c4d4d66bb" sha1="26623418f8c6f271ba36b68eaecb18db19563b2b" serial="NDTB" />
 	</game>
-	<game name="South Park - Chef's Luv Shack (Europe)">
+	<game name="South Park - Chef's Luv Shack (Europe)" id="0675">
 		<description>South Park - Chef's Luv Shack (Europe)</description>
 		<rom name="South Park - Chef's Luv Shack (Europe).n64" />
-		<release name="South Park - Chef's Luv Shack (Europe)" region="EUR" />
-		<rom name="South Park - Chef's Luv Shack (Europe).z64" size="16777216" crc="ac1628eb" md5="f1ae48b778c8431a50c37eb1ed96b120" sha1="5aeec40c04ae9f7bc286f38e5250712c5fead191" />
+		<rom name="South Park - Chef's Luv Shack (Europe).z64" size="16777216" crc="ac1628eb" md5="f1ae48b778c8431a50c37eb1ed96b120" sha1="5aeec40c04ae9f7bc286f38e5250712c5fead191" sha256="808c16c10a8c60998b743f7ed96ec82363172dfeccc1035d2cbd527bdc9df6d0" status="verified" serial="NCYP" />
 	</game>
-	<game name="South Park - Chef's Luv Shack (USA)" cloneof="South Park - Chef's Luv Shack (Europe)">
+	<game name="South Park - Chef's Luv Shack (USA)" id="0676" cloneofid="0675">
 		<description>South Park - Chef's Luv Shack (USA)</description>
 		<rom name="South Park - Chef's Luv Shack (USA).n64" />
-		<release name="South Park - Chef's Luv Shack (USA)" region="USA" />
-		<rom name="South Park - Chef's Luv Shack (USA).z64" size="16777216" crc="6b6b1d09" md5="6af573eb055648a8542aa82d9524fb2f" sha1="0344b569e8410a860cd54165bc33130e80760896" />
+		<rom name="South Park - Chef's Luv Shack (USA).z64" size="16777216" crc="6b6b1d09" md5="6af573eb055648a8542aa82d9524fb2f" sha1="0344b569e8410a860cd54165bc33130e80760896" serial="NCYE" />
 	</game>
-	<game name="South Park Rally (Europe)">
+	<game name="South Park Rally (Europe)" id="0677">
 		<description>South Park Rally (Europe)</description>
 		<rom name="South Park Rally (Europe).n64" />
-		<release name="South Park Rally (Europe)" region="EUR" />
-		<rom name="South Park Rally (Europe).z64" size="16777216" crc="296e3525" md5="c33fa02791077a71b0afe1cfed47c180" sha1="e16b5b16e41c66fefb3bc82bd6a82f9ef4d709fd" />
+		<rom name="South Park Rally (Europe).z64" size="16777216" crc="296e3525" md5="c33fa02791077a71b0afe1cfed47c180" sha1="e16b5b16e41c66fefb3bc82bd6a82f9ef4d709fd" serial="NPRP" />
 	</game>
-	<game name="South Park Rally (USA)" cloneof="South Park Rally (Europe)">
+	<game name="South Park Rally (USA)" id="0678" cloneofid="0677">
 		<description>South Park Rally (USA)</description>
 		<rom name="South Park Rally (USA).n64" />
-		<release name="South Park Rally (USA)" region="USA" />
-		<rom name="South Park Rally (USA).z64" size="16777216" crc="ccdd322a" md5="1c494719032ff99382b167c43fb11762" sha1="e0b9e2358b09d430a100a14a6cb19e30b55faea2" />
+		<rom name="South Park Rally (USA).z64" size="16777216" crc="ccdd322a" md5="1c494719032ff99382b167c43fb11762" sha1="e0b9e2358b09d430a100a14a6cb19e30b55faea2" serial="NPRE" />
 	</game>
-	<game name="South Park Rally (Europe) (Beta)" cloneof="South Park Rally (Europe)">
-		<description>South Park Rally (Europe) (Beta)</description>
-		<rom name="South Park Rally (Europe) (Beta).n64" />
-		<rom name="South Park Rally (Europe) (Beta).z64" size="16777216" crc="1c535592" md5="cdee4b0529b33405a293d51cb3765c57" sha1="0a12d66e1014e55f216c8693774494c85915103b" />
+	<game name="South Park Rally (Europe) (Beta) (2000-01-08)" id="1061" cloneofid="0677">
+		<category>Games</category>
+		<rom name="South Park Rally (Europe) (Beta) (2000-01-08).n64" />
+		<description>South Park Rally (Europe) (Beta) (2000-01-08)</description>
+		<rom name="South Park Rally (Europe) (Beta) (2000-01-08).z64" size="16777216" crc="1c535592" md5="cdee4b0529b33405a293d51cb3765c57" sha1="0a12d66e1014e55f216c8693774494c85915103b" sha256="c432b645a583dc5ea0eb9ec9bcc9c8a56777b6c270bac88f8d8b08b8651ec392" serial="!none" />
 	</game>
-	<game name="Space Invaders (USA)">
+	<game name="South Park Rally (USA) (Beta) (2000-01-27)" id="1091" cloneofid="0677">
+		<category>Games</category>
+		<rom name="South Park Rally (USA) (Beta) (2000-01-27).n64" />
+		<description>South Park Rally (USA) (Beta) (2000-01-27)</description>
+		<rom name="South Park Rally (USA) (Beta) (2000-01-27).z64" size="16777216" crc="a0f81b94" md5="1be2624e4c597b8094195a2348900514" sha1="3a92980e05b4207a849c822acfca55d42ab19f7e" sha256="f7170b81bc2f635334cc3c58aa8f78e743daf5eeaa0ce0f1fc60420e6135412f" serial="NTUE" />
+	</game>
+	<game name="South Park Rally (USA) (Beta) (2000-01-14)" id="1092" cloneofid="0677">
+		<category>Games</category>
+		<rom name="South Park Rally (USA) (Beta) (2000-01-14).n64" />
+		<description>South Park Rally (USA) (Beta) (2000-01-14)</description>
+		<rom name="South Park Rally (USA) (Beta) (2000-01-14).z64" size="16777216" crc="3e3cd1e3" md5="a5b3b1d07af3c0bb51091e68304cce18" sha1="b2b1e520c69b9ade878e3f4e5863315540059a3d" sha256="01e014810a06896be27db02f3896686e99a806a0c9da8693ea9256ab4e3a41d7" serial="NSPE" />
+	</game>
+	<game name="South Park Rally (Europe) (Beta) (2000-01-17)" id="1121" cloneofid="0677">
+		<category>Games</category>
+		<rom name="South Park Rally (Europe) (Beta) (2000-01-17).n64" />
+		<description>South Park Rally (Europe) (Beta) (2000-01-17)</description>
+		<rom name="South Park Rally (Europe) (Beta) (2000-01-17).z64" size="16777216" crc="cf8d799d" md5="e3c1c713917bb39ab9e5278894229a84" sha1="febe7ca41b605ed0abfce9f4bf83381802148cfa" sha256="fc9abc30131d3268cefac6933361f3980f82576dcd49383f770e005f004f8275" serial="NTUE" />
+	</game>
+	<game name="Space Dynamites (Japan)" id="0679" cloneofid="0156">
+		<description>Space Dynamites (Japan)</description>
+		<rom name="Space Dynamites (Japan).n64" />
+		<rom name="Space Dynamites (Japan).z64" size="8388608" crc="8cb4b948" md5="7f9cdbbb1aaaaf0983c64988ef9c58be" sha1="def172a1b2d17a6ebbbc0551172de4ae46b88e48" serial="NDKJ" />
+	</game>
+	<game name="Space Invaders (USA)" id="0680">
 		<description>Space Invaders (USA)</description>
 		<rom name="Space Invaders (USA).n64" />
-		<release name="Space Invaders (USA)" region="USA" />
-		<rom name="Space Invaders (USA).z64" size="8388608" crc="60f7ff8e" md5="c72417e0f8f043f9f11851633c4b1a57" sha1="6850205eace572ae1aa31100320ad8df1b8db37e" />
+		<rom name="Space Invaders (USA).z64" size="8388608" crc="60f7ff8e" md5="c72417e0f8f043f9f11851633c4b1a57" sha1="6850205eace572ae1aa31100320ad8df1b8db37e" sha256="c5075e54bd06fe05881f9ff0f590366afb1c917adb0dc24f3d573c51d6e26a2d" serial="NIVE" />
 	</game>
-	<game name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)">
+	<game name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)" id="0681">
 		<description>SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)</description>
 		<rom name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt).n64" />
-		<release name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)" region="EUR" />
-		<rom name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt).z64" size="8388608" crc="63042e36" md5="fca7afcadcf5e5545a62919ba94dad18" sha1="23710541bb3394072740b0f0236a7cb1a7d41531" />
+		<rom name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt).z64" size="8388608" crc="63042e36" md5="fca7afcadcf5e5545a62919ba94dad18" sha1="23710541bb3394072740b0f0236a7cb1a7d41531" sha256="0b13e3a0d4c7eaeda6556fdcad9bf0e6aefad2696c827a820786bb123e9387b0" status="verified" serial="NSVP" />
 	</game>
-	<game name="SpaceStation Silicon Valley (Japan) (Proto)" cloneof="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)">
+	<game name="SpaceStation Silicon Valley (Japan) (Proto)" id="0682" cloneofid="0681">
 		<description>SpaceStation Silicon Valley (Japan) (Proto)</description>
 		<rom name="SpaceStation Silicon Valley (Japan) (Proto).n64" />
-		<rom name="SpaceStation Silicon Valley (Japan) (Proto).z64" size="8388608" crc="dcec9f8a" md5="e66ed1cc4ab95d0872bb2ebc49b206c4" sha1="7320f08474c011fc7781093bf1a6818c37ce51e2" />
+		<rom name="SpaceStation Silicon Valley (Japan) (Proto).z64" size="8388608" crc="dcec9f8a" md5="e66ed1cc4ab95d0872bb2ebc49b206c4" sha1="7320f08474c011fc7781093bf1a6818c37ce51e2" serial="NSVJ" />
 	</game>
-	<game name="SpaceStation Silicon Valley (USA)" cloneof="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)">
+	<game name="SpaceStation Silicon Valley (USA)" id="0683" cloneofid="0681">
 		<description>SpaceStation Silicon Valley (USA)</description>
 		<rom name="SpaceStation Silicon Valley (USA).n64" />
-		<rom name="SpaceStation Silicon Valley (USA).z64" size="8388608" crc="a606e8ae" md5="868b37d1b66d1d994e2bad4e218bf129" sha1="e5e09205aa743a9e5043a42df72adc379c746b0b" />
+		<rom name="SpaceStation Silicon Valley (USA).z64" size="8388608" crc="a606e8ae" md5="868b37d1b66d1d994e2bad4e218bf129" sha1="e5e09205aa743a9e5043a42df72adc379c746b0b" sha256="b125bf0d761547ba878e44ef83f9e1ec3f400da7c46cf9a404b6caee6f9ba473" serial="NSVE" />
 	</game>
-	<game name="SpaceStation Silicon Valley (USA) (Rev 1)" cloneof="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)">
+	<game name="SpaceStation Silicon Valley (USA) (Rev 1)" id="1021" cloneofid="0681">
 		<description>SpaceStation Silicon Valley (USA) (Rev 1)</description>
 		<rom name="SpaceStation Silicon Valley (USA) (Rev 1).n64" />
-		<release name="SpaceStation Silicon Valley (USA) (Rev 1)" region="USA" />
-		<rom name="SpaceStation Silicon Valley (USA) (Rev 1).z64" size="8388608" crc="e32d9e7b" md5="f1f1c5e2b895db63348bc738c0cdc645" sha1="c968bba6a90db9ecbd957e910684a80726b0497d" status="verified" />
+		<rom name="SpaceStation Silicon Valley (USA) (Rev 1).z64" size="8388608" crc="e32d9e7b" md5="f1f1c5e2b895db63348bc738c0cdc645" sha1="c968bba6a90db9ecbd957e910684a80726b0497d" status="verified" serial="NSVE" />
 	</game>
-	<game name="Spider-Man (USA)">
+	<game name="Spider-Man (USA)" id="0684">
 		<description>Spider-Man (USA)</description>
 		<rom name="Spider-Man (USA).n64" />
-		<release name="Spider-Man (USA)" region="USA" />
-		<rom name="Spider-Man (USA).z64" size="33554432" crc="696cc2a4" md5="7f1991b8861e7e532ec21ecf2af82191" sha1="382c9c5d4e416444c4f6f9f4f6a5914d679fedf1" />
+		<rom name="Spider-Man (USA).z64" size="33554432" crc="696cc2a4" md5="7f1991b8861e7e532ec21ecf2af82191" sha1="382c9c5d4e416444c4f6f9f4f6a5914d679fedf1" sha256="feff90ed1201c91ff167d66958048e61c192c9d6a756ddb98f799017ac9cd25c" serial="NSLE" />
 	</game>
-	<game name="Star Soldier - Vanishing Earth (USA)">
+	<game name="Star Fox 64 (Japan)" id="0685" cloneofid="0387">
+		<description>Star Fox 64 (Japan)</description>
+		<rom name="Star Fox 64 (Japan).n64" />
+		<rom name="Star Fox 64 (Japan).z64" size="12582912" crc="411142a7" md5="446d5215c4d34eb8ab0f355f324b8d0e" sha1="9bd71afbecf4d0a43146e4e7a893395e19bf3220" sha256="438d5a25aafe7d0b2e490b9a87183ca3f00d2d7ddce6b3a5784c7bdc0cffc7bd" status="verified" serial="NFXJ" />
+	</game>
+	<game name="Star Fox 64 (USA)" id="0686" cloneofid="0387">
+		<description>Star Fox 64 (USA)</description>
+		<rom name="Star Fox 64 (USA).n64" />
+		<rom name="Star Fox 64 (USA).z64" size="12582912" crc="b1fcaa9c" md5="caf9a78db13ee00002ff63a3c0c5eabb" sha1="d8b1088520f7c5f81433292a9258c1184afa1457" sha256="a8d31134f6d2658fb7bdce5e8f8e74ab70cfcbed73ada22d680225915cb0fe22" status="verified" serial="NFXE" />
+	</game>
+	<game name="Star Fox 64 (USA) (Rev 1)" id="0687" cloneofid="0387">
+		<description>Star Fox 64 (USA) (Rev 1)</description>
+		<rom name="Star Fox 64 (USA) (Rev 1).n64" />
+		<rom name="Star Fox 64 (USA) (Rev 1).z64" size="12582912" crc="b1b5fc46" md5="741a94eee093c4c8684e66b89f8685e8" sha1="09f0d105f476b00efa5303a3ebc42e60a7753b7a" sha256="385bcf1901ed12fb1152f3c227d1968cc54ae41e8566da66695df71af40a573f" status="verified" serial="NFXE" />
+	</game>
+	<game name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console)" id="0993" cloneofid="0387">
+		<description>Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console)</description>
+		<rom name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console).n64" />
+		<rom name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console).z64" size="12582912" crc="6508d4ad" md5="91fc4c63ca613530df22c8bb810cb2c3" sha1="a39f14f0d1224095717fabc021023203cb7561d5" serial="NFXJ" />
+	</game>
+	<game name="Star Fox 64 (USA) (LodgeNet)" id="1160" cloneofid="0387">
+		<category>Games</category>
+		<rom name="Star Fox 64 (USA) (LodgeNet).n64" />
+		<description>Star Fox 64 (USA) (LodgeNet)</description>
+		<rom name="Star Fox 64 (USA) (LodgeNet).i64" size="64" crc="f89ccbcf" md5="dbc8d5b044e1f10eb82a7c32fb8c8218" sha1="0de280df6c5ed6dd7c529c1784123a79514b3d74" />
+		<rom name="Star Fox 64 (USA) (LodgeNet).z64" size="12582912" crc="637a422d" md5="4193b28348f4c294dfb07510e9ebd76b" sha1="1b759465439297fbbe21c19df0924d8e75b1aa5a" />
+	</game>
+	<game name="Star Soldier - Vanishing Earth (Japan) (En) (Beta) (1998-03-10)" id="1187" cloneofid="0689">
+		<category>Games</category>
+		<rom name="Star Soldier - Vanishing Earth (Japan) (En) (Beta) (1998-03-10).n64" />
+		<category>Preproduction</category>
+		<description>Star Soldier - Vanishing Earth (Japan) (En) (Beta) (1998-03-10)</description>
+		<rom name="Star Soldier - Vanishing Earth (Japan) (En) (Beta) (1998-03-10).z64" size="12582912" crc="2103103f" md5="b6f9ee435b3f1b28d45bd367dfc197a4" sha1="01b62e6417f08fc2d1aebc8c230111d5cc5d3739" sha256="35291a9fff3bb06aeaf079987a83587cb7cc048a809b96dab99dced573976452" serial="!none" />
+	</game>
+	<game name="Star Soldier - Vanishing Earth (Japan) (En)" id="0688" cloneofid="0689">
+		<category>Games</category>
+		<rom name="Star Soldier - Vanishing Earth (Japan) (En).n64" />
+		<description>Star Soldier - Vanishing Earth (Japan) (En)</description>
+		<rom name="Star Soldier - Vanishing Earth (Japan) (En).z64" size="12582912" crc="7ee5f51d" md5="14a21928be46c18ba04161305e89f5de" sha1="0b34bddd00c49530e0ef47330a05dc70ebe5f8b7" serial="NS6J" />
+	</game>
+	<game name="Star Soldier - Vanishing Earth (USA)" id="0689">
 		<description>Star Soldier - Vanishing Earth (USA)</description>
 		<rom name="Star Soldier - Vanishing Earth (USA).n64" />
-		<release name="Star Soldier - Vanishing Earth (USA)" region="USA" />
-		<rom name="Star Soldier - Vanishing Earth (USA).z64" size="12582912" crc="ea650def" md5="ee045a2e9f924cd8fd00018b50e46650" sha1="14dfd0172567b47c819b3e61d1ce13281e0ffed6" status="verified" />
+		<rom name="Star Soldier - Vanishing Earth (USA).z64" size="12582912" crc="ea650def" md5="ee045a2e9f924cd8fd00018b50e46650" sha1="14dfd0172567b47c819b3e61d1ce13281e0ffed6" status="verified" serial="NS6E" />
 	</game>
-	<game name="Star Soldier - Vanishing Earth (Japan)" cloneof="Star Soldier - Vanishing Earth (USA)">
-		<description>Star Soldier - Vanishing Earth (Japan)</description>
-		<rom name="Star Soldier - Vanishing Earth (Japan).n64" />
-		<release name="Star Soldier - Vanishing Earth (Japan)" region="JPN" />
-		<rom name="Star Soldier - Vanishing Earth (Japan).z64" size="12582912" crc="7ee5f51d" md5="14a21928be46c18ba04161305e89f5de" sha1="0b34bddd00c49530e0ef47330a05dc70ebe5f8b7" />
+	<game name="Star Twins (Japan)" id="0690" cloneofid="0330">
+		<description>Star Twins (Japan)</description>
+		<rom name="Star Twins (Japan).n64" />
+		<rom name="Star Twins (Japan).z64" size="33554432" crc="964506ce" md5="ca28a3645fc7ad969ebd75c5d6506e7a" sha1="15099233760b36e7afad7da36b9464da1512c4b1" serial="NJFJ" />
 	</game>
-	<game name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
-		<description>Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)</description>
-		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1).n64" />
-		<release name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)" region="EUR" />
-		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1).z64" size="16777216" crc="c88e5638" md5="a9dd498e6a28f55311ce4ef057e164b8" sha1="66a70566d267532272b15abc0be20e2a1074ae45" />
-	</game>
-	<game name="Star Wars - Rogue Squadron (Europe) (En,Fr,De)" cloneof="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
+	<game name="Star Wars - Rogue Squadron (Europe) (En,Fr,De)" id="0691" cloneofid="0692">
 		<description>Star Wars - Rogue Squadron (Europe) (En,Fr,De)</description>
 		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De).n64" />
-		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De).z64" size="16777216" crc="6289645f" md5="7f919d2e35cbe561e139ae8fe93aca86" sha1="da91a86f1f566dc66a2ae1292aa581bfc4f9cdfd" status="verified" />
+		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De).z64" size="16777216" crc="6289645f" md5="7f919d2e35cbe561e139ae8fe93aca86" sha1="da91a86f1f566dc66a2ae1292aa581bfc4f9cdfd" sha256="a33b6b738116c36e78a0d078ceb9ff7ddaa7b36244689421fa7d85d70ccc2273" status="verified" serial="NRSP" />
 	</game>
-	<game name="Star Wars - Rogue Squadron (USA)" cloneof="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
+	<game name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)" id="0692">
+		<description>Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)</description>
+		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1).n64" />
+		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1).z64" size="16777216" crc="c88e5638" md5="a9dd498e6a28f55311ce4ef057e164b8" sha1="66a70566d267532272b15abc0be20e2a1074ae45" serial="NRSP" />
+	</game>
+	<game name="Star Wars - Rogue Squadron (USA)" id="0693" cloneofid="0692">
 		<description>Star Wars - Rogue Squadron (USA)</description>
 		<rom name="Star Wars - Rogue Squadron (USA).n64" />
-		<rom name="Star Wars - Rogue Squadron (USA).z64" size="16777216" crc="83c225cc" md5="47cac4e2a6309458342f21a9018ffbf0" sha1="ed42eed1ee2db646ff7ef94ba8c5421d164a4f0d" />
+		<rom name="Star Wars - Rogue Squadron (USA).z64" size="16777216" crc="83c225cc" md5="47cac4e2a6309458342f21a9018ffbf0" sha1="ed42eed1ee2db646ff7ef94ba8c5421d164a4f0d" sha256="9c32d0087fa2b83c5ee6f19ee86683907653ed8f30e7d4680a0adac334559dd7" status="verified" serial="NRSE" />
 	</game>
-	<game name="Star Wars - Rogue Squadron (USA) (Rev 1)" cloneof="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
+	<game name="Star Wars - Rogue Squadron (USA) (Rev 1)" id="0903" cloneofid="0692">
 		<description>Star Wars - Rogue Squadron (USA) (Rev 1)</description>
 		<rom name="Star Wars - Rogue Squadron (USA) (Rev 1).n64" />
-		<release name="Star Wars - Rogue Squadron (USA) (Rev 1)" region="USA" />
-		<rom name="Star Wars - Rogue Squadron (USA) (Rev 1).z64" size="16777216" crc="65a8fba0" md5="2e458d7cc355d7918493b0e0362c9a20" sha1="c12e1c6fb47a67da463c50b705ec682ec24ae80d" />
+		<rom name="Star Wars - Rogue Squadron (USA) (Rev 1).z64" size="16777216" crc="65a8fba0" md5="2e458d7cc355d7918493b0e0362c9a20" sha1="c12e1c6fb47a67da463c50b705ec682ec24ae80d" serial="NRSE" />
 	</game>
-	<game name="Star Wars - Shutsugeki! Rogue Chuutai (Japan)" cloneof="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
-		<description>Star Wars - Shutsugeki! Rogue Chuutai (Japan)</description>
-		<rom name="Star Wars - Shutsugeki! Rogue Chuutai (Japan).n64" />
-		<release name="Star Wars - Shutsugeki! Rogue Chuutai (Japan)" region="JPN" />
-		<rom name="Star Wars - Shutsugeki! Rogue Chuutai (Japan).z64" size="16777216" crc="ee7643b6" md5="8603b180e70b2a72ef77d46c2bec2234" sha1="d8bddb9727264c14bf3bc20b2fe983fb86eada32" />
+	<game name="Star Wars - Rogue Squadron (USA) (LodgeNet)" id="1157" cloneofid="0692">
+		<category>Games</category>
+		<rom name="Star Wars - Rogue Squadron (USA) (LodgeNet).n64" />
+		<description>Star Wars - Rogue Squadron (USA) (LodgeNet)</description>
+		<rom name="Star Wars - Rogue Squadron (USA) (LodgeNet).i64" size="64" crc="b2c4fd5d" md5="1c9ad5b555bcc1263958aa2a1a046305" sha1="dccd8a3aaecf1b3d8148f56dd51be31dc1048f27" />
+		<rom name="Star Wars - Rogue Squadron (USA) (LodgeNet).z64" size="16777216" crc="b31c4197" md5="9adbbb596860db244490eb77e53a8df6" sha1="80cdebe735d21589b692157633aae4be0b98c08e" />
 	</game>
-	<game name="Star Wars - Shadows of the Empire (Europe)">
+	<game name="Star Wars - Shadows of the Empire (Europe)" id="0694">
 		<description>Star Wars - Shadows of the Empire (Europe)</description>
 		<rom name="Star Wars - Shadows of the Empire (Europe).n64" />
-		<release name="Star Wars - Shadows of the Empire (Europe)" region="EUR" />
-		<rom name="Star Wars - Shadows of the Empire (Europe).z64" size="12582912" crc="f0a191bf" md5="591cf8e672c9cc0fe9c871cc56dcc854" sha1="e014f60bea29bbc7fbd7f3ba4fcc6bdd228c8fe5" status="verified" />
+		<rom name="Star Wars - Shadows of the Empire (Europe).z64" size="12582912" crc="f0a191bf" md5="591cf8e672c9cc0fe9c871cc56dcc854" sha1="e014f60bea29bbc7fbd7f3ba4fcc6bdd228c8fe5" sha256="e9a7566a699e2c885d3cf86eb366f9fcd36e06a68f1ca0419700bbec44e3eacb" status="verified" serial="NSWP" />
 	</game>
-	<game name="Star Wars - Shadows of the Empire (USA)" cloneof="Star Wars - Shadows of the Empire (Europe)">
+	<game name="Star Wars - Shadows of the Empire (USA)" id="0695" cloneofid="0694">
 		<description>Star Wars - Shadows of the Empire (USA)</description>
 		<rom name="Star Wars - Shadows of the Empire (USA).n64" />
-		<rom name="Star Wars - Shadows of the Empire (USA).z64" size="12582912" crc="3c0837b3" md5="5cce8ad5f86e8a373a7525dc4c7e6705" sha1="271c285f6e5069133ab27a2a8324d4651591e35d" />
+		<rom name="Star Wars - Shadows of the Empire (USA).z64" size="12582912" crc="3c0837b3" md5="5cce8ad5f86e8a373a7525dc4c7e6705" sha1="271c285f6e5069133ab27a2a8324d4651591e35d" serial="NSWE" />
 	</game>
-	<game name="Star Wars - Shadows of the Empire (USA) (Rev 1)" cloneof="Star Wars - Shadows of the Empire (Europe)">
+	<game name="Star Wars - Shadows of the Empire (USA) (Rev 1)" id="0696" cloneofid="0694">
 		<description>Star Wars - Shadows of the Empire (USA) (Rev 1)</description>
 		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 1).n64" />
-		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 1).z64" size="12582912" crc="b0540688" md5="fa635e837275d28fd5a24d5675ba42c8" sha1="ded8f972d1e1d662614b1ec79822d649a8ce5430" />
+		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 1).z64" size="12582912" crc="b0540688" md5="fa635e837275d28fd5a24d5675ba42c8" sha1="ded8f972d1e1d662614b1ec79822d649a8ce5430" sha256="895d3dbbdc4945b690ef80f6dff8e5c95b5e3ab9fb3d9b62b5a8e9c61110a0e9" status="verified" serial="NSWE" />
 	</game>
-	<game name="Star Wars - Shadows of the Empire (USA) (Rev 2)" cloneof="Star Wars - Shadows of the Empire (Europe)">
+	<game name="Star Wars - Shadows of the Empire (USA) (Rev 2)" id="0697" cloneofid="0694">
 		<description>Star Wars - Shadows of the Empire (USA) (Rev 2)</description>
 		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 2).n64" />
-		<release name="Star Wars - Shadows of the Empire (USA) (Rev 2)" region="USA" />
-		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 2).z64" size="12582912" crc="e8727549" md5="c7b40352aad8d863d88d51672f9a0087" sha1="9ab85626c27372ee614b7c5301c2c4eb187fd9f6" />
+		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 2).z64" size="12582912" crc="e8727549" md5="c7b40352aad8d863d88d51672f9a0087" sha1="9ab85626c27372ee614b7c5301c2c4eb187fd9f6" sha256="e7085e013123537f34e0edec8801318016da4dbac424172d6dc5f3b67d98642c" status="verified" serial="NSWE" />
 	</game>
-	<game name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15)" cloneof="Star Wars - Shadows of the Empire (Europe)">
+	<game name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15)" id="0945" cloneofid="0694">
 		<description>Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15)</description>
 		<rom name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15).n64" />
-		<rom name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15).z64" size="12582912" crc="28368603" md5="4076973cfda277fc876e9f066cc73deb" sha1="0f642f17693adf1b97121a61bbeca37df59bb55a" />
+		<rom name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15).z64" size="12582912" crc="28368603" md5="4076973cfda277fc876e9f066cc73deb" sha1="0f642f17693adf1b97121a61bbeca37df59bb55a" serial="NSWE" />
 	</game>
-	<game name="Star Wars - Teikoku no Kage (Japan)" cloneof="Star Wars - Shadows of the Empire (Europe)">
+	<game name="Star Wars - Shutsugeki! Rogue Chuutai (Japan)" id="0698" cloneofid="0692">
+		<description>Star Wars - Shutsugeki! Rogue Chuutai (Japan)</description>
+		<rom name="Star Wars - Shutsugeki! Rogue Chuutai (Japan).n64" />
+		<rom name="Star Wars - Shutsugeki! Rogue Chuutai (Japan).z64" size="16777216" crc="ee7643b6" md5="8603b180e70b2a72ef77d46c2bec2234" sha1="d8bddb9727264c14bf3bc20b2fe983fb86eada32" serial="NRSJ" />
+	</game>
+	<game name="Star Wars - Teikoku no Kage (Japan)" id="0699" cloneofid="0694">
 		<description>Star Wars - Teikoku no Kage (Japan)</description>
 		<rom name="Star Wars - Teikoku no Kage (Japan).n64" />
-		<release name="Star Wars - Teikoku no Kage (Japan)" region="JPN" />
-		<rom name="Star Wars - Teikoku no Kage (Japan).z64" size="12582912" crc="7ce71426" md5="5b6b6b0c8c9a40286dcf61706b6a05cb" sha1="93ed6f1497ede2239f9d75b4a39204b6c9dd9ffd" />
+		<rom name="Star Wars - Teikoku no Kage (Japan).z64" size="12582912" crc="7ce71426" md5="5b6b6b0c8c9a40286dcf61706b6a05cb" sha1="93ed6f1497ede2239f9d75b4a39204b6c9dd9ffd" serial="NSWJ" />
 	</game>
-	<game name="Star Wars Episode I - Battle for Naboo (Europe)">
+	<game name="Star Wars Episode I - Battle for Naboo (Europe)" id="0700">
 		<description>Star Wars Episode I - Battle for Naboo (Europe)</description>
 		<rom name="Star Wars Episode I - Battle for Naboo (Europe).n64" />
-		<release name="Star Wars Episode I - Battle for Naboo (Europe)" region="EUR" />
-		<rom name="Star Wars Episode I - Battle for Naboo (Europe).z64" size="33554432" crc="029104fd" md5="0bd1f7bb9f4b02520e4e9285c809f099" sha1="c949856a6cb0b59a2d171c8ad2e8d913cca23022" />
+		<rom name="Star Wars Episode I - Battle for Naboo (Europe).z64" size="33554432" crc="029104fd" md5="0bd1f7bb9f4b02520e4e9285c809f099" sha1="c949856a6cb0b59a2d171c8ad2e8d913cca23022" sha256="b5bdfe343a2b24cad636b66cac0af54ac04aefbfa26a817957227cc24ced4846" status="verified" serial="NNAP" />
 	</game>
-	<game name="Star Wars Episode I - Battle for Naboo (USA)" cloneof="Star Wars Episode I - Battle for Naboo (Europe)">
+	<game name="Star Wars Episode I - Battle for Naboo (USA)" id="0701" cloneofid="0700">
 		<description>Star Wars Episode I - Battle for Naboo (USA)</description>
 		<rom name="Star Wars Episode I - Battle for Naboo (USA).n64" />
-		<release name="Star Wars Episode I - Battle for Naboo (USA)" region="USA" />
-		<rom name="Star Wars Episode I - Battle for Naboo (USA).z64" size="33554432" crc="99dee3c0" md5="3cb88b934572e7520f35e5458798775b" sha1="e4441a6eeb67861408c2e009baae8aad4df34021" />
+		<rom name="Star Wars Episode I - Battle for Naboo (USA).z64" size="33554432" crc="99dee3c0" md5="3cb88b934572e7520f35e5458798775b" sha1="e4441a6eeb67861408c2e009baae8aad4df34021" sha256="515b2302fefe1741c09103f70708690a058ba77a7ab8acd086c48b972b22d33e" serial="NNAE" />
 	</game>
-	<game name="Star Wars Episode I - Racer (Europe) (En,Fr,De)">
+	<game name="Star Wars Episode I - Battle for Naboo (USA) (Beta)" id="1124" cloneofid="0700">
+		<category>Games</category>
+		<rom name="Star Wars Episode I - Battle for Naboo (USA) (Beta).n64" />
+		<description>Star Wars Episode I - Battle for Naboo (USA) (Beta)</description>
+		<rom name="Star Wars Episode I - Battle for Naboo (USA) (Beta).z64" size="33554432" crc="90759d7b" md5="88776081f0f92eef355cd451b9c6a819" sha1="8f82880cde3f11af23f580667ac133ccb5f6a0ca" sha256="2dbba691279d4879b0e6edfa6f69113b79227b37afb5097108691870c8a8dbf4" serial="NNAE" />
+	</game>
+	<game name="Star Wars Episode I - Racer (Europe) (En,Fr,De)" id="0702">
 		<description>Star Wars Episode I - Racer (Europe) (En,Fr,De)</description>
 		<rom name="Star Wars Episode I - Racer (Europe) (En,Fr,De).n64" />
-		<release name="Star Wars Episode I - Racer (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Star Wars Episode I - Racer (Europe) (En,Fr,De).z64" size="33554432" crc="e0f46629" md5="6ef9fed309f28bd59b605f128869aa00" sha1="899a8245da017289c88e97327fdcd6694b770a25" status="verified" />
+		<rom name="Star Wars Episode I - Racer (Europe) (En,Fr,De).z64" size="33554432" crc="e0f46629" md5="6ef9fed309f28bd59b605f128869aa00" sha1="899a8245da017289c88e97327fdcd6694b770a25" sha256="326b810b24cef38b04b74084bfd487fb6d40ea955dc2a54849de942bde076edc" status="verified" serial="NEPP" />
 	</game>
-	<game name="Star Wars Episode I - Racer (Japan)" cloneof="Star Wars Episode I - Racer (Europe) (En,Fr,De)">
+	<game name="Star Wars Episode I - Racer (Japan)" id="0703" cloneofid="0702">
 		<description>Star Wars Episode I - Racer (Japan)</description>
 		<rom name="Star Wars Episode I - Racer (Japan).n64" />
-		<release name="Star Wars Episode I - Racer (Japan)" region="JPN" />
-		<rom name="Star Wars Episode I - Racer (Japan).z64" size="33554432" crc="97c155c5" md5="7579ab0e79b1011479b88f2bf39d48e0" sha1="9577ccd2d069d0e7e306cf21ddb0e4765a308072" />
+		<rom name="Star Wars Episode I - Racer (Japan).z64" size="33554432" crc="97c155c5" md5="7579ab0e79b1011479b88f2bf39d48e0" sha1="9577ccd2d069d0e7e306cf21ddb0e4765a308072" serial="NEPJ" />
 	</game>
-	<game name="Star Wars Episode I - Racer (USA)" cloneof="Star Wars Episode I - Racer (Europe) (En,Fr,De)">
+	<game name="Star Wars Episode I - Racer (USA)" id="0704" cloneofid="0702">
 		<description>Star Wars Episode I - Racer (USA)</description>
 		<rom name="Star Wars Episode I - Racer (USA).n64" />
-		<release name="Star Wars Episode I - Racer (USA)" region="USA" />
-		<rom name="Star Wars Episode I - Racer (USA).z64" size="33554432" crc="c53c1035" md5="1ee8800a4003e7f9688c5a35f929d01b" sha1="3542d5597c8a56ea8f5c63bceae97a24c4c08d58" />
+		<rom name="Star Wars Episode I - Racer (USA).z64" size="33554432" crc="c53c1035" md5="1ee8800a4003e7f9688c5a35f929d01b" sha1="3542d5597c8a56ea8f5c63bceae97a24c4c08d58" sha256="8d6f85683b630e25385619af37197d48279366f6609bb6edc1201ff24c08b757" status="verified" serial="NEPE" />
 	</game>
-	<game name="StarCraft 64 (USA)">
-		<description>StarCraft 64 (USA)</description>
-		<rom name="StarCraft 64 (USA).n64" />
-		<release name="StarCraft 64 (USA)" region="USA" />
-		<rom name="StarCraft 64 (USA).z64" size="33554432" crc="4e4c7ec9" md5="559f71b861f639b6376d891e3023414b" sha1="a36d91b5aac7bb95df0d7de5f9814f5270e25c2b" />
-	</game>
-	<game name="StarCraft 64 (Australia)" cloneof="StarCraft 64 (USA)">
+	<game name="StarCraft 64 (Australia)" id="0705" cloneofid="0706">
 		<description>StarCraft 64 (Australia)</description>
 		<rom name="StarCraft 64 (Australia).n64" />
-		<release name="StarCraft 64 (Australia)" region="AUS" />
-		<rom name="StarCraft 64 (Australia).z64" size="33554432" crc="2639dae2" md5="72b60fac5ee257fa387b43c57632d50c" sha1="bd8ab8994be02368c844234006e5c11509ce2894" status="verified" />
+		<rom name="StarCraft 64 (Australia).z64" size="33554432" crc="2639dae2" md5="72b60fac5ee257fa387b43c57632d50c" sha1="bd8ab8994be02368c844234006e5c11509ce2894" sha256="f2267c9325d608f283830a7d568dcd9a2fc126f93b1c7d3ea23a34082031c19a" status="verified" serial="NSQP" />
 	</game>
-	<game name="StarCraft 64 (USA) (Beta)" cloneof="StarCraft 64 (USA)">
+	<game name="StarCraft 64 (USA)" id="0706">
+		<description>StarCraft 64 (USA)</description>
+		<rom name="StarCraft 64 (USA).n64" />
+		<rom name="StarCraft 64 (USA).z64" size="33554432" crc="4e4c7ec9" md5="559f71b861f639b6376d891e3023414b" sha1="a36d91b5aac7bb95df0d7de5f9814f5270e25c2b" sha256="e7d21880c13953b45b8f8db6b2b6cfa02daa29d35b23799a967e96f21001b020" serial="NSQE" />
+	</game>
+	<game name="StarCraft 64 (USA) (Beta)" id="0707" cloneofid="0706">
 		<description>StarCraft 64 (USA) (Beta)</description>
 		<rom name="StarCraft 64 (USA) (Beta).n64" />
 		<rom name="StarCraft 64 (USA) (Beta).z64" size="33554432" crc="b0e1654f" md5="3eb732a8d004263ad8eb0da59a29582a" sha1="472573d057e42653b7413861319b9f7342f2467d" />
 	</game>
-	<game name="StarCraft 64 (Germany) (Proto)" cloneof="StarCraft 64 (USA)">
+	<game name="StarCraft 64 (Germany) (Proto)" id="0905" cloneofid="0706">
 		<description>StarCraft 64 (Germany) (Proto)</description>
 		<rom name="StarCraft 64 (Germany) (Proto).n64" />
-		<rom name="StarCraft 64 (Germany) (Proto).z64" size="33554432" crc="2b1c9fe4" md5="356a5d3d59e0adef6efae6096fc20f77" sha1="bc585da421caba45f5eb87caa6d7a138a09e9b43" />
+		<rom name="StarCraft 64 (Germany) (Proto).z64" size="33554432" crc="2b1c9fe4" md5="356a5d3d59e0adef6efae6096fc20f77" sha1="bc585da421caba45f5eb87caa6d7a138a09e9b43" serial="NSQD" />
 	</game>
-	<game name="Starshot - Space Circus Fever (Europe) (En,Fr,De)">
+	<game name="Starshot - Space Circus Fever (Europe) (En,Fr,De)" id="0708">
 		<description>Starshot - Space Circus Fever (Europe) (En,Fr,De)</description>
 		<rom name="Starshot - Space Circus Fever (Europe) (En,Fr,De).n64" />
-		<release name="Starshot - Space Circus Fever (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Starshot - Space Circus Fever (Europe) (En,Fr,De).z64" size="12582912" crc="056d2218" md5="a9c393aa232b32798adf378f4318f99f" sha1="b92818c5ff6be02bec77edcbe278d06785d00c78" status="verified" />
+		<rom name="Starshot - Space Circus Fever (Europe) (En,Fr,De).z64" size="12582912" crc="056d2218" md5="a9c393aa232b32798adf378f4318f99f" sha1="b92818c5ff6be02bec77edcbe278d06785d00c78" sha256="c82d314e5aee48c305d141ba1cb0203cc450e4ea3fd49e464563bc6a64d69094" status="verified" serial="NSCP" />
 	</game>
-	<game name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" cloneof="Starshot - Space Circus Fever (Europe) (En,Fr,De)">
+	<game name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" id="0709" cloneofid="0708">
 		<description>Starshot - Space Circus Fever (USA) (En,Fr,Es)</description>
 		<rom name="Starshot - Space Circus Fever (USA) (En,Fr,Es).n64" />
-		<release name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" region="SPA" />
-		<release name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" region="USA" />
-		<rom name="Starshot - Space Circus Fever (USA) (En,Fr,Es).z64" size="12582912" crc="7720e5f3" md5="42af1992978229bbb5f560571708e25e" sha1="7def46651f55745d5bbd633c9002bdbffc53a5e0" />
+		<rom name="Starshot - Space Circus Fever (USA) (En,Fr,Es).z64" size="12582912" crc="7720e5f3" md5="42af1992978229bbb5f560571708e25e" sha1="7def46651f55745d5bbd633c9002bdbffc53a5e0" sha256="0119becb46b84107ce9f67c89439474f43b08b77f0da2e3731ae4cc95f573d5f" serial="NSCE" />
 	</game>
-	<game name="Stunt Racer 64 (USA)">
+	<game name="Stunt Racer 64 (USA)" id="0710">
 		<description>Stunt Racer 64 (USA)</description>
 		<rom name="Stunt Racer 64 (USA).n64" />
-		<release name="Stunt Racer 64 (USA)" region="USA" />
-		<rom name="Stunt Racer 64 (USA).z64" size="12582912" crc="3438b1af" md5="e8b666a429fedb2a1a1228cd450cd4fc" sha1="8570fa1f3e4cf7e62dc49da181353e4f301503b7" />
+		<rom name="Stunt Racer 64 (USA).z64" size="12582912" crc="3438b1af" md5="e8b666a429fedb2a1a1228cd450cd4fc" sha1="8570fa1f3e4cf7e62dc49da181353e4f301503b7" serial="NR3E" />
 	</game>
-	<game name="Super B-Daman - Battle Phoenix 64 (Japan)">
+	<game name="Super B-Daman - Battle Phoenix 64 (Japan)" id="0711">
 		<description>Super B-Daman - Battle Phoenix 64 (Japan)</description>
 		<rom name="Super B-Daman - Battle Phoenix 64 (Japan).n64" />
-		<release name="Super B-Daman - Battle Phoenix 64 (Japan)" region="JPN" />
-		<rom name="Super B-Daman - Battle Phoenix 64 (Japan).z64" size="12582912" crc="5006dc88" md5="b3c1d4b9ec7dcd2922e681dbbc393915" sha1="d443fb2e2e3980fcb90e5bba4138922477ea9037" />
+		<rom name="Super B-Daman - Battle Phoenix 64 (Japan).z64" size="12582912" crc="5006dc88" md5="b3c1d4b9ec7dcd2922e681dbbc393915" sha1="d443fb2e2e3980fcb90e5bba4138922477ea9037" serial="NB6J" />
 	</game>
-	<game name="Super Bowling (USA)">
-		<description>Super Bowling (USA)</description>
-		<rom name="Super Bowling (USA).n64" />
-		<release name="Super Bowling (USA)" region="USA" />
-		<rom name="Super Bowling (USA).z64" size="8388608" crc="f6ccd04a" md5="fa3a043997a3acdf17337385b126bc04" sha1="56937a9e9536af55ebed06480413265848c4a04a" />
-	</game>
-	<game name="Super Bowling (Japan)" cloneof="Super Bowling (USA)">
+	<game name="Super Bowling (Japan)" id="0712" cloneofid="0713">
 		<description>Super Bowling (Japan)</description>
 		<rom name="Super Bowling (Japan).n64" />
-		<release name="Super Bowling (Japan)" region="JPN" />
-		<rom name="Super Bowling (Japan).z64" size="8388608" crc="ba2d8b2e" md5="09c5b4d19364efe48bb818087734978e" sha1="faa5ffdffec1fa56125130becb6e150032c6923e" />
+		<rom name="Super Bowling (Japan).z64" size="8388608" crc="ba2d8b2e" md5="09c5b4d19364efe48bb818087734978e" sha1="faa5ffdffec1fa56125130becb6e150032c6923e" serial="NBWJ" />
 	</game>
-	<game name="Super Mario 64 (Europe) (En,Fr,De)">
+	<game name="Super Bowling (USA)" id="0713">
+		<description>Super Bowling (USA)</description>
+		<rom name="Super Bowling (USA).n64" />
+		<rom name="Super Bowling (USA).z64" size="8388608" crc="f6ccd04a" md5="fa3a043997a3acdf17337385b126bc04" sha1="56937a9e9536af55ebed06480413265848c4a04a" serial="NBWE" />
+	</game>
+	<game name="Super Mario 64 (Europe) (En,Fr,De)" id="0714">
 		<description>Super Mario 64 (Europe) (En,Fr,De)</description>
 		<rom name="Super Mario 64 (Europe) (En,Fr,De).n64" />
-		<release name="Super Mario 64 (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Super Mario 64 (Europe) (En,Fr,De).z64" size="8388608" crc="03048de6" md5="45676429ef6b90e65b517129b700308e" sha1="4ac5721683d0e0b6bbb561b58a71740845dceea9" status="verified" />
+		<rom name="Super Mario 64 (Europe) (En,Fr,De).z64" size="8388608" crc="03048de6" md5="45676429ef6b90e65b517129b700308e" sha1="4ac5721683d0e0b6bbb561b58a71740845dceea9" sha256="c792e5ebcba34c8d98c0c44cf29747c8ee67e7b907fcc77887f9ff2523f80572" status="verified" serial="NSMP" />
 	</game>
-	<game name="Shen You Mario (China) (iQue)" cloneof="Super Mario 64 (Europe) (En,Fr,De)">
-		<description>Shen You Mario (China) (iQue)</description>
-		<rom name="Shen You Mario (China) (iQue).n64" />
-		<rom name="Shen You Mario (China) (iQue).z64" size="8060928" crc="08b48ca1" md5="29047fba820695bd14c5bd7aa1aa4400" sha1="2e1db2780985a1f068077dc0444b685f39cd90ec" />
-	</game>
-	<game name="Super Mario 64 (Japan)" cloneof="Super Mario 64 (Europe) (En,Fr,De)">
+	<game name="Super Mario 64 (Japan)" id="0715" cloneofid="0714">
 		<description>Super Mario 64 (Japan)</description>
 		<rom name="Super Mario 64 (Japan).n64" />
-		<rom name="Super Mario 64 (Japan).z64" size="8388608" crc="dd801954" md5="85d61f5525af708c9f1e84dce6dc10e9" sha1="8a20a5c83d6ceb0f0506cfc9fa20d8f438cafe51" status="verified" />
+		<rom name="Super Mario 64 (Japan).z64" size="8388608" crc="dd801954" md5="85d61f5525af708c9f1e84dce6dc10e9" sha1="8a20a5c83d6ceb0f0506cfc9fa20d8f438cafe51" sha256="9cf7a80db321b07a8d461fe536c02c87b7412433953891cdec9191bfad2db317" status="verified" serial="NSMJ" />
 	</game>
-	<game name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition)" cloneof="Super Mario 64 (Europe) (En,Fr,De)">
+	<game name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition)" id="0716" cloneofid="0714">
 		<description>Super Mario 64 (Japan) (Rev 3) (Shindou Edition)</description>
 		<rom name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition).n64" />
-		<release name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition)" region="JPN" />
-		<rom name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition).z64" size="8388608" crc="a1e15117" md5="2d727c3278aa232d94f2fb45aec4d303" sha1="3f319ae697533a255a1003d09202379d78d5a2e0" status="verified" />
+		<rom name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition).z64" size="8388608" crc="a1e15117" md5="2d727c3278aa232d94f2fb45aec4d303" sha1="3f319ae697533a255a1003d09202379d78d5a2e0" sha256="f8807b5e28f1b1a31c5d3675d23ece73f949ccb553dcbb07972666a1e76adfa2" serial="NSMJ" />
 	</game>
-	<game name="Super Mario 64 (USA)" cloneof="Super Mario 64 (Europe) (En,Fr,De)">
+	<game name="Super Mario 64 (USA)" id="0717" cloneofid="0714">
 		<description>Super Mario 64 (USA)</description>
 		<rom name="Super Mario 64 (USA).n64" />
-		<release name="Super Mario 64 (USA)" region="USA" />
-		<rom name="Super Mario 64 (USA).z64" size="8388608" crc="3ce60709" md5="20b854b239203baf6c961b850a4a51a2" sha1="9bef1128717f958171a4afac3ed78ee2bb4e86ce" status="verified" />
+		<rom name="Super Mario 64 (USA).z64" size="8388608" crc="3ce60709" md5="20b854b239203baf6c961b850a4a51a2" sha1="9bef1128717f958171a4afac3ed78ee2bb4e86ce" sha256="17ce077343c6133f8c9f2d6d6d9a4ab62c8cd2aa57c40aea1f490b4c8bb21d91" status="verified" serial="NSME" />
 	</game>
-	<game name="Super Robot Spirits (Japan)">
+	<game name="Super Mario 64 (USA) (LodgeNet)" id="1161" cloneofid="0714">
+		<category>Games</category>
+		<rom name="Super Mario 64 (USA) (LodgeNet).n64" />
+		<description>Super Mario 64 (USA) (LodgeNet)</description>
+		<rom name="Super Mario 64 (USA) (LodgeNet).i64" size="64" crc="1749981b" md5="1b5ff38194ee06d8b4687e675a6c77ee" sha1="1530b8a818b0457847b9b79add0840c4c2fa0629" />
+		<rom name="Super Mario 64 (USA) (LodgeNet).z64" size="8388608" crc="35c02d9f" md5="5c653198036c372df77289da22f790b8" sha1="37f5ed5394d885de2aff705074bd76ddc95d3cc9" />
+	</game>
+	<game name="Super Robot Spirits (Japan)" id="0718">
 		<description>Super Robot Spirits (Japan)</description>
 		<rom name="Super Robot Spirits (Japan).n64" />
-		<release name="Super Robot Spirits (Japan)" region="JPN" />
-		<rom name="Super Robot Spirits (Japan).z64" size="16777216" crc="8c9216c1" md5="3ec3f83eab22702e146c467eb1db45fa" sha1="3bf62a1a48716708a5831ce47fb8c1a41dc365e6" />
+		<rom name="Super Robot Spirits (Japan).z64" size="16777216" crc="8c9216c1" md5="3ec3f83eab22702e146c467eb1db45fa" sha1="3bf62a1a48716708a5831ce47fb8c1a41dc365e6" serial="NSSJ" />
 	</game>
-	<game name="Super Robot Taisen 64 (Japan)">
+	<game name="Super Robot Taisen 64 (Japan)" id="0719">
 		<description>Super Robot Taisen 64 (Japan)</description>
 		<rom name="Super Robot Taisen 64 (Japan).n64" />
-		<release name="Super Robot Taisen 64 (Japan)" region="JPN" />
-		<rom name="Super Robot Taisen 64 (Japan).z64" size="33554432" crc="85df2771" md5="3f4b73963abc91cee59c416063efd4ae" sha1="9883aef6e20a46e110560c505999f3e21a1897de" />
+		<rom name="Super Robot Taisen 64 (Japan).z64" size="33554432" crc="85df2771" md5="3f4b73963abc91cee59c416063efd4ae" sha1="9883aef6e20a46e110560c505999f3e21a1897de" sha256="ee5f4a21d8e5f7827d21199e27800edf250df9a8e4d10befb1a6992df597b13e" status="verified" serial="NS4J" />
 	</game>
-	<game name="Super Smash Bros. (Europe) (En,Fr,De)">
-		<description>Super Smash Bros. (Europe) (En,Fr,De)</description>
-		<rom name="Super Smash Bros. (Europe) (En,Fr,De).n64" />
-		<release name="Super Smash Bros. (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Super Smash Bros. (Europe) (En,Fr,De).z64" size="33554432" crc="45a91cb1" md5="5e54c6c563b09c107f86fb33e914ef81" sha1="6ee8a41fef66280ce3e3f0984d00b96079442fb9" status="verified" />
-	</game>
-	<game name="Nintendo All-Star! Dairantou Smash Brothers (Japan)" cloneof="Super Smash Bros. (Europe) (En,Fr,De)">
-		<description>Nintendo All-Star! Dairantou Smash Brothers (Japan)</description>
-		<rom name="Nintendo All-Star! Dairantou Smash Brothers (Japan).n64" />
-		<release name="Nintendo All-Star! Dairantou Smash Brothers (Japan)" region="JPN" />
-		<rom name="Nintendo All-Star! Dairantou Smash Brothers (Japan).z64" size="16777216" crc="04c9d3b1" md5="66db457b130d31a286a23d6e4dd9726e" sha1="4b71f0e01878696733eefa9c80d11c147ecb4984" status="verified" />
-	</game>
-	<game name="Rentiantang Mingxing - Daluan Dou (China) (iQue)" cloneof="Super Smash Bros. (Europe) (En,Fr,De)">
-		<description>Rentiantang Mingxing - Daluan Dou (China) (iQue)</description>
-		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue).n64" />
-		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue).z64" size="16793600" crc="d86e2edf" md5="7b815846ec91e6c4a8b8baa0ce4078f0" sha1="926dfad9daede0ddd088d3006bbd1d02ca6222a4" />
-	</game>
-	<game name="Super Smash Bros. (Australia)" cloneof="Super Smash Bros. (Europe) (En,Fr,De)">
+	<game name="Super Smash Bros. (Australia)" id="0720" cloneofid="0721">
 		<description>Super Smash Bros. (Australia)</description>
 		<rom name="Super Smash Bros. (Australia).n64" />
-		<release name="Super Smash Bros. (Australia)" region="AUS" />
-		<rom name="Super Smash Bros. (Australia).z64" size="16777216" crc="e96779fa" md5="694dea68dbf1c3f06ff0476acf2169e6" sha1="a9bf83fe73361e8d042c33ed48b3851d7d46712c" />
+		<rom name="Super Smash Bros. (Australia).z64" size="16777216" crc="e96779fa" md5="694dea68dbf1c3f06ff0476acf2169e6" sha1="a9bf83fe73361e8d042c33ed48b3851d7d46712c" serial="NALU" />
 	</game>
-	<game name="Super Smash Bros. (USA)" cloneof="Super Smash Bros. (Europe) (En,Fr,De)">
+	<game name="Super Smash Bros. (Europe) (En,Fr,De)" id="0721">
+		<description>Super Smash Bros. (Europe) (En,Fr,De)</description>
+		<rom name="Super Smash Bros. (Europe) (En,Fr,De).n64" />
+		<rom name="Super Smash Bros. (Europe) (En,Fr,De).z64" size="33554432" crc="45a91cb1" md5="5e54c6c563b09c107f86fb33e914ef81" sha1="6ee8a41fef66280ce3e3f0984d00b96079442fb9" sha256="ddc65284e78c301f764d2f5e1e01de9a017225867a0b9326b73057fb8bdb1daf" status="verified" serial="NALP" />
+	</game>
+	<game name="Super Smash Bros. (USA)" id="0722" cloneofid="0721">
 		<description>Super Smash Bros. (USA)</description>
 		<rom name="Super Smash Bros. (USA).n64" />
-		<release name="Super Smash Bros. (USA)" region="USA" />
-		<rom name="Super Smash Bros. (USA).z64" size="16777216" crc="eb97929e" md5="f7c52568a31aadf26e14dc2b6416b2ed" sha1="e2929e10fccc0aa84e5776227e798abc07cedabf" status="verified" />
+		<rom name="Super Smash Bros. (USA).z64" size="16777216" crc="eb97929e" md5="f7c52568a31aadf26e14dc2b6416b2ed" sha1="e2929e10fccc0aa84e5776227e798abc07cedabf" sha256="15592e79d3c5295cef4371d4992f0bd25bec2102fc29644c93e682f7ea99ef3d" status="verified" serial="NALE" />
 	</game>
-	<game name="Supercross 2000 (Europe) (En,Fr,De)">
+	<game name="Super Smash Bros. (USA) (LodgeNet)" id="1159" cloneofid="0721">
+		<category>Games</category>
+		<rom name="Super Smash Bros. (USA) (LodgeNet).n64" />
+		<description>Super Smash Bros. (USA) (LodgeNet)</description>
+		<rom name="Super Smash Bros. (USA) (LodgeNet).i64" size="64" crc="6c30334f" md5="314fe951d563b8150346e0aa0894d3b9" sha1="7ecf5ccbc981ecca414ebaa86eef57ce721c32e8" />
+		<rom name="Super Smash Bros. (USA) (LodgeNet).z64" size="16777216" crc="1c001a5d" md5="bf751a6c92d113e3ebdcb2bea6a814d0" sha1="a0aea7d219443209c6580a501601d3151c58d3ac" />
+	</game>
+	<game name="Super Speed Race 64 (Japan)" id="0723" cloneofid="0049">
+		<description>Super Speed Race 64 (Japan)</description>
+		<rom name="Super Speed Race 64 (Japan).n64" />
+		<rom name="Super Speed Race 64 (Japan).z64" size="4194304" crc="0f879a70" md5="6b5d93b3566e96147009d1ac4fb15c97" sha1="e0a49ff953b882f9f135b583ef9e09a664d24288" serial="NLCJ" />
+	</game>
+	<game name="Supercross 2000 (Europe) (En,Fr,De)" id="0724">
 		<description>Supercross 2000 (Europe) (En,Fr,De)</description>
 		<rom name="Supercross 2000 (Europe) (En,Fr,De).n64" />
-		<release name="Supercross 2000 (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Supercross 2000 (Europe) (En,Fr,De).z64" size="16777216" crc="cb5482ec" md5="6d58a01ef7a7a7c779d2a66315992c5f" sha1="3fa3f859048a65e1e810ed7be98ada0a0b4e49ad" />
+		<rom name="Supercross 2000 (Europe) (En,Fr,De).z64" size="16777216" crc="cb5482ec" md5="6d58a01ef7a7a7c779d2a66315992c5f" sha1="3fa3f859048a65e1e810ed7be98ada0a0b4e49ad" sha256="92db4d0ba456d921c077d5bd524c913c297ea888bc78d5018ced70faa6203a59" status="verified" serial="NSXP" />
 	</game>
-	<game name="Supercross 2000 (USA)" cloneof="Supercross 2000 (Europe) (En,Fr,De)">
+	<game name="Supercross 2000 (USA)" id="0725" cloneofid="0724">
 		<description>Supercross 2000 (USA)</description>
 		<rom name="Supercross 2000 (USA).n64" />
-		<release name="Supercross 2000 (USA)" region="USA" />
-		<rom name="Supercross 2000 (USA).z64" size="16777216" crc="094e2a48" md5="60347200a1a7cabc0d849ee69ec51df7" sha1="8d726c2ef6bc74b0d516067ffd92da00efa07993" />
+		<rom name="Supercross 2000 (USA).z64" size="16777216" crc="094e2a48" md5="60347200a1a7cabc0d849ee69ec51df7" sha1="8d726c2ef6bc74b0d516067ffd92da00efa07993" sha256="2659be83dc4d8795d01d4838383579ad9aecf1a06ef0ea6aebc9588184fb9080" serial="NSXE" />
 	</game>
-	<game name="Superman (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Superman (Europe) (En,Fr,De,Es,It,Nl)" id="0726">
 		<description>Superman (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Superman (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Superman (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Superman (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="bca4ff8c" md5="5ab39f2d7a144e1ba243df059560e878" sha1="326378f4c05ca48b69d29ca1c72ab8e19b6ee10d" />
+		<rom name="Superman (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="bca4ff8c" md5="5ab39f2d7a144e1ba243df059560e878" sha1="326378f4c05ca48b69d29ca1c72ab8e19b6ee10d" sha256="ae0cb81d7fff296f4a079e3ec08255ea9d65979230bb41ab4ae492bf830d56a0" status="verified" serial="NSPP" />
 	</game>
-	<game name="Superman (USA) (Beta) (1998-09-06)" cloneof="Superman (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Superman (USA) (Beta) (1998-09-06)" id="0941" cloneofid="0726">
 		<description>Superman (USA) (Beta) (1998-09-06)</description>
 		<rom name="Superman (USA) (Beta) (1998-09-06).n64" />
 		<rom name="Superman (USA) (Beta) (1998-09-06).z64" size="33554432" crc="a0897826" md5="19c9491dd517603be2fa3020c2f2deb2" sha1="9eccd95652cf6ba95f2dc78c44a26fc0832dfe35" />
 	</game>
-	<game name="Superman - The New Superman Aventures (USA) (En,Fr,Es)" cloneof="Superman (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Superman - The New Superman Aventures (USA) (En,Fr,Es)" id="0727" cloneofid="0726">
 		<description>Superman - The New Superman Aventures (USA) (En,Fr,Es)</description>
 		<rom name="Superman - The New Superman Aventures (USA) (En,Fr,Es).n64" />
-		<release name="Superman - The New Superman Aventures (USA) (En,Fr,Es)" region="USA" />
-		<rom name="Superman - The New Superman Aventures (USA) (En,Fr,Es).z64" size="8388608" crc="437e3677" md5="3f64b4f72e61225ef3ae93976c9bfc7c" sha1="c271db752610c9581e1ba1e9125ea8ecdb56f74f" />
+		<rom name="Superman - The New Superman Aventures (USA) (En,Fr,Es).z64" size="8388608" crc="437e3677" md5="3f64b4f72e61225ef3ae93976c9bfc7c" sha1="c271db752610c9581e1ba1e9125ea8ecdb56f74f" serial="NSPE" />
 	</game>
-	<game name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)">
+	<game name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)" id="0728">
 		<description>Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)</description>
 		<rom name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan).n64" />
-		<release name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)" region="JPN" />
-		<rom name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan).z64" size="8388608" crc="4cd21372" md5="26f4ca20f7b9c88199ac046c57e282b4" sha1="fb905ac5887de6c3670f73f9c92efbacd55b6816" />
+		<rom name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan).z64" size="8388608" crc="4cd21372" md5="26f4ca20f7b9c88199ac046c57e282b4" sha1="fb905ac5887de6c3670f73f9c92efbacd55b6816" serial="NPZJ" />
 	</game>
-	<game name="Sydney 2000 (Europe) (Proto)">
+	<game name="Sydney 2000 (Europe) (Proto)" id="0907">
 		<description>Sydney 2000 (Europe) (Proto)</description>
 		<rom name="Sydney 2000 (Europe) (Proto).n64" />
-		<release name="Sydney 2000 (Europe) (Proto)" region="EUR" />
 		<rom name="Sydney 2000 (Europe) (Proto).z64" size="33554432" crc="db7b31b9" md5="fc32007ba03ff2510020e979c7bdad4f" sha1="ecc18f53e0ca563b3d5fa6876768ef2f94d35e36" />
 	</game>
-	<game name="Sydney 2000 (USA) (Proto)" cloneof="Sydney 2000 (Europe) (Proto)">
+	<game name="Sydney 2000 (USA) (Proto)" id="0908" cloneofid="0907">
 		<description>Sydney 2000 (USA) (Proto)</description>
 		<rom name="Sydney 2000 (USA) (Proto).n64" />
-		<release name="Sydney 2000 (USA) (Proto)" region="USA" />
 		<rom name="Sydney 2000 (USA) (Proto).z64" size="33554432" crc="5b6673aa" md5="2eea8d20bef26f88a5e82fdd39f87e75" sha1="711c79790a713e65cc2ecb4857f35898b8e92985" />
 	</game>
-	<game name="Tarzan (Europe)">
+	<game name="Tamiya Racing 64 (USA) (Proto)" id="0922" cloneofid="0923">
+		<description>Tamiya Racing 64 (USA) (Proto)</description>
+		<rom name="Tamiya Racing 64 (USA) (Proto).n64" />
+		<rom name="Tamiya Racing 64 (USA) (Proto).z64" size="16777216" crc="1b4c53fa" md5="cecab8df02c02f38c9cf1bdd57b1da00" sha1="be11aa2170fb3900379b127241161833400bf58c" serial="!none" />
+	</game>
+	<game name="Tarzan (Europe)" id="0729">
 		<description>Tarzan (Europe)</description>
 		<rom name="Tarzan (Europe).n64" />
-		<release name="Tarzan (Europe)" region="EUR" />
-		<rom name="Tarzan (Europe).z64" size="16777216" crc="7737ed9e" md5="bd1de2fc1cf31096423563a40ecbf933" sha1="7623aceecd244f4352a7d9346a607ac183b32cd6" />
+		<rom name="Tarzan (Europe).z64" size="16777216" crc="7737ed9e" md5="bd1de2fc1cf31096423563a40ecbf933" sha1="7623aceecd244f4352a7d9346a607ac183b32cd6" serial="NTAP" />
 	</game>
-	<game name="Tarzan (France)" cloneof="Tarzan (Europe)">
+	<game name="Tarzan (France)" id="0730" cloneofid="0729">
 		<description>Tarzan (France)</description>
 		<rom name="Tarzan (France).n64" />
-		<release name="Tarzan (France)" region="FRA" />
-		<rom name="Tarzan (France).z64" size="16777216" crc="99c7649d" md5="5d82e903f65341487ddc11af80ad607a" sha1="1cf1f0f8217ba4e1691427f97ef62b15dc02a1c3" />
+		<rom name="Tarzan (France).z64" size="16777216" crc="99c7649d" md5="5d82e903f65341487ddc11af80ad607a" sha1="1cf1f0f8217ba4e1691427f97ef62b15dc02a1c3" sha256="4dba12006cfbb965de11f95cde4042afde4fb53a5c8dfed0393dfadc87e7394f" serial="NTAF" />
 	</game>
-	<game name="Tarzan (Germany)" cloneof="Tarzan (Europe)">
+	<game name="Tarzan (Germany)" id="0731" cloneofid="0729">
 		<description>Tarzan (Germany)</description>
 		<rom name="Tarzan (Germany).n64" />
-		<release name="Tarzan (Germany)" region="GER" />
-		<rom name="Tarzan (Germany).z64" size="16777216" crc="0b0954c5" md5="df3cdd959e8c63b45f557fc197ce0e63" sha1="4fc7ded9601a78db964ed5b1a585bb716f6d636c" />
+		<rom name="Tarzan (Germany).z64" size="16777216" crc="0b0954c5" md5="df3cdd959e8c63b45f557fc197ce0e63" sha1="4fc7ded9601a78db964ed5b1a585bb716f6d636c" serial="NTAD" />
 	</game>
-	<game name="Tarzan (USA)" cloneof="Tarzan (Europe)">
+	<game name="Tarzan (USA)" id="0732" cloneofid="0729">
 		<description>Tarzan (USA)</description>
 		<rom name="Tarzan (USA).n64" />
-		<release name="Tarzan (USA)" region="USA" />
-		<rom name="Tarzan (USA).z64" size="16777216" crc="c38ca641" md5="eae7e0ee5328ed9f13b9cf9990189928" sha1="44c63a89e1e8f9eeee0aa4b45442822feb3cc579" />
+		<rom name="Tarzan (USA).z64" size="16777216" crc="c38ca641" md5="eae7e0ee5328ed9f13b9cf9990189928" sha1="44c63a89e1e8f9eeee0aa4b45442822feb3cc579" serial="NTAE" />
 	</game>
-	<game name="Taz Express (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Taz Express (Europe) (En,Fr,De,Es,It,Nl)" id="0733">
 		<description>Taz Express (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Taz Express (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Taz Express (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Taz Express (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="0712c306" md5="192b715e8bc5972a4986df21dc8bf357" sha1="e1d8121986652ed180505af21456c180c8b29fab" />
+		<rom name="Taz Express (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="0712c306" md5="192b715e8bc5972a4986df21dc8bf357" sha1="e1d8121986652ed180505af21456c180c8b29fab" sha256="5f3dcf40286aa1bb914b5fc3b6672b8db59d7a75e6e37f8941bae0dd87860cd8" status="verified" serial="NTXP" />
 	</game>
-	<game name="Taz Express (USA) (Proto) (2000-05-15)" cloneof="Taz Express (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Taz Express (USA) (Proto) (2000-05-15)" id="0909" cloneofid="0733">
 		<description>Taz Express (USA) (Proto) (2000-05-15)</description>
 		<rom name="Taz Express (USA) (Proto) (2000-05-15).n64" />
-		<release name="Taz Express (USA) (Proto) (2000-05-15)" region="USA" />
-		<rom name="Taz Express (USA) (Proto) (2000-05-15).z64" size="33554432" crc="dde7cfbd" md5="7a94f94485bd28f0d6d67257050b26d4" sha1="674f73fe81e9121751add1e24991993b8dde1b9b" />
+		<rom name="Taz Express (USA) (Proto) (2000-05-15).z64" size="33554432" crc="dde7cfbd" md5="7a94f94485bd28f0d6d67257050b26d4" sha1="674f73fe81e9121751add1e24991993b8dde1b9b" serial="NTXE" />
 	</game>
-	<game name="Tetris 64 (Japan) (En)">
+	<game name="Telefoot Soccer 2000 (France)" id="0734" cloneofid="0430">
+		<description>Telefoot Soccer 2000 (France)</description>
+		<rom name="Telefoot Soccer 2000 (France).n64" />
+		<rom name="Telefoot Soccer 2000 (France).z64" size="16777216" crc="7bd20931" md5="7f244aff8d729417e32b6a5b299afda5" sha1="ffc1f3271929b0e7d6467fdcbed9e0ccf2eba0a5" sha256="c2abd9801d992e9470d3a312d9bc9845d18e2e270826bb95c120371632297e1c" serial="NWKF" />
+	</game>
+	<game name="Tetris 64 (Japan) (En)" id="0735">
 		<description>Tetris 64 (Japan) (En)</description>
 		<rom name="Tetris 64 (Japan) (En).n64" />
-		<release name="Tetris 64 (Japan) (En)" region="JPN" />
-		<rom name="Tetris 64 (Japan) (En).z64" size="8388608" crc="f128cd17" md5="7c8efcf4fba28f9f5b5ea10a71283bf3" sha1="ea9a3ba1384e15e0af996b43fe3e56db889002de" />
+		<rom name="Tetris 64 (Japan) (En).z64" size="8388608" crc="f128cd17" md5="7c8efcf4fba28f9f5b5ea10a71283bf3" sha1="ea9a3ba1384e15e0af996b43fe3e56db889002de" sha256="ba6305efc6a8d8ae1ea4b48e714d8e56abfda872d82af1e2ba4d7701b1166d2e" status="verified" serial="NT6J" />
 	</game>
-	<game name="Tetrisphere (Europe)">
+	<game name="Tetrisphere (Europe)" id="0736">
 		<description>Tetrisphere (Europe)</description>
 		<rom name="Tetrisphere (Europe).n64" />
-		<release name="Tetrisphere (Europe)" region="EUR" />
-		<rom name="Tetrisphere (Europe).z64" size="8388608" crc="7cb31b0f" md5="765a330d5ce2dbe7120c6c8e18a1487d" sha1="a730d8dd3b00c22f8fa4c6e74299e5cc2bbb8207" />
+		<rom name="Tetrisphere (Europe).z64" size="8388608" crc="7cb31b0f" md5="765a330d5ce2dbe7120c6c8e18a1487d" sha1="a730d8dd3b00c22f8fa4c6e74299e5cc2bbb8207" sha256="1bb4ed1ef078560e283a4fe942972fb0297bd33d7f9e36cb673358c394176dd1" status="verified" serial="NTPP" />
 	</game>
-	<game name="Tetrisphere (USA)" cloneof="Tetrisphere (Europe)">
+	<game name="Tetrisphere (USA)" id="0737" cloneofid="0736">
 		<description>Tetrisphere (USA)</description>
 		<rom name="Tetrisphere (USA).n64" />
-		<release name="Tetrisphere (USA)" region="USA" />
-		<rom name="Tetrisphere (USA).z64" size="8388608" crc="70a3a5ce" md5="3f88078e2d9dbf6c9372f6373cf9ae09" sha1="32adaa274ceed246aeee9f53592d642a121f3bdb" />
+		<rom name="Tetrisphere (USA).z64" size="8388608" crc="70a3a5ce" md5="3f88078e2d9dbf6c9372f6373cf9ae09" sha1="32adaa274ceed246aeee9f53592d642a121f3bdb" sha256="f7cbc93ac273488bfb89955ab6ae9b60c730907872107a67a56b945e8579ef87" serial="NTPE" />
 	</game>
-	<game name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)">
+	<game name="TG Rally 2 (Europe)" id="0738" cloneofid="0764">
+		<description>TG Rally 2 (Europe)</description>
+		<rom name="TG Rally 2 (Europe).n64" />
+		<rom name="TG Rally 2 (Europe).z64" size="12582912" crc="135c8eb0" md5="acd0118ac4709db3943b3d35112c2001" sha1="46907a7bd1ceb65f48c39d9d60b56dbc75a7a2c3" status="verified" serial="NL2X" />
+	</game>
+	<game name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)" id="0739">
 		<description>Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)</description>
 		<rom name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da).n64" />
-		<release name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)" region="EUR" />
-		<rom name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da).z64" size="16777216" crc="d82d5736" md5="a09663b596f348d28af846a51375eb81" sha1="53944f6c63b2e971abf756efeccab24fa0b96e78" />
+		<rom name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da).z64" size="16777216" crc="d82d5736" md5="a09663b596f348d28af846a51375eb81" sha1="53944f6c63b2e971abf756efeccab24fa0b96e78" sha256="52212186f8b790dcde0deefcef1a066e1ec279f727ce9a4b92d04e769919200d" status="verified" serial="NT9P" />
 	</game>
-	<game name="Tigger's Honey Hunt (USA)" cloneof="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)">
+	<game name="Tigger's Honey Hunt (USA)" id="0740" cloneofid="0739">
 		<description>Tigger's Honey Hunt (USA)</description>
 		<rom name="Tigger's Honey Hunt (USA).n64" />
-		<release name="Tigger's Honey Hunt (USA)" region="USA" />
-		<rom name="Tigger's Honey Hunt (USA).z64" size="16777216" crc="68c2ac8f" md5="f8636514b5b0edebf376c3111d24417a" sha1="98db3a0f9025893107e9fb1bb8d0b6bc0ef3e280" />
+		<rom name="Tigger's Honey Hunt (USA).z64" size="16777216" crc="68c2ac8f" md5="f8636514b5b0edebf376c3111d24417a" sha1="98db3a0f9025893107e9fb1bb8d0b6bc0ef3e280" serial="NT9E" />
 	</game>
-	<game name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)" id="0741">
 		<description>Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="9ea8a3b8" md5="46be5d00682fcc1f7fc0fba507e8e5c1" sha1="96c874c4556b4872269e41339a1cbac53cc5b052" />
+		<rom name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="9ea8a3b8" md5="46be5d00682fcc1f7fc0fba507e8e5c1" sha1="96c874c4556b4872269e41339a1cbac53cc5b052" sha256="389bc437af911d02f02dbf1f5996d34b895ff1d61335ea9b8fbbfd8f1e5f2fa9" status="verified" serial="NTJP" />
 	</game>
-	<game name="Tom and Jerry in Fists of Furry (USA)" cloneof="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Tom and Jerry in Fists of Furry (USA)" id="0742" cloneofid="0741">
 		<description>Tom and Jerry in Fists of Furry (USA)</description>
 		<rom name="Tom and Jerry in Fists of Furry (USA).n64" />
-		<release name="Tom and Jerry in Fists of Furry (USA)" region="USA" />
-		<rom name="Tom and Jerry in Fists of Furry (USA).z64" size="12582912" crc="6d685b83" md5="a63a9af85be8bb47c1741b8a37115354" sha1="d8980a34ece4a8933d439d0378e0cff8f03994a7" />
+		<rom name="Tom and Jerry in Fists of Furry (USA).z64" size="12582912" crc="6d685b83" md5="a63a9af85be8bb47c1741b8a37115354" sha1="d8980a34ece4a8933d439d0378e0cff8f03994a7" serial="NTJE" />
 	</game>
-	<game name="Tom Clancy's Rainbow Six (Europe)">
+	<game name="Tom Clancy's Rainbow Six (Europe)" id="0743">
 		<description>Tom Clancy's Rainbow Six (Europe)</description>
 		<rom name="Tom Clancy's Rainbow Six (Europe).n64" />
-		<release name="Tom Clancy's Rainbow Six (Europe)" region="EUR" />
-		<rom name="Tom Clancy's Rainbow Six (Europe).z64" size="16777216" crc="4b71e083" md5="1b991cf41c70ff2c92ffbefacabe8d03" sha1="64105f5c17ba7e2e0350f20e18addcc0a4766bd8" />
+		<rom name="Tom Clancy's Rainbow Six (Europe).z64" size="16777216" crc="4b71e083" md5="1b991cf41c70ff2c92ffbefacabe8d03" sha1="64105f5c17ba7e2e0350f20e18addcc0a4766bd8" serial="NR6P" />
 	</game>
-	<game name="Tom Clancy's Rainbow Six (France)" cloneof="Tom Clancy's Rainbow Six (Europe)">
+	<game name="Tom Clancy's Rainbow Six (France)" id="0744" cloneofid="0743">
 		<description>Tom Clancy's Rainbow Six (France)</description>
 		<rom name="Tom Clancy's Rainbow Six (France).n64" />
-		<release name="Tom Clancy's Rainbow Six (France)" region="FRA" />
-		<rom name="Tom Clancy's Rainbow Six (France).z64" size="16777216" crc="bbf7b6a8" md5="15e4c1b4f3f459d4caa7f7e2cf0c95da" sha1="ec38196491aeee7ad2fb4a0a7f139c0839e864c6" />
+		<rom name="Tom Clancy's Rainbow Six (France).z64" size="16777216" crc="bbf7b6a8" md5="15e4c1b4f3f459d4caa7f7e2cf0c95da" sha1="ec38196491aeee7ad2fb4a0a7f139c0839e864c6" sha256="13783f667340351ddd75e08786191f42849601b4370b721d1f1c0cc84d0f3912" status="verified" serial="NR6F" />
 	</game>
-	<game name="Tom Clancy's Rainbow Six (Germany)" cloneof="Tom Clancy's Rainbow Six (Europe)">
+	<game name="Tom Clancy's Rainbow Six (Germany)" id="0745" cloneofid="0743">
 		<description>Tom Clancy's Rainbow Six (Germany)</description>
 		<rom name="Tom Clancy's Rainbow Six (Germany).n64" />
-		<release name="Tom Clancy's Rainbow Six (Germany)" region="GER" />
-		<rom name="Tom Clancy's Rainbow Six (Germany).z64" size="16777216" crc="5d73e788" md5="fdc76a53b1056d3e50ea6a3e295fe4d1" sha1="e41c7b71284976ea5d51b42593973a1d3ce58508" />
+		<rom name="Tom Clancy's Rainbow Six (Germany).z64" size="16777216" crc="5d73e788" md5="fdc76a53b1056d3e50ea6a3e295fe4d1" sha1="e41c7b71284976ea5d51b42593973a1d3ce58508" serial="NR6D" />
 	</game>
-	<game name="Tom Clancy's Rainbow Six (USA)" cloneof="Tom Clancy's Rainbow Six (Europe)">
+	<game name="Tom Clancy's Rainbow Six (USA)" id="0746" cloneofid="0743">
 		<description>Tom Clancy's Rainbow Six (USA)</description>
 		<rom name="Tom Clancy's Rainbow Six (USA).n64" />
-		<release name="Tom Clancy's Rainbow Six (USA)" region="USA" />
-		<rom name="Tom Clancy's Rainbow Six (USA).z64" size="16777216" crc="53b0cc13" md5="80f3b1abd9fb9ae73997489db185a74d" sha1="f785674c670c01e31c77b3034525d43fd6703b9a" />
+		<rom name="Tom Clancy's Rainbow Six (USA).z64" size="16777216" crc="53b0cc13" md5="80f3b1abd9fb9ae73997489db185a74d" sha1="f785674c670c01e31c77b3034525d43fd6703b9a" serial="NR6E" />
 	</game>
-	<game name="Tommy Thunder (USA) (Proto) (1997-10-01)">
+	<game name="Tommy Thunder (USA) (Proto) (1997-10-01)" id="0891">
 		<description>Tommy Thunder (USA) (Proto) (1997-10-01)</description>
 		<rom name="Tommy Thunder (USA) (Proto) (1997-10-01).n64" />
-		<release name="Tommy Thunder (USA) (Proto) (1997-10-01)" region="USA" />
-		<rom name="Tommy Thunder (USA) (Proto) (1997-10-01).z64" size="8388608" crc="66734854" md5="99f95ad4a3b0c78b6f58a0fc3ad22db6" sha1="287fd68b5de520ade240889bc0133777fed5c671" />
+		<rom name="Tommy Thunder (USA) (Proto) (1997-10-01).z64" size="8388608" crc="66734854" md5="99f95ad4a3b0c78b6f58a0fc3ad22db6" sha1="287fd68b5de520ade240889bc0133777fed5c671" serial="NNiE" />
 	</game>
-	<game name="Tonic Trouble (Europe) (En,Fr,De,Es,It)">
+	<game name="Tonic Trouble (Europe) (Beta)" id="1188" cloneofid="0747">
+		<category>Games</category>
+		<rom name="Tonic Trouble (Europe) (Beta).n64" />
+		<category>Preproduction</category>
+		<description>Tonic Trouble (Europe) (Beta)</description>
+		<rom name="Tonic Trouble (Europe) (Beta).z64" size="16777216" crc="ee66a35e" md5="8882e815f8798f437ee95c9bdf8eb7e3" sha1="be4be4a81eabd9cf9926d04dbc28f3eb84818f19" sha256="8bb9bb43d2778fe77fd45eb5f58928aca58c75b8d81aeb0185894edcd4f2b660" serial="!none" />
+	</game>
+	<game name="Tonic Trouble (Europe) (En,Fr,De,Es,It)" id="0747">
 		<description>Tonic Trouble (Europe) (En,Fr,De,Es,It)</description>
 		<rom name="Tonic Trouble (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="Tonic Trouble (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="Tonic Trouble (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="b4322403" md5="3d3573a855835a98de29d598c35590e0" sha1="81909104362baeb7ae3793c08c3d138e96105bbf" />
+		<rom name="Tonic Trouble (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="b4322403" md5="3d3573a855835a98de29d598c35590e0" sha1="81909104362baeb7ae3793c08c3d138e96105bbf" sha256="03ec2d3d3ba63bd394313589333b8d6781331bc3cca06321beddae76e747bcb6" status="verified" serial="NTTP" />
 	</game>
-	<game name="Tonic Trouble (USA) (Rev 1)" cloneof="Tonic Trouble (Europe) (En,Fr,De,Es,It)">
+	<game name="Tonic Trouble (USA) (Rev 1)" id="0748" cloneofid="0747">
 		<description>Tonic Trouble (USA) (Rev 1)</description>
 		<rom name="Tonic Trouble (USA) (Rev 1).n64" />
-		<release name="Tonic Trouble (USA) (Rev 1)" region="USA" />
-		<rom name="Tonic Trouble (USA) (Rev 1).z64" size="16777216" crc="1c04ba12" md5="7d3e935156844de0002db875e1076a5c" sha1="38f9837159d6aa69ca656d8005eccf099c129537" />
+		<rom name="Tonic Trouble (USA) (Rev 1).z64" size="16777216" crc="1c04ba12" md5="7d3e935156844de0002db875e1076a5c" sha1="38f9837159d6aa69ca656d8005eccf099c129537" serial="NTTE" />
 	</game>
-	<game name="Tony Hawk's Pro Skater 2 (Europe)">
-		<description>Tony Hawk's Pro Skater 2 (Europe)</description>
-		<rom name="Tony Hawk's Pro Skater 2 (Europe).n64" />
-		<release name="Tony Hawk's Pro Skater 2 (Europe)" region="EUR" />
-		<rom name="Tony Hawk's Pro Skater 2 (Europe).z64" size="16777216" crc="a1207132" md5="6be030475c4db52f273ef8a02b4dafa8" sha1="803672c1ffa7860536d8b35dca8b59f637f4165e" />
-	</game>
-	<game name="Tony Hawk's Pro Skater 2 (USA)" cloneof="Tony Hawk's Pro Skater 2 (Europe)">
-		<description>Tony Hawk's Pro Skater 2 (USA)</description>
-		<rom name="Tony Hawk's Pro Skater 2 (USA).n64" />
-		<release name="Tony Hawk's Pro Skater 2 (USA)" region="USA" />
-		<rom name="Tony Hawk's Pro Skater 2 (USA).z64" size="16777216" crc="80aa83f3" md5="29974692808c112b306fbd259273dc96" sha1="458ac754cd8e08c46f4c5c9204192ecde84a179d" />
-	</game>
-	<game name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20)" cloneof="Tony Hawk's Pro Skater 2 (Europe)">
-		<description>Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20)</description>
-		<rom name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20).n64" />
-		<rom name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20).z64" size="33554432" crc="98d0d335" md5="317a4e89618b8b7955632c5f70177690" sha1="fab693f9da784837d10a3281d16ec5a1d3d733c9" />
-	</game>
-	<game name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04)" cloneof="Tony Hawk's Pro Skater 2 (Europe)">
-		<description>Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04)</description>
-		<rom name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04).n64" />
-		<rom name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04).z64" size="33554432" crc="bcf178c5" md5="6440a67e2c27bd9adedfc60939c2bf1b" sha1="134289253ccccbcabbf52660f28a49449c399ede" />
-	</game>
-	<game name="Tony Hawk's Pro Skater 3 (USA)">
-		<description>Tony Hawk's Pro Skater 3 (USA)</description>
-		<rom name="Tony Hawk's Pro Skater 3 (USA).n64" />
-		<release name="Tony Hawk's Pro Skater 3 (USA)" region="USA" />
-		<rom name="Tony Hawk's Pro Skater 3 (USA).z64" size="16777216" crc="62a8ce7d" md5="9d4891bf26881c4541171b0235015fd4" sha1="7b9438120c67214afaea09f4b106c54ef8f366c5" />
-	</game>
-	<game name="Tony Hawk's Skateboarding (Europe)">
-		<description>Tony Hawk's Skateboarding (Europe)</description>
-		<rom name="Tony Hawk's Skateboarding (Europe).n64" />
-		<release name="Tony Hawk's Skateboarding (Europe)" region="EUR" />
-		<rom name="Tony Hawk's Skateboarding (Europe).z64" size="12582912" crc="39e4f766" md5="c9e9c4a18b1540c6b4111331d7c663b8" sha1="c321cd05eec58765467878ac8015784535280e3c" status="verified" />
-	</game>
-	<game name="Tony Hawk's Pro Skater (USA)" cloneof="Tony Hawk's Skateboarding (Europe)">
+	<game name="Tony Hawk's Pro Skater (USA)" id="0750" cloneofid="0749">
 		<description>Tony Hawk's Pro Skater (USA)</description>
 		<rom name="Tony Hawk's Pro Skater (USA).n64" />
-		<rom name="Tony Hawk's Pro Skater (USA).z64" size="12582912" crc="f5c1b64f" md5="5ed7e392198a5fa56ee37ea9e93a8d50" sha1="fc1b4dec85e6874fa7321edc24f5a1e78600d9d0" />
+		<rom name="Tony Hawk's Pro Skater (USA).z64" size="12582912" crc="f5c1b64f" md5="5ed7e392198a5fa56ee37ea9e93a8d50" sha1="fc1b4dec85e6874fa7321edc24f5a1e78600d9d0" serial="NTFE" />
 	</game>
-	<game name="Tony Hawk's Pro Skater (USA) (Rev 1)" cloneof="Tony Hawk's Skateboarding (Europe)">
+	<game name="Tony Hawk's Pro Skater (USA) (Rev 1)" id="0751" cloneofid="0749">
 		<description>Tony Hawk's Pro Skater (USA) (Rev 1)</description>
 		<rom name="Tony Hawk's Pro Skater (USA) (Rev 1).n64" />
-		<release name="Tony Hawk's Pro Skater (USA) (Rev 1)" region="USA" />
-		<rom name="Tony Hawk's Pro Skater (USA) (Rev 1).z64" size="12582912" crc="6182a092" md5="aff424a1883dc7bb92c7b2ebe9342f85" sha1="4900b6c92fb8df1765e91e891dccc525bb102fe1" />
+		<rom name="Tony Hawk's Pro Skater (USA) (Rev 1).z64" size="12582912" crc="6182a092" md5="aff424a1883dc7bb92c7b2ebe9342f85" sha1="4900b6c92fb8df1765e91e891dccc525bb102fe1" serial="NTFE" />
 	</game>
-	<game name="Tony Hawk's Pro Skater (USA) (Beta)" cloneof="Tony Hawk's Skateboarding (Europe)">
+	<game name="Tony Hawk's Pro Skater (USA) (Beta)" id="1044" cloneofid="0749">
 		<description>Tony Hawk's Pro Skater (USA) (Beta)</description>
 		<rom name="Tony Hawk's Pro Skater (USA) (Beta).n64" />
-		<rom name="Tony Hawk's Pro Skater (USA) (Beta).z64" size="25165824" crc="f50204da" md5="035c0700406197104d977c379e410cb7" sha1="839be141af2f5cd717b264c8167c72cebd87ef29" />
+		<rom name="Tony Hawk's Pro Skater (USA) (Beta).z64" size="25165824" crc="f50204da" md5="035c0700406197104d977c379e410cb7" sha1="839be141af2f5cd717b264c8167c72cebd87ef29" sha256="f176d2698222758e67a8dddd5f0faa902a9b79a3415845a769cf0a59652027f6" serial="NTFE" />
 	</game>
-	<game name="Toon Panic (Japan) (Proto)">
+	<game name="Tony Hawk's Pro Skater 2 (Europe)" id="0752">
+		<description>Tony Hawk's Pro Skater 2 (Europe)</description>
+		<rom name="Tony Hawk's Pro Skater 2 (Europe).n64" />
+		<rom name="Tony Hawk's Pro Skater 2 (Europe).z64" size="16777216" crc="a1207132" md5="6be030475c4db52f273ef8a02b4dafa8" sha1="803672c1ffa7860536d8b35dca8b59f637f4165e" sha256="1f675f4a3c73d4e985fb72764a80a6a2b28fd888152d438efcfe629d0d80180c" status="verified" serial="NTQP" />
+	</game>
+	<game name="Tony Hawk's Pro Skater 2 (USA)" id="0753" cloneofid="0752">
+		<description>Tony Hawk's Pro Skater 2 (USA)</description>
+		<rom name="Tony Hawk's Pro Skater 2 (USA).n64" />
+		<rom name="Tony Hawk's Pro Skater 2 (USA).z64" size="16777216" crc="80aa83f3" md5="29974692808c112b306fbd259273dc96" sha1="458ac754cd8e08c46f4c5c9204192ecde84a179d" sha256="6ac38612aaae84f8bba22a33a165c17fba3072b16999edcc9a86ab726008d726" serial="NTQE" />
+	</game>
+	<game name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20)" id="1045" cloneofid="0752">
+		<description>Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20)</description>
+		<rom name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20).n64" />
+		<rom name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20).z64" size="33554432" crc="98d0d335" md5="317a4e89618b8b7955632c5f70177690" sha1="fab693f9da784837d10a3281d16ec5a1d3d733c9" sha256="39df4d15ffdb081a29d399f0df935dad667080b9ffc255f44dcbf559871f2586" serial="!none" />
+	</game>
+	<game name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04)" id="1046" cloneofid="0752">
+		<description>Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04)</description>
+		<rom name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04).n64" />
+		<rom name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04).z64" size="33554432" crc="bcf178c5" md5="6440a67e2c27bd9adedfc60939c2bf1b" sha1="134289253ccccbcabbf52660f28a49449c399ede" sha256="05946af0bcc0ca1e9c8b17675c24df98038e66864a934b5182ff858993b0d0ae" serial="!none" />
+	</game>
+	<game name="Tony Hawk's Pro Skater 3 (USA)" id="0754">
+		<description>Tony Hawk's Pro Skater 3 (USA)</description>
+		<rom name="Tony Hawk's Pro Skater 3 (USA).n64" />
+		<rom name="Tony Hawk's Pro Skater 3 (USA).z64" size="16777216" crc="62a8ce7d" md5="9d4891bf26881c4541171b0235015fd4" sha1="7b9438120c67214afaea09f4b106c54ef8f366c5" serial="N3TE" />
+	</game>
+	<game name="Tony Hawk's Skateboarding (Europe)" id="0749">
+		<description>Tony Hawk's Skateboarding (Europe)</description>
+		<rom name="Tony Hawk's Skateboarding (Europe).n64" />
+		<rom name="Tony Hawk's Skateboarding (Europe).z64" size="12582912" crc="39e4f766" md5="c9e9c4a18b1540c6b4111331d7c663b8" sha1="c321cd05eec58765467878ac8015784535280e3c" sha256="10eb3aa1501d8172a711c4bc939fec65afd1f2d79f51e11c59235ca4c29f3585" status="verified" serial="NTFP" />
+	</game>
+	<game name="Toon Panic (Japan) (Proto)" id="0887">
 		<description>Toon Panic (Japan) (Proto)</description>
 		<rom name="Toon Panic (Japan) (Proto).n64" />
-		<release name="Toon Panic (Japan) (Proto)" region="JPN" />
 		<rom name="Toon Panic (Japan) (Proto).z64" size="12582912" crc="cf396c4e" md5="b6fd2a048d1f4f324cebc97ba09872bb" sha1="c0da7fe28d05fab82f79703fdf9d807b9d7ee70e" />
 	</game>
-	<game name="Top Gear Hyper Bike (Europe)">
+	<game name="Top Gear Hyper Bike (Europe)" id="0755">
 		<description>Top Gear Hyper Bike (Europe)</description>
 		<rom name="Top Gear Hyper Bike (Europe).n64" />
-		<release name="Top Gear Hyper Bike (Europe)" region="EUR" />
-		<rom name="Top Gear Hyper Bike (Europe).z64" size="16777216" crc="bae57ea7" md5="0072538ef925645db310f8e23a480b89" sha1="ff4eb866c48700fa978a5e663cda1499c8eac0b4" status="verified" />
+		<rom name="Top Gear Hyper Bike (Europe).z64" size="16777216" crc="bae57ea7" md5="0072538ef925645db310f8e23a480b89" sha1="ff4eb866c48700fa978a5e663cda1499c8eac0b4" sha256="37de2e8503c5306d40ab9488f0c74424a5f5dfe795990ba9bd839a0d991ef5b0" status="verified" serial="NGBP" />
 	</game>
-	<game name="Top Gear Hyper Bike (Japan)" cloneof="Top Gear Hyper Bike (Europe)">
+	<game name="Top Gear Hyper Bike (Japan)" id="0756" cloneofid="0755">
 		<description>Top Gear Hyper Bike (Japan)</description>
 		<rom name="Top Gear Hyper Bike (Japan).n64" />
-		<release name="Top Gear Hyper Bike (Japan)" region="JPN" />
-		<rom name="Top Gear Hyper Bike (Japan).z64" size="16777216" crc="09b2cda1" md5="4347174bb415ca970f2d50df2973f656" sha1="7db7337260af8f153b6291b13e655f192b59ec01" />
+		<rom name="Top Gear Hyper Bike (Japan).z64" size="16777216" crc="09b2cda1" md5="4347174bb415ca970f2d50df2973f656" sha1="7db7337260af8f153b6291b13e655f192b59ec01" sha256="9c85d8dac5c32a0cf72b68fda3e0ca7687bbac64d364f8cbf285885c74b05767" status="verified" serial="NGBJ" />
 	</game>
-	<game name="Top Gear Hyper-Bike (USA)" cloneof="Top Gear Hyper Bike (Europe)">
+	<game name="Top Gear Hyper-Bike (USA)" id="0757" cloneofid="0755">
 		<description>Top Gear Hyper-Bike (USA)</description>
 		<rom name="Top Gear Hyper-Bike (USA).n64" />
-		<release name="Top Gear Hyper-Bike (USA)" region="USA" />
-		<rom name="Top Gear Hyper-Bike (USA).z64" size="16777216" crc="6eebc26a" md5="7258f4ab367b025c95a4f476c461e717" sha1="c7593b3d0d793cf03616df02501735221624ac04" />
+		<rom name="Top Gear Hyper-Bike (USA).z64" size="16777216" crc="6eebc26a" md5="7258f4ab367b025c95a4f476c461e717" sha1="c7593b3d0d793cf03616df02501735221624ac04" serial="NGBE" />
 	</game>
-	<game name="Top Gear Hyper-Bike (USA) (Beta)" cloneof="Top Gear Hyper Bike (Europe)">
+	<game name="Top Gear Hyper-Bike (USA) (Beta)" id="1010" cloneofid="0755">
 		<description>Top Gear Hyper-Bike (USA) (Beta)</description>
 		<rom name="Top Gear Hyper-Bike (USA) (Beta).n64" />
 		<rom name="Top Gear Hyper-Bike (USA) (Beta).z64" size="33554432" crc="00c0278a" md5="b60d26c2c2242bff61f76469fc272d2a" sha1="d3ae07e2c4360ec4eb06a70c6e48d848eec532dd" />
 	</game>
-	<game name="Top Gear Overdrive (Europe)">
+	<game name="Top Gear Overdrive (Europe)" id="0758">
 		<description>Top Gear Overdrive (Europe)</description>
 		<rom name="Top Gear Overdrive (Europe).n64" />
-		<release name="Top Gear Overdrive (Europe)" region="EUR" />
-		<rom name="Top Gear Overdrive (Europe).z64" size="12582912" crc="0cc70580" md5="6c65a252f227aef18df2dd3ce04cc821" sha1="bad781b7a3fe73a0127223cd807fafbc4007dccf" />
+		<rom name="Top Gear Overdrive (Europe).z64" size="12582912" crc="0cc70580" md5="6c65a252f227aef18df2dd3ce04cc821" sha1="bad781b7a3fe73a0127223cd807fafbc4007dccf" sha256="f9befa4ff29d2291cf7d82e4b32dcca2e516add8d75365328ea5f7280bea0e97" status="verified" serial="NRCP" />
 	</game>
-	<game name="Top Gear Overdrive (Japan)" cloneof="Top Gear Overdrive (Europe)">
+	<game name="Top Gear Overdrive (Japan)" id="0759" cloneofid="0758">
 		<description>Top Gear Overdrive (Japan)</description>
 		<rom name="Top Gear Overdrive (Japan).n64" />
-		<release name="Top Gear Overdrive (Japan)" region="JPN" />
-		<rom name="Top Gear Overdrive (Japan).z64" size="12582912" crc="81aafc2b" md5="b5691794a851d8b603f0c741d44aa244" sha1="be62d75c7ac1067111cd213365a9583550f897f3" />
+		<rom name="Top Gear Overdrive (Japan).z64" size="12582912" crc="81aafc2b" md5="b5691794a851d8b603f0c741d44aa244" sha1="be62d75c7ac1067111cd213365a9583550f897f3" serial="NRCJ" />
 	</game>
-	<game name="Top Gear Overdrive (USA)" cloneof="Top Gear Overdrive (Europe)">
+	<game name="Top Gear Overdrive (USA)" id="0760" cloneofid="0758">
 		<description>Top Gear Overdrive (USA)</description>
 		<rom name="Top Gear Overdrive (USA).n64" />
-		<release name="Top Gear Overdrive (USA)" region="USA" />
-		<rom name="Top Gear Overdrive (USA).z64" size="12582912" crc="f3e0ff21" md5="7818696426c0a429fbfccc4efe8d5570" sha1="75ebbe451906ce68b0dd43eef9ee44416452a4f1" />
+		<rom name="Top Gear Overdrive (USA).z64" size="12582912" crc="f3e0ff21" md5="7818696426c0a429fbfccc4efe8d5570" sha1="75ebbe451906ce68b0dd43eef9ee44416452a4f1" serial="NRCE" />
 	</game>
-	<game name="Top Gear Rally (Europe)">
+	<game name="Top Gear Overdrive (USA) (Beta)" id="1116" cloneofid="0758">
+		<category>Games</category>
+		<rom name="Top Gear Overdrive (USA) (Beta).n64" />
+		<description>Top Gear Overdrive (USA) (Beta)</description>
+		<rom name="Top Gear Overdrive (USA) (Beta).z64" size="12582912" crc="c1160b09" md5="975d01545d0803f20d1ee61385c28eed" sha1="2d7ed4805f3fa14412dbaa1bb99375dbd85b2b02" sha256="917f2f7ae45bb14a0c588e266f0909a0f2be206bd6b78d33b29be138cedcf46f" serial="!none" />
+	</game>
+	<game name="Top Gear Rally (Europe)" id="0761">
 		<description>Top Gear Rally (Europe)</description>
 		<rom name="Top Gear Rally (Europe).n64" />
-		<release name="Top Gear Rally (Europe)" region="EUR" />
-		<rom name="Top Gear Rally (Europe).z64" size="8388608" crc="40b3bb21" md5="1698508f521280d0a80e078ec981d4ac" sha1="9fae5d98fe3464f00d59034690df90118646eb95" />
+		<rom name="Top Gear Rally (Europe).z64" size="8388608" crc="40b3bb21" md5="1698508f521280d0a80e078ec981d4ac" sha1="9fae5d98fe3464f00d59034690df90118646eb95" sha256="a519d53ddc8481a0fcc8f92034257b86a363b9e75ae4438ac4fad6c3e018e8c3" status="verified" serial="NTRP" />
 	</game>
-	<game name="Top Gear Rally (Japan)" cloneof="Top Gear Rally (Europe)">
+	<game name="Top Gear Rally (Japan)" id="0762" cloneofid="0761">
 		<description>Top Gear Rally (Japan)</description>
 		<rom name="Top Gear Rally (Japan).n64" />
-		<release name="Top Gear Rally (Japan)" region="JPN" />
-		<rom name="Top Gear Rally (Japan).z64" size="8388608" crc="c6707cd6" md5="6e0af13dcefee6a11c4d7262206d6d2d" sha1="e0415b87c5a5b69ac581e79137406bdaa79b354a" />
+		<rom name="Top Gear Rally (Japan).z64" size="8388608" crc="c6707cd6" md5="6e0af13dcefee6a11c4d7262206d6d2d" sha1="e0415b87c5a5b69ac581e79137406bdaa79b354a" serial="NTRJ" />
 	</game>
-	<game name="Top Gear Rally (USA)" cloneof="Top Gear Rally (Europe)">
+	<game name="Top Gear Rally (USA)" id="0763" cloneofid="0761">
 		<description>Top Gear Rally (USA)</description>
 		<rom name="Top Gear Rally (USA).n64" />
-		<release name="Top Gear Rally (USA)" region="USA" />
-		<rom name="Top Gear Rally (USA).z64" size="8388608" crc="137287f5" md5="6f7030284b6bc84a49e07da864526b52" sha1="bfc51f086ebdb78904dc24ad0c3a2d946e26d022" />
+		<rom name="Top Gear Rally (USA).z64" size="8388608" crc="137287f5" md5="6f7030284b6bc84a49e07da864526b52" sha1="bfc51f086ebdb78904dc24ad0c3a2d946e26d022" serial="NGRE" />
 	</game>
-	<game name="Top Gear Rally (Asia) (En)" cloneof="Top Gear Rally (Europe)">
+	<game name="Top Gear Rally (Asia) (En)" id="1026" cloneofid="0761">
 		<description>Top Gear Rally (Asia) (En)</description>
 		<rom name="Top Gear Rally (Asia) (En).n64" />
-		<release name="Top Gear Rally (Asia) (En)" region="ASI" />
-		<rom name="Top Gear Rally (Asia) (En).z64" size="8388608" crc="c4bc4df8" md5="50195216c8a37f9bd5b2105a40ee8d8f" sha1="7e36a98f6fafe3ff7e72d14e0fae16418458da47" />
+		<rom name="Top Gear Rally (Asia) (En).z64" size="8388608" crc="c4bc4df8" md5="50195216c8a37f9bd5b2105a40ee8d8f" sha1="7e36a98f6fafe3ff7e72d14e0fae16418458da47" serial="NGRX" />
 	</game>
-	<game name="Top Gear Rally 2 (Europe)">
+	<game name="Top Gear Rally 2 (Europe)" id="0764">
 		<description>Top Gear Rally 2 (Europe)</description>
 		<rom name="Top Gear Rally 2 (Europe).n64" />
-		<release name="Top Gear Rally 2 (Europe)" region="EUR" />
-		<rom name="Top Gear Rally 2 (Europe).z64" size="12582912" crc="cb294d39" md5="44c4566572dc0662d4299ab5b19043ae" sha1="cc140d2a8bab74109d34fda97f4da21f8c3cd083" />
+		<rom name="Top Gear Rally 2 (Europe).z64" size="12582912" crc="cb294d39" md5="44c4566572dc0662d4299ab5b19043ae" sha1="cc140d2a8bab74109d34fda97f4da21f8c3cd083" sha256="a59a4e5bed8bd6957f0b7ff32e5a0971b72781dc12923a7b373d30a25a755f79" status="verified" serial="NL2P" />
 	</game>
-	<game name="TG Rally 2 (Europe)" cloneof="Top Gear Rally 2 (Europe)">
-		<description>TG Rally 2 (Europe)</description>
-		<rom name="TG Rally 2 (Europe).n64" />
-		<rom name="TG Rally 2 (Europe).z64" size="12582912" crc="135c8eb0" md5="acd0118ac4709db3943b3d35112c2001" sha1="46907a7bd1ceb65f48c39d9d60b56dbc75a7a2c3" status="verified" />
-	</game>
-	<game name="Top Gear Rally 2 (Japan)" cloneof="Top Gear Rally 2 (Europe)">
+	<game name="Top Gear Rally 2 (Japan)" id="0765" cloneofid="0764">
 		<description>Top Gear Rally 2 (Japan)</description>
 		<rom name="Top Gear Rally 2 (Japan).n64" />
-		<release name="Top Gear Rally 2 (Japan)" region="JPN" />
-		<rom name="Top Gear Rally 2 (Japan).z64" size="12582912" crc="aa136e07" md5="b10d781ec625ca45713fd34e5096c24a" sha1="d78df79985bfdc7c77f7ed0338e86e852bb3f45a" />
+		<rom name="Top Gear Rally 2 (Japan).z64" size="12582912" crc="aa136e07" md5="b10d781ec625ca45713fd34e5096c24a" sha1="d78df79985bfdc7c77f7ed0338e86e852bb3f45a" serial="NL2J" />
 	</game>
-	<game name="Top Gear Rally 2 (USA)" cloneof="Top Gear Rally 2 (Europe)">
+	<game name="Top Gear Rally 2 (USA)" id="0766" cloneofid="0764">
 		<description>Top Gear Rally 2 (USA)</description>
 		<rom name="Top Gear Rally 2 (USA).n64" />
-		<release name="Top Gear Rally 2 (USA)" region="USA" />
-		<rom name="Top Gear Rally 2 (USA).z64" size="12582912" crc="914cf9c4" md5="1fa409fcac007ddeccc4cf439a0d8dae" sha1="fed36b2202b28fc7ff6446ecba541413660d0630" />
+		<rom name="Top Gear Rally 2 (USA).z64" size="12582912" crc="914cf9c4" md5="1fa409fcac007ddeccc4cf439a0d8dae" sha1="fed36b2202b28fc7ff6446ecba541413660d0630" sha256="e3e523e92aaad69abda8df4cd4aa92505f5d8fa4d67fac4bbe6980666237c4db" serial="NL2E" />
 	</game>
-	<game name="Top Gear Rally 2 (Europe) (Beta) (1999-08-31)" cloneof="Top Gear Rally 2 (Europe)">
+	<game name="Top Gear Rally 2 (Europe) (Beta) (1999-08-31)" id="1018" cloneofid="0764">
 		<description>Top Gear Rally 2 (Europe) (Beta) (1999-08-31)</description>
 		<rom name="Top Gear Rally 2 (Europe) (Beta) (1999-08-31).n64" />
 		<rom name="Top Gear Rally 2 (Europe) (Beta) (1999-08-31).z64" size="16777216" crc="3c77c5d6" md5="c33cd926e1e71f39f7238af7b9e0dc5c" sha1="168dd383edd88a921d25cf7eaeb18b2da29c744a" />
 	</game>
-	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
-		<description>Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)</description>
-		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).n64" />
-		<release name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)" region="EUR" />
-		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).z64" size="12582912" crc="59574cb9" md5="5f2c9e5e39ab09311d96e6c751184b6b" sha1="92015e5254cbbad1bc668ecb13a4b568e5f55052" />
+	<game name="Top Gear Rally 2 (USA) (Beta)" id="1115" cloneofid="0764">
+		<category>Games</category>
+		<rom name="Top Gear Rally 2 (USA) (Beta).n64" />
+		<description>Top Gear Rally 2 (USA) (Beta)</description>
+		<rom name="Top Gear Rally 2 (USA) (Beta).z64" size="12582912" crc="1548e137" md5="b468f0d00264950dd197f5f8fc7e3db7" sha1="34c24c0cb789423c6b13da4d70832cf40f03979d" sha256="c06049ac701f5c4d0035704b8df96b3f31e1e02e9cd084259b2166804e59a5a1" serial="NL2E" />
 	</game>
-	<game name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
+	<game name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)" id="0768" cloneofid="0767">
 		<description>Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)</description>
 		<rom name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France).n64" />
-		<release name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)" region="FRA" />
-		<rom name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France).z64" size="12582912" crc="fb4bea9a" md5="fa0f12c15b3655f9f56888c3249b1ced" sha1="a9f97e22391313095d2c2fbaf81fb33bfa2ba7c6" />
+		<rom name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France).z64" size="12582912" crc="fb4bea9a" md5="fa0f12c15b3655f9f56888c3249b1ced" sha1="a9f97e22391313095d2c2fbaf81fb33bfa2ba7c6" sha256="5ff7efb853a66959e1a8a96d94942d96ea97d5409769edcb4952db41b0c82a04" serial="NTHF" />
 	</game>
-	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
+	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)" id="0767">
+		<description>Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)</description>
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).n64" />
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).z64" size="12582912" crc="59574cb9" md5="5f2c9e5e39ab09311d96e6c751184b6b" sha1="92015e5254cbbad1bc668ecb13a4b568e5f55052" serial="NTHP" />
+	</game>
+	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA)" id="0770" cloneofid="0767">
 		<description>Toy Story 2 - Buzz Lightyear to the Rescue! (USA)</description>
 		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA).n64" />
-		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA).z64" size="12582912" crc="b9570841" md5="b44e9c2d9d2f2de3af4793b824ccf936" sha1="982ad2e1e44c6662c88a77367bc5df91c51531bf" status="verified" />
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA).z64" size="12582912" crc="b9570841" md5="b44e9c2d9d2f2de3af4793b824ccf936" sha1="982ad2e1e44c6662c88a77367bc5df91c51531bf" sha256="b8b0db1259ca80b4397c3c58ef63d38100a69d436ed3f097079eb81d07e764c9" status="verified" serial="NTHE" />
 	</game>
-	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
+	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)" id="0944" cloneofid="0767">
 		<description>Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)</description>
 		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).n64" />
-		<release name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)" region="USA" />
-		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).z64" size="12582912" crc="c81f3321" md5="cd61a7fdbd7297733b246204e8360d83" sha1="486dbb2e6068065a7b354a21089e889de0970ec8" />
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).z64" size="12582912" crc="c81f3321" md5="cd61a7fdbd7297733b246204e8360d83" sha1="486dbb2e6068065a7b354a21089e889de0970ec8" serial="NTHE" />
 	</game>
-	<game name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
+	<game name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)" id="0769" cloneofid="0767">
 		<description>Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)</description>
 		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany).n64" />
-		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany).z64" size="12582912" crc="c5e4c89f" md5="3f40f37b0464dd065067523fb21016dd" sha1="f8fbb100227015be8629243f53d70f29a2a14315" />
+		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany).z64" size="12582912" crc="c5e4c89f" md5="3f40f37b0464dd065067523fb21016dd" sha1="f8fbb100227015be8629243f53d70f29a2a14315" serial="NTHD" />
 	</game>
-	<game name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
+	<game name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)" id="0918" cloneofid="0767">
 		<description>Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)</description>
 		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1).n64" />
-		<release name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)" region="GER" />
-		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1).z64" size="12582912" crc="d1906de4" md5="a4a2b825797e2059b5df60d733461f34" sha1="eae83c07e2e777d8e71a5be6120aed03d7e67782" />
+		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1).z64" size="12582912" crc="d1906de4" md5="a4a2b825797e2059b5df60d733461f34" sha1="eae83c07e2e777d8e71a5be6120aed03d7e67782" serial="NTHD" />
 	</game>
-	<game name="Transformers - Beast Wars Transmetals (USA)">
-		<description>Transformers - Beast Wars Transmetals (USA)</description>
-		<rom name="Transformers - Beast Wars Transmetals (USA).n64" />
-		<release name="Transformers - Beast Wars Transmetals (USA)" region="USA" />
-		<rom name="Transformers - Beast Wars Transmetals (USA).z64" size="16777216" crc="85138b5a" md5="6d38909faa2840fc409afa221489de49" sha1="8d074a0e74e69a45a57a48470383bd5268521cde" />
-	</game>
-	<game name="Transformers - Beast Wars Metals 64 (Japan)" cloneof="Transformers - Beast Wars Transmetals (USA)">
+	<game name="Transformers - Beast Wars Metals 64 (Japan)" id="0771" cloneofid="0772">
 		<description>Transformers - Beast Wars Metals 64 (Japan)</description>
 		<rom name="Transformers - Beast Wars Metals 64 (Japan).n64" />
-		<release name="Transformers - Beast Wars Metals 64 (Japan)" region="JPN" />
-		<rom name="Transformers - Beast Wars Metals 64 (Japan).z64" size="12582912" crc="338f1d45" md5="3d22d5bd7997293612ecdd3046beba13" sha1="a292c7aab0092f39f1292434f3059782715863db" />
+		<rom name="Transformers - Beast Wars Metals 64 (Japan).z64" size="12582912" crc="338f1d45" md5="3d22d5bd7997293612ecdd3046beba13" sha1="a292c7aab0092f39f1292434f3059782715863db" serial="NTBJ" />
 	</game>
-	<game name="Triple Play 2000 (USA)">
+	<game name="Transformers - Beast Wars Transmetals (USA)" id="0772">
+		<description>Transformers - Beast Wars Transmetals (USA)</description>
+		<rom name="Transformers - Beast Wars Transmetals (USA).n64" />
+		<rom name="Transformers - Beast Wars Transmetals (USA).z64" size="16777216" crc="85138b5a" md5="6d38909faa2840fc409afa221489de49" sha1="8d074a0e74e69a45a57a48470383bd5268521cde" serial="NOHE" />
+	</game>
+	<game name="Triple Play 2000 (USA)" id="0773">
 		<description>Triple Play 2000 (USA)</description>
 		<rom name="Triple Play 2000 (USA).n64" />
-		<release name="Triple Play 2000 (USA)" region="USA" />
-		<rom name="Triple Play 2000 (USA).z64" size="16777216" crc="785dd0f8" md5="6f2c37a20e6eccb657fbfc4ba36a34bb" sha1="03619f14149d5a2716dffbe02e21c2a0f5ee24f5" />
+		<rom name="Triple Play 2000 (USA).z64" size="16777216" crc="785dd0f8" md5="6f2c37a20e6eccb657fbfc4ba36a34bb" sha1="03619f14149d5a2716dffbe02e21c2a0f5ee24f5" serial="N3PE" />
 	</game>
-	<game name="Tsumi to Batsu - Hoshi no Keishousha (Japan)">
+	<game name="Tsumi to Batsu - Hoshi no Keishousha (Japan)" id="0774">
 		<description>Tsumi to Batsu - Hoshi no Keishousha (Japan)</description>
 		<rom name="Tsumi to Batsu - Hoshi no Keishousha (Japan).n64" />
-		<release name="Tsumi to Batsu - Hoshi no Keishousha (Japan)" region="JPN" />
-		<rom name="Tsumi to Batsu - Hoshi no Keishousha (Japan).z64" size="33554432" crc="ca2e5e49" md5="a0657bc99e169153fd46aeccfde748f3" sha1="581297b9d5c3a4c33169ae0aae218c742cd9cbcf" status="verified" />
+		<rom name="Tsumi to Batsu - Hoshi no Keishousha (Japan).z64" size="33554432" crc="ca2e5e49" md5="a0657bc99e169153fd46aeccfde748f3" sha1="581297b9d5c3a4c33169ae0aae218c742cd9cbcf" sha256="750c67c56762678d44260831dc15206f50b1a5589ffcd7f6aaad85beafa7d5ba" status="verified" serial="NGUJ" />
 	</game>
-	<game name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue)" cloneof="Tsumi to Batsu - Hoshi no Keishousha (Japan)">
-		<description>Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue)</description>
-		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue).n64" />
-		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue).z64" size="33636352" crc="e00db418" md5="5ba3aa2953c47c8b2e615b21e60f2f17" sha1="5b9b53c4d93cf16a73903cfef7fbeb845f10c2e5" />
-	</game>
-	<game name="Turok - Dinosaur Hunter (Europe) (Rev 2)">
-		<description>Turok - Dinosaur Hunter (Europe) (Rev 2)</description>
-		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 2).n64" />
-		<release name="Turok - Dinosaur Hunter (Europe) (Rev 2)" region="EUR" />
-		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 2).z64" size="8388608" crc="312af877" md5="548fc0e6035b65bc2108255039859934" sha1="0b3cd4fcb03c704e1f8eb3bbd109c82f4be50075" />
-	</game>
-	<game name="Jikuu Senshi Turok (Japan)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
-		<description>Jikuu Senshi Turok (Japan)</description>
-		<rom name="Jikuu Senshi Turok (Japan).n64" />
-		<release name="Jikuu Senshi Turok (Japan)" region="JPN" />
-		<rom name="Jikuu Senshi Turok (Japan).z64" size="8388608" crc="e6bd65d5" md5="7b261247150c431de55ab371e8b46ea8" sha1="726baefd703eb2ca72ec22b4aab8844662f32845" />
-	</game>
-	<game name="Turok - Dinosaur Hunter (Europe)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
+	<game name="Turok - Dinosaur Hunter (Europe)" id="0775" cloneofid="0777">
 		<description>Turok - Dinosaur Hunter (Europe)</description>
 		<rom name="Turok - Dinosaur Hunter (Europe).n64" />
-		<rom name="Turok - Dinosaur Hunter (Europe).z64" size="8388608" crc="e8525687" md5="13faa58604597e4edc608070f8e0ae24" sha1="88916d5d2e2470f395ad8f4245d34138ef2d156a" />
+		<rom name="Turok - Dinosaur Hunter (Europe).z64" size="8388608" crc="e8525687" md5="13faa58604597e4edc608070f8e0ae24" sha1="88916d5d2e2470f395ad8f4245d34138ef2d156a" sha256="9c9ea5dffe062ebc5038827a5b1d16100752561de6d904eec4186620bc351a0a" status="verified" serial="NTUP" />
 	</game>
-	<game name="Turok - Dinosaur Hunter (Europe) (Rev 1)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
+	<game name="Turok - Dinosaur Hunter (Europe) (Rev 1)" id="0776" cloneofid="0777">
 		<description>Turok - Dinosaur Hunter (Europe) (Rev 1)</description>
 		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 1).n64" />
-		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 1).z64" size="8388608" crc="c2353283" md5="992ba72f4a1e9c51934ff345cdd0d90c" sha1="90809f3d30bf085f5eacbd12136672216aa7b88b" />
+		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 1).z64" size="8388608" crc="c2353283" md5="992ba72f4a1e9c51934ff345cdd0d90c" sha1="90809f3d30bf085f5eacbd12136672216aa7b88b" serial="NTUP" />
 	</game>
-	<game name="Turok - Dinosaur Hunter (Germany)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
+	<game name="Turok - Dinosaur Hunter (Europe) (Rev 2)" id="0777">
+		<description>Turok - Dinosaur Hunter (Europe) (Rev 2)</description>
+		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 2).n64" />
+		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 2).z64" size="8388608" crc="312af877" md5="548fc0e6035b65bc2108255039859934" sha1="0b3cd4fcb03c704e1f8eb3bbd109c82f4be50075" sha256="4c12397d7a85896e488df15f1329f7fe66502323fcec589b7e0c726a1c93c969" status="verified" serial="NTUP" />
+	</game>
+	<game name="Turok - Dinosaur Hunter (Germany)" id="0778" cloneofid="0777">
 		<description>Turok - Dinosaur Hunter (Germany)</description>
 		<rom name="Turok - Dinosaur Hunter (Germany).n64" />
-		<rom name="Turok - Dinosaur Hunter (Germany).z64" size="8388608" crc="64631ff9" md5="0c0bfd1038eda4f5c958dc362cdff2d6" sha1="698760178edfbb8293a536d4960aa9566f1a1871" />
+		<rom name="Turok - Dinosaur Hunter (Germany).z64" size="8388608" crc="64631ff9" md5="0c0bfd1038eda4f5c958dc362cdff2d6" sha1="698760178edfbb8293a536d4960aa9566f1a1871" serial="NTUD" />
 	</game>
-	<game name="Turok - Dinosaur Hunter (USA)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
+	<game name="Turok - Dinosaur Hunter (USA)" id="0779" cloneofid="0777">
 		<description>Turok - Dinosaur Hunter (USA)</description>
 		<rom name="Turok - Dinosaur Hunter (USA).n64" />
-		<rom name="Turok - Dinosaur Hunter (USA).z64" size="8388608" crc="26c4f597" md5="ae5107efdd3c210e1edd4acd9b3cac31" sha1="40fb0250c095740031278fb1f82b9937a3895e01" />
+		<rom name="Turok - Dinosaur Hunter (USA).z64" size="8388608" crc="26c4f597" md5="ae5107efdd3c210e1edd4acd9b3cac31" sha1="40fb0250c095740031278fb1f82b9937a3895e01" sha256="4111045ae8e05da883037906dc9f693d8e6f55ad6b3a0c43a9472c632486e082" status="verified" serial="NTUE" />
 	</game>
-	<game name="Turok - Dinosaur Hunter (USA) (Rev 1)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
+	<game name="Turok - Dinosaur Hunter (USA) (Rev 1)" id="0780" cloneofid="0777">
 		<description>Turok - Dinosaur Hunter (USA) (Rev 1)</description>
 		<rom name="Turok - Dinosaur Hunter (USA) (Rev 1).n64" />
-		<rom name="Turok - Dinosaur Hunter (USA) (Rev 1).z64" size="8388608" crc="7f2476f4" md5="37260287d59fe4ec6049c1d22b5614e6" sha1="6e67dcb49f700f01b18b7b4fd9aeb6bd911f1850" />
+		<rom name="Turok - Dinosaur Hunter (USA) (Rev 1).z64" size="8388608" crc="7f2476f4" md5="37260287d59fe4ec6049c1d22b5614e6" sha1="6e67dcb49f700f01b18b7b4fd9aeb6bd911f1850" serial="NTUE" />
 	</game>
-	<game name="Turok - Dinosaur Hunter (USA) (Rev 2)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
+	<game name="Turok - Dinosaur Hunter (USA) (Rev 2)" id="0781" cloneofid="0777">
 		<description>Turok - Dinosaur Hunter (USA) (Rev 2)</description>
 		<rom name="Turok - Dinosaur Hunter (USA) (Rev 2).n64" />
-		<release name="Turok - Dinosaur Hunter (USA) (Rev 2)" region="USA" />
-		<rom name="Turok - Dinosaur Hunter (USA) (Rev 2).z64" size="8388608" crc="8c3bbc00" md5="039875b92c0e4fef9797ec1744877b17" sha1="c7ed00dee20f4235823bcf50d32fa5d6862d6fce" />
+		<rom name="Turok - Dinosaur Hunter (USA) (Rev 2).z64" size="8388608" crc="8c3bbc00" md5="039875b92c0e4fef9797ec1744877b17" sha1="c7ed00dee20f4235823bcf50d32fa5d6862d6fce" sha256="3f46508afd36173886f8a6ea65066663c431be9e1edb8d299356569d87e48bab" serial="NTUE" />
 	</game>
-	<game name="Turok - Dinosaur Hunter (Germany) (Rev 1)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
+	<game name="Turok - Dinosaur Hunter (Germany) (Rev 1)" id="0915" cloneofid="0777">
 		<description>Turok - Dinosaur Hunter (Germany) (Rev 1)</description>
 		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 1).n64" />
-		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 1).z64" size="8388608" crc="2765dd8f" md5="388440013641887d85b791cf01729fa8" sha1="803bbc3cb2663aa24a88ec277d93c8ddd4ec34e3" />
+		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 1).z64" size="8388608" crc="2765dd8f" md5="388440013641887d85b791cf01729fa8" sha1="803bbc3cb2663aa24a88ec277d93c8ddd4ec34e3" serial="NTUD" />
 	</game>
-	<game name="Turok - Dinosaur Hunter (Germany) (Rev 2)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
+	<game name="Turok - Dinosaur Hunter (Germany) (Rev 2)" id="0916" cloneofid="0777">
 		<description>Turok - Dinosaur Hunter (Germany) (Rev 2)</description>
 		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 2).n64" />
-		<release name="Turok - Dinosaur Hunter (Germany) (Rev 2)" region="GER" />
-		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 2).z64" size="8388608" crc="72ca307a" md5="f0f687b449a9f4b0bff08104c35ea08c" sha1="0ad61791fb8fb1e0a3bd2a286f32e1967dc79309" status="verified" />
+		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 2).z64" size="8388608" crc="72ca307a" md5="f0f687b449a9f4b0bff08104c35ea08c" sha1="0ad61791fb8fb1e0a3bd2a286f32e1967dc79309" sha256="f608a67ab6c3262683da4d207c029ff8d2a08e5aa6375e583935c094503b10b7" status="verified" serial="NTUD" />
 	</game>
-	<game name="Turok - Rage Wars (Europe)">
-		<description>Turok - Rage Wars (Europe)</description>
-		<rom name="Turok - Rage Wars (Europe).n64" />
-		<release name="Turok - Rage Wars (Europe)" region="EUR" />
-		<rom name="Turok - Rage Wars (Europe).z64" size="8388608" crc="82b1e116" md5="dba166a42710f40dc78dc52eb37b0be6" sha1="46b474fac79a4b21535bb6c78ce3039a2c202359" status="verified" />
+	<game name="Turok - Dinosaur Hunter (USA) (Demo) (Kiosk, E3 1997)" id="1131" cloneofid="0777">
+		<category>Games</category>
+		<rom name="Turok - Dinosaur Hunter (USA) (Demo) (Kiosk, E3 1997).n64" />
+		<category>Preproduction</category>
+		<description>Turok - Dinosaur Hunter (USA) (Demo) (Kiosk, E3 1997)</description>
+		<rom name="Turok - Dinosaur Hunter (USA) (Demo) (Kiosk, E3 1997).z64" size="10019568" crc="940f1d87" md5="3f348189bfebc8cd94dc15b8e35c5c42" sha1="a57b0d475a7b11971b4c3dc66e593fc5a6412ae2" sha256="6134251820b4ff94c62c1a83f9eca4dc27f72dfe2f3f71aaaa7c4b81dbd99cdf" serial="!none" />
 	</game>
-	<game name="Turok - Legenden des Verlorenen Landes (Germany)" cloneof="Turok - Rage Wars (Europe)">
+	<game name="Turok - Legenden des Verlorenen Landes (Germany)" id="0782" cloneofid="0783">
 		<description>Turok - Legenden des Verlorenen Landes (Germany)</description>
 		<rom name="Turok - Legenden des Verlorenen Landes (Germany).n64" />
-		<release name="Turok - Legenden des Verlorenen Landes (Germany)" region="GER" />
-		<rom name="Turok - Legenden des Verlorenen Landes (Germany).z64" size="8388608" crc="b937874f" md5="72a6aa28608ee93a1cb6feb0a5f4c28c" sha1="a6daacbd0e7f77c73208cf494aefc24703060b17" status="verified" />
+		<rom name="Turok - Legenden des Verlorenen Landes (Germany).z64" size="8388608" crc="b937874f" md5="72a6aa28608ee93a1cb6feb0a5f4c28c" sha1="a6daacbd0e7f77c73208cf494aefc24703060b17" status="verified" serial="NRWD" />
 	</game>
-	<game name="Turok - Rage Wars (Europe) (En,Fr,It)" cloneof="Turok - Rage Wars (Europe)">
+	<game name="Turok - Rage Wars (Europe)" id="0783">
+		<description>Turok - Rage Wars (Europe)</description>
+		<rom name="Turok - Rage Wars (Europe).n64" />
+		<rom name="Turok - Rage Wars (Europe).z64" size="8388608" crc="82b1e116" md5="dba166a42710f40dc78dc52eb37b0be6" sha1="46b474fac79a4b21535bb6c78ce3039a2c202359" status="verified" serial="NRWP" />
+	</game>
+	<game name="Turok - Rage Wars (Europe) (En,Fr,It)" id="0784" cloneofid="0783">
 		<description>Turok - Rage Wars (Europe) (En,Fr,It)</description>
 		<rom name="Turok - Rage Wars (Europe) (En,Fr,It).n64" />
-		<release name="Turok - Rage Wars (Europe) (En,Fr,It)" region="FRA" />
-		<release name="Turok - Rage Wars (Europe) (En,Fr,It)" region="ITA" />
-		<rom name="Turok - Rage Wars (Europe) (En,Fr,It).z64" size="8388608" crc="f4a2862b" md5="241cf94bed487fff62ffb7b846da46ab" sha1="0b54615930a55675955eef8d8a22f1dfc34d2b44" />
+		<rom name="Turok - Rage Wars (Europe) (En,Fr,It).z64" size="8388608" crc="f4a2862b" md5="241cf94bed487fff62ffb7b846da46ab" sha1="0b54615930a55675955eef8d8a22f1dfc34d2b44" sha256="511f6c876586bf401faf01a270c67f26fcb7db55ed3f35759c71ab15a29de750" status="verified" serial="NRWX" />
 	</game>
-	<game name="Turok - Rage Wars (USA)" cloneof="Turok - Rage Wars (Europe)">
+	<game name="Turok - Rage Wars (USA)" id="0785" cloneofid="0783">
 		<description>Turok - Rage Wars (USA)</description>
 		<rom name="Turok - Rage Wars (USA).n64" />
-		<rom name="Turok - Rage Wars (USA).z64" size="8388608" crc="422872a2" md5="cf5b28578fd62fa1ff8690079f5d68f5" sha1="9f8cb190831945f6f707aa8c2b20e04fa4276795" />
+		<rom name="Turok - Rage Wars (USA).z64" size="8388608" crc="422872a2" md5="cf5b28578fd62fa1ff8690079f5d68f5" sha1="9f8cb190831945f6f707aa8c2b20e04fa4276795" serial="NRWE" />
 	</game>
-	<game name="Turok - Rage Wars (USA) (Rev 1)" cloneof="Turok - Rage Wars (Europe)">
+	<game name="Turok - Rage Wars (USA) (Rev 1)" id="0919" cloneofid="0783">
 		<description>Turok - Rage Wars (USA) (Rev 1)</description>
 		<rom name="Turok - Rage Wars (USA) (Rev 1).n64" />
-		<release name="Turok - Rage Wars (USA) (Rev 1)" region="USA" />
-		<rom name="Turok - Rage Wars (USA) (Rev 1).z64" size="8388608" crc="e28756f4" md5="9b2ffe72080b03a5f92eb87ea849cac4" sha1="037fb397cee2669048ed6b762a64698de4a4d88a" />
+		<rom name="Turok - Rage Wars (USA) (Rev 1).z64" size="8388608" crc="e28756f4" md5="9b2ffe72080b03a5f92eb87ea849cac4" sha1="037fb397cee2669048ed6b762a64698de4a4d88a" serial="NRWE" />
 	</game>
-	<game name="Turok 2 - Seeds of Evil (Europe)">
+	<game name="Turok 2 - Seeds of Evil (Europe)" id="0786">
 		<description>Turok 2 - Seeds of Evil (Europe)</description>
 		<rom name="Turok 2 - Seeds of Evil (Europe).n64" />
-		<release name="Turok 2 - Seeds of Evil (Europe)" region="EUR" />
-		<rom name="Turok 2 - Seeds of Evil (Europe).z64" size="33554432" crc="e2d34bfe" md5="e5a39521fa954eb97b96ac2154a5fd7a" sha1="1a0b36d9fd95db483c846d0d604d2549d6ce4cc3" />
+		<rom name="Turok 2 - Seeds of Evil (Europe).z64" size="33554432" crc="e2d34bfe" md5="e5a39521fa954eb97b96ac2154a5fd7a" sha1="1a0b36d9fd95db483c846d0d604d2549d6ce4cc3" sha256="6c8ec2083adeb6eb7bc0aad865384f77a8f89a98ff21b74a630dd85e8256ebf8" status="verified" serial="NT2P" />
 	</game>
-	<game name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" cloneof="Turok 2 - Seeds of Evil (Europe)">
+	<game name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" id="0787" cloneofid="0786">
 		<description>Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)</description>
 		<rom name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It).n64" />
-		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="FRA" />
-		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="ITA" />
-		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="SPA" />
-		<rom name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It).z64" size="33554432" crc="1febde32" md5="144b10a484a22367fd2679529dbd2fed" sha1="fb20f8e540c01d321bf805922b05e7a448521e1e" status="verified" />
+		<rom name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It).z64" size="33554432" crc="1febde32" md5="144b10a484a22367fd2679529dbd2fed" sha1="fb20f8e540c01d321bf805922b05e7a448521e1e" status="verified" serial="NT2X" />
 	</game>
-	<game name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)" cloneof="Turok 2 - Seeds of Evil (Europe)">
+	<game name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)" id="0788" cloneofid="0786">
 		<description>Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)</description>
 		<rom name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk).n64" />
-		<rom name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk).z64" size="12582912" crc="4e29b234" md5="ce72237707f481cfe97fde330c2afcd6" sha1="bfc04b6c5c300d39bbabe0b42227aef45cc41d3f" />
+		<rom name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk).z64" size="12582912" crc="4e29b234" md5="ce72237707f481cfe97fde330c2afcd6" sha1="bfc04b6c5c300d39bbabe0b42227aef45cc41d3f" serial="NTYP" />
 	</game>
-	<game name="Turok 2 - Seeds of Evil (Germany)" cloneof="Turok 2 - Seeds of Evil (Europe)">
+	<game name="Turok 2 - Seeds of Evil (Germany)" id="0789" cloneofid="0786">
 		<description>Turok 2 - Seeds of Evil (Germany)</description>
 		<rom name="Turok 2 - Seeds of Evil (Germany).n64" />
-		<release name="Turok 2 - Seeds of Evil (Germany)" region="GER" />
-		<rom name="Turok 2 - Seeds of Evil (Germany).z64" size="33554432" crc="c07877b6" md5="b932116c967795076b5c112841ab4427" sha1="d09353c551f5309f29b6ff964b583a54e3d63c5f" />
+		<rom name="Turok 2 - Seeds of Evil (Germany).z64" size="33554432" crc="c07877b6" md5="b932116c967795076b5c112841ab4427" sha1="d09353c551f5309f29b6ff964b583a54e3d63c5f" serial="NT2D" />
 	</game>
-	<game name="Turok 2 - Seeds of Evil (USA)" cloneof="Turok 2 - Seeds of Evil (Europe)">
+	<game name="Turok 2 - Seeds of Evil (USA)" id="0790" cloneofid="0786">
 		<description>Turok 2 - Seeds of Evil (USA)</description>
 		<rom name="Turok 2 - Seeds of Evil (USA).n64" />
-		<rom name="Turok 2 - Seeds of Evil (USA).z64" size="33554432" crc="ff5e7636" md5="fad4da8e17ce12f68cdf29180cdd4a90" sha1="fb0400f21e3f043939ab56500c7b12a3231006f1" status="verified" />
+		<rom name="Turok 2 - Seeds of Evil (USA).z64" size="33554432" crc="ff5e7636" md5="fad4da8e17ce12f68cdf29180cdd4a90" sha1="fb0400f21e3f043939ab56500c7b12a3231006f1" status="verified" serial="NT2E" />
 	</game>
-	<game name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)" cloneof="Turok 2 - Seeds of Evil (Europe)">
+	<game name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)" id="0791" cloneofid="0786">
 		<description>Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)</description>
 		<rom name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk).n64" />
-		<rom name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk).z64" size="12582912" crc="8d5b9bd0" md5="3bd42f6aec477c056e1afebb3515495c" sha1="68d1c5b79cc243804fce3c993d9c93a10a58cab8" />
+		<rom name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk).z64" size="12582912" crc="8d5b9bd0" md5="3bd42f6aec477c056e1afebb3515495c" sha1="68d1c5b79cc243804fce3c993d9c93a10a58cab8" serial="NTYE" />
 	</game>
-	<game name="Turok 2 - Seeds of Evil (USA) (Rev 1)" cloneof="Turok 2 - Seeds of Evil (Europe)">
+	<game name="Turok 2 - Seeds of Evil (USA) (Rev 1)" id="0792" cloneofid="0786">
 		<description>Turok 2 - Seeds of Evil (USA) (Rev 1)</description>
 		<rom name="Turok 2 - Seeds of Evil (USA) (Rev 1).n64" />
-		<release name="Turok 2 - Seeds of Evil (USA) (Rev 1)" region="USA" />
-		<rom name="Turok 2 - Seeds of Evil (USA) (Rev 1).z64" size="33554432" crc="57f1fbf5" md5="166221365db70d446c4206083d422dd1" sha1="a86af6c2ac9f6d837181f07c0a27f7ee59e7df68" />
+		<rom name="Turok 2 - Seeds of Evil (USA) (Rev 1).z64" size="33554432" crc="57f1fbf5" md5="166221365db70d446c4206083d422dd1" sha1="a86af6c2ac9f6d837181f07c0a27f7ee59e7df68" sha256="cb62df8e8085fc1828b943723b2cd164aeabbe53b2940314189d4133233dfb86" status="verified" serial="NT2E" />
 	</game>
-	<game name="Violence Killer - Turok New Generation (Japan)" cloneof="Turok 2 - Seeds of Evil (Europe)">
-		<description>Violence Killer - Turok New Generation (Japan)</description>
-		<rom name="Violence Killer - Turok New Generation (Japan).n64" />
-		<release name="Violence Killer - Turok New Generation (Japan)" region="JPN" />
-		<rom name="Violence Killer - Turok New Generation (Japan).z64" size="33554432" crc="097f139f" md5="c3005d76af42e929e5c67421a19f8235" sha1="2dd9771030500a4e4512e76209267e358a4a0ae6" />
-	</game>
-	<game name="Turok 3 - Shadow of Oblivion (Europe)">
+	<game name="Turok 3 - Shadow of Oblivion (Europe)" id="0793">
 		<description>Turok 3 - Shadow of Oblivion (Europe)</description>
 		<rom name="Turok 3 - Shadow of Oblivion (Europe).n64" />
-		<release name="Turok 3 - Shadow of Oblivion (Europe)" region="EUR" />
-		<rom name="Turok 3 - Shadow of Oblivion (Europe).z64" size="33554432" crc="98d3114c" md5="279ec83bd60a3cce69a1db22b0a5c318" sha1="f3fdc0b58d0ae8111f033c5f61c364e6a9425f91" status="verified" />
+		<rom name="Turok 3 - Shadow of Oblivion (Europe).z64" size="33554432" crc="98d3114c" md5="279ec83bd60a3cce69a1db22b0a5c318" sha1="f3fdc0b58d0ae8111f033c5f61c364e6a9425f91" sha256="26520b99cbadf6a2f095ec94d898907901a9541703c34976f5f8c926bc90b706" status="verified" serial="NTKP" />
 	</game>
-	<game name="Turok 3 - Shadow of Oblivion (USA)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
+	<game name="Turok 3 - Shadow of Oblivion (USA)" id="0794" cloneofid="0793">
 		<description>Turok 3 - Shadow of Oblivion (USA)</description>
 		<rom name="Turok 3 - Shadow of Oblivion (USA).n64" />
-		<release name="Turok 3 - Shadow of Oblivion (USA)" region="USA" />
-		<rom name="Turok 3 - Shadow of Oblivion (USA).z64" size="33554432" crc="cb297224" md5="1211c556d77b169d81a666a9661e1777" sha1="a2e0a28dc0d3a48c7c02cb9e4c4b38fe04b2d436" />
+		<rom name="Turok 3 - Shadow of Oblivion (USA).z64" size="33554432" crc="cb297224" md5="1211c556d77b169d81a666a9661e1777" sha1="a2e0a28dc0d3a48c7c02cb9e4c4b38fe04b2d436" sha256="9ac5a8049d6c0dce16fd0ac2898fb42fec42455ca8497d3244de215df1e6e096" status="verified" serial="NTKE" />
 	</game>
-	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
-		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10)</description>
-		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10).n64" />
-		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10).z64" size="33554432" crc="3cd1f9af" md5="c38acbae773cc3845ea354421e171998" sha1="22bd7985055c08da0d9885772fe65c2f78a5f9ac" />
+	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10) [b]" id="0795" cloneofid="0793">
+		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10) [b]</description>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10) [b].n64" />
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10) [b].z64" size="33554432" crc="3cd1f9af" md5="c38acbae773cc3845ea354421e171998" sha1="22bd7985055c08da0d9885772fe65c2f78a5f9ac" status="baddump" serial="NSED" />
 	</game>
-	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
+	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31)" id="0935" cloneofid="0793">
 		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31)</description>
 		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31).n64" />
 		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31).z64" size="33554432" crc="66e63bbc" md5="03d17aa3dc7663502017d3cc5a19aa8b" sha1="df10c5d421aeab2af438648588600839cd82b5e0" />
 	</game>
-	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
-		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06)</description>
-		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06).n64" />
-		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06).z64" size="33554432" crc="7946b05a" md5="69ce88c46a7c829c6f54004de93efcef" sha1="08ec9170b67afe259104977def70fbcc706729f9" />
+	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06) [b]" id="1014" cloneofid="0793">
+		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06) [b]</description>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06) [b].n64" />
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06) [b].z64" size="33554432" crc="7946b05a" md5="69ce88c46a7c829c6f54004de93efcef" sha1="08ec9170b67afe259104977def70fbcc706729f9" status="baddump" serial="ABCD" />
 	</game>
-	<game name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
-		<description>Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21)</description>
-		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21).n64" />
-		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21).z64" size="33554432" crc="667b553d" md5="9865a336b00e95601ed05a43a2422c23" sha1="0bac8aa24d636f1b8e5a65a7fd95b9c282c3e495" />
+	<game name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-18)" id="1042" cloneofid="0793">
+		<description>Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-18)</description>
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-18).n64" />
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-18).z64" size="33554432" crc="667b553d" md5="9865a336b00e95601ed05a43a2422c23" sha1="0bac8aa24d636f1b8e5a65a7fd95b9c282c3e495" sha256="bd01280dd12dc579da8dbb080c79b97cedab0d535334c913b5206815eaf8d2dc" serial="ABCD" />
 	</game>
-	<game name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
+	<game name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26)" id="1054" cloneofid="0793">
 		<description>Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26)</description>
 		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26).n64" />
 		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26).z64" size="33554432" crc="58c4c0ab" md5="f5738c4b804b0260b99ad39d49ddd43c" sha1="f3cddfc1bfce0348c41217f9f4e053f8ab3dd4ca" />
 	</game>
-	<game name="Twisted Edge - Snowboarding (Europe)">
-		<description>Twisted Edge - Snowboarding (Europe)</description>
-		<rom name="Twisted Edge - Snowboarding (Europe).n64" />
-		<release name="Twisted Edge - Snowboarding (Europe)" region="EUR" />
-		<rom name="Twisted Edge - Snowboarding (Europe).z64" size="12582912" crc="bf0c1291" md5="420c9fdbae15767c5e584070209ff253" sha1="de12629f2538f80e25901decafc7ccc18c7d481c" />
+	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-16T211412)" id="1069" cloneofid="0793">
+		<category>Games</category>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-16T211412).n64" />
+		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-16T211412)</description>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-16T211412).z64" size="33554432" crc="9a01a5f4" md5="3d64e47f1c0cba540ed00f816fa75e9d" sha1="823f0fec1afb1f2b734d558a09568e17b9e1b0e7" sha256="12f6f14c38c3a19fa332d2068bcf11f36ab2d82982c40788ea6c17655e50872c" serial="NSHT" />
 	</game>
-	<game name="King Hill 64 - Extreme Snowboarding (Japan)" cloneof="Twisted Edge - Snowboarding (Europe)">
-		<description>King Hill 64 - Extreme Snowboarding (Japan)</description>
-		<rom name="King Hill 64 - Extreme Snowboarding (Japan).n64" />
-		<release name="King Hill 64 - Extreme Snowboarding (Japan)" region="JPN" />
-		<rom name="King Hill 64 - Extreme Snowboarding (Japan).z64" size="12582912" crc="f120cc52" md5="cca4e87ec206b5b65aeab9531c0f275b" sha1="10924ab3c8909b18dae64fede304af2a08d7ffe1" />
+	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-18)" id="1093" cloneofid="0793">
+		<category>Games</category>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-18).n64" />
+		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-18)</description>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-18).z64" size="33554432" crc="9d96edfd" md5="ed64e19322382a86467666902760a76c" sha1="2b7aa989ebd0df1452dabc29f5d8f334e3f17529" sha256="628cdd8067ff066d02d7a08b375f5b64ac6131127a510d4fc0050135225c2574" serial="ABCD" />
 	</game>
-	<game name="Twisted Edge - Extreme Snowboarding (USA)" cloneof="Twisted Edge - Snowboarding (Europe)">
+	<game name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-05-03)" id="1118" cloneofid="0793">
+		<category>Games</category>
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-05-03).n64" />
+		<description>Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-05-03)</description>
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-05-03).z64" size="33554432" crc="bd65ede5" md5="da557a2f10fb66bf966140fbb066772f" sha1="aebcd74971791a6cedff2760582a34522cdd7d55" sha256="73857c14229df113fb20a05e726a36e71b039ca9d5862c917eac2c6bb35a9727" serial="NSHT" />
+	</game>
+	<game name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-16)" id="1119" cloneofid="0793">
+		<category>Games</category>
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-16).n64" />
+		<description>Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-16)</description>
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-16).z64" size="33554432" crc="d6c552d0" md5="4ae7c142d09f850f6ac0320034d80fa5" sha1="f589ace7e502422b41178cc7cdae29a3bde9e117" sha256="78175f1a4731ecc25dbc52987e3dcc12464d3d0be8bd9f6eeeeea71e14cfad9f" serial="NSHT" />
+	</game>
+	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-16T220245)" id="1120" cloneofid="0793">
+		<category>Games</category>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-16T220245).n64" />
+		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-16T220245)</description>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-16T220245).z64" size="33554432" crc="5d0d0943" md5="d44af456933062c4ebe103b6f23518ea" sha1="f67b8d1eeaaa3b6e8c2a81a8fec9b4ce257c1362" sha256="24e7e1ba7bb79156f0181227192383575e22dfd67279f7660d4d44111436ecf3" serial="NSHT" />
+	</game>
+	<game name="Twisted Edge - Extreme Snowboarding (USA)" id="0797" cloneofid="0796">
 		<description>Twisted Edge - Extreme Snowboarding (USA)</description>
 		<rom name="Twisted Edge - Extreme Snowboarding (USA).n64" />
-		<release name="Twisted Edge - Extreme Snowboarding (USA)" region="USA" />
-		<rom name="Twisted Edge - Extreme Snowboarding (USA).z64" size="12582912" crc="bfbcc038" md5="9df6c2c97fa34a978ef3cb77631536fe" sha1="8888228ad423df143c2c820130fb0658df64c930" />
+		<rom name="Twisted Edge - Extreme Snowboarding (USA).z64" size="12582912" crc="bfbcc038" md5="9df6c2c97fa34a978ef3cb77631536fe" sha1="8888228ad423df143c2c820130fb0658df64c930" sha256="ae18c310cc6130ba7cb38068fc34ce3e2cd01b1311ee1112613cb5dd5048bf9a" status="verified" serial="NSBE" />
 	</game>
-	<game name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)">
+	<game name="Twisted Edge - Snowboarding (Europe)" id="0796">
+		<description>Twisted Edge - Snowboarding (Europe)</description>
+		<rom name="Twisted Edge - Snowboarding (Europe).n64" />
+		<rom name="Twisted Edge - Snowboarding (Europe).z64" size="12582912" crc="bf0c1291" md5="420c9fdbae15767c5e584070209ff253" sha1="de12629f2538f80e25901decafc7ccc18c7d481c" sha256="a00c0c81651f01a7c88e120c09028ae8419ef7627ad3f912ab3a036fe400e3ec" status="verified" serial="NSBP" />
+	</game>
+	<game name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)" id="0798">
 		<description>Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)</description>
 		<rom name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan).n64" />
-		<release name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)" region="JPN" />
-		<rom name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan).z64" size="8388608" crc="50cbe8a6" md5="ffeb5c1a85babbbe60f2feba2b35c893" sha1="557d2dadebea77fbc7342a881311fca5c5b35b39" />
+		<rom name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan).z64" size="8388608" crc="50cbe8a6" md5="ffeb5c1a85babbbe60f2feba2b35c893" sha1="557d2dadebea77fbc7342a881311fca5c5b35b39" sha256="d702729e9702b3db6a6dbb5fd91767d07108d97c91b41a2dbc89cf75eba7515e" status="verified" serial="NIRJ" />
 	</game>
-	<game name="V-Rally Edition 99 (Europe) (En,Fr,De)">
+	<game name="V-Rally Edition 99 (Europe) (En,Fr,De)" id="0799">
 		<description>V-Rally Edition 99 (Europe) (En,Fr,De)</description>
 		<rom name="V-Rally Edition 99 (Europe) (En,Fr,De).n64" />
-		<release name="V-Rally Edition 99 (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="V-Rally Edition 99 (Europe) (En,Fr,De).z64" size="12582912" crc="0735d7a2" md5="dcac12eb5832d4a489188330eb9ec387" sha1="da3f262dfb86cff1376c9a1aa081212e5a7aad64" status="verified" />
+		<rom name="V-Rally Edition 99 (Europe) (En,Fr,De).z64" size="12582912" crc="0735d7a2" md5="dcac12eb5832d4a489188330eb9ec387" sha1="da3f262dfb86cff1376c9a1aa081212e5a7aad64" sha256="d510b5ccf5a0513ce0a3776f045f7ef9a4983a07e0d00a31f0b1ae5d3eb2d4a7" status="verified" serial="NVLP" />
 	</game>
-	<game name="V-Rally Edition 99 (Japan)" cloneof="V-Rally Edition 99 (Europe) (En,Fr,De)">
+	<game name="V-Rally Edition 99 (Japan)" id="0800" cloneofid="0799">
 		<description>V-Rally Edition 99 (Japan)</description>
 		<rom name="V-Rally Edition 99 (Japan).n64" />
-		<release name="V-Rally Edition 99 (Japan)" region="JPN" />
-		<rom name="V-Rally Edition 99 (Japan).z64" size="8388608" crc="02475a01" md5="8541d7a8737be09c52d4ec1274de2a91" sha1="b23adb839ac7bb51cc080ff531e42ab0bc86dd13" />
+		<rom name="V-Rally Edition 99 (Japan).z64" size="8388608" crc="02475a01" md5="8541d7a8737be09c52d4ec1274de2a91" sha1="b23adb839ac7bb51cc080ff531e42ab0bc86dd13" serial="NVYJ" />
 	</game>
-	<game name="V-Rally Edition 99 (USA)" cloneof="V-Rally Edition 99 (Europe) (En,Fr,De)">
+	<game name="V-Rally Edition 99 (USA)" id="0801" cloneofid="0799">
 		<description>V-Rally Edition 99 (USA)</description>
 		<rom name="V-Rally Edition 99 (USA).n64" />
-		<release name="V-Rally Edition 99 (USA)" region="USA" />
-		<rom name="V-Rally Edition 99 (USA).z64" size="8388608" crc="4803075e" md5="0c3448a9d85300acb9c5556f27a84b23" sha1="891c64c871993c043bf47745fcce16cd7e6aa76f" />
+		<rom name="V-Rally Edition 99 (USA).z64" size="8388608" crc="4803075e" md5="0c3448a9d85300acb9c5556f27a84b23" sha1="891c64c871993c043bf47745fcce16cd7e6aa76f" sha256="7bd50354861472b6de24f89e133c6fedb2ce91ac7802df2d618175c83b028585" serial="NVLE" />
 	</game>
-	<game name="Viewpoint 2064 (Japan) (Proto)">
+	<game name="Viewpoint 2064 (Japan) (Proto)" id="1039">
 		<description>Viewpoint 2064 (Japan) (Proto)</description>
 		<rom name="Viewpoint 2064 (Japan) (Proto).n64" />
-		<release name="Viewpoint 2064 (Japan) (Proto)" region="JPN" />
-		<rom name="Viewpoint 2064 (Japan) (Proto).z64" size="16777216" crc="93a630cb" md5="b7425d12935662e480268b48055f2e6c" sha1="defacaf6dbd22962ec0184849ed4a4c53a147454" />
+		<rom name="Viewpoint 2064 (Japan) (Proto).z64" size="16777216" crc="93a630cb" md5="b7425d12935662e480268b48055f2e6c" sha1="defacaf6dbd22962ec0184849ed4a4c53a147454" sha256="a909dc41517a07f22eabba5a8b3f68968cf608be1c81a41e5276bcde515ba7e3" />
 	</game>
-	<game name="Vigilante 8 (Europe)">
+	<game name="Vigilante 8 (Europe)" id="0802">
 		<description>Vigilante 8 (Europe)</description>
 		<rom name="Vigilante 8 (Europe).n64" />
-		<release name="Vigilante 8 (Europe)" region="EUR" />
-		<rom name="Vigilante 8 (Europe).z64" size="8388608" crc="0e9bb6d6" md5="df011e19f41b1b19c21f1e77e13780b7" sha1="37603e7afba0d0ebebe64782efd135b096d4cadc" status="verified" />
+		<rom name="Vigilante 8 (Europe).z64" size="8388608" crc="0e9bb6d6" md5="df011e19f41b1b19c21f1e77e13780b7" sha1="37603e7afba0d0ebebe64782efd135b096d4cadc" status="verified" serial="NV8P" />
 	</game>
-	<game name="Vigilante 8 (France)" cloneof="Vigilante 8 (Europe)">
+	<game name="Vigilante 8 (France)" id="0803" cloneofid="0802">
 		<description>Vigilante 8 (France)</description>
 		<rom name="Vigilante 8 (France).n64" />
-		<release name="Vigilante 8 (France)" region="FRA" />
-		<rom name="Vigilante 8 (France).z64" size="8388608" crc="11d23ab3" md5="ff9f85c50982dbdba9853a8915321d31" sha1="16688eac55153332d49a62696294f38d6c1afefa" />
+		<rom name="Vigilante 8 (France).z64" size="8388608" crc="11d23ab3" md5="ff9f85c50982dbdba9853a8915321d31" sha1="16688eac55153332d49a62696294f38d6c1afefa" sha256="20c61c00a592b2084803fa1490af32b75bc225dd1bde3832dd2341116cf0b13e" serial="NV8F" />
 	</game>
-	<game name="Vigilante 8 (Germany)" cloneof="Vigilante 8 (Europe)">
+	<game name="Vigilante 8 (Germany)" id="0804" cloneofid="0802">
 		<description>Vigilante 8 (Germany)</description>
 		<rom name="Vigilante 8 (Germany).n64" />
-		<release name="Vigilante 8 (Germany)" region="GER" />
-		<rom name="Vigilante 8 (Germany).z64" size="8388608" crc="17f63c3f" md5="37b430ee16167831c6c6292994f93277" sha1="39e4fc6d553d370efc0710de2e99d8bc8a020a7c" />
+		<rom name="Vigilante 8 (Germany).z64" size="8388608" crc="17f63c3f" md5="37b430ee16167831c6c6292994f93277" sha1="39e4fc6d553d370efc0710de2e99d8bc8a020a7c" serial="NV8D" />
 	</game>
-	<game name="Vigilante 8 (USA)" cloneof="Vigilante 8 (Europe)">
+	<game name="Vigilante 8 (USA)" id="0805" cloneofid="0802">
 		<description>Vigilante 8 (USA)</description>
 		<rom name="Vigilante 8 (USA).n64" />
-		<release name="Vigilante 8 (USA)" region="USA" />
-		<rom name="Vigilante 8 (USA).z64" size="8388608" crc="330b73e6" md5="d616adf6441acbbd0e6bef023a8f6031" sha1="22b7d7b4f1722efd52d3c8beba8cf5d07340569b" />
+		<rom name="Vigilante 8 (USA).z64" size="8388608" crc="330b73e6" md5="d616adf6441acbbd0e6bef023a8f6031" sha1="22b7d7b4f1722efd52d3c8beba8cf5d07340569b" sha256="fd75b40f561049b70b7e0bc652584062061fd17cf23e518700f5dcc5d4938799" serial="NV8E" />
 	</game>
-	<game name="Vigilante 8 - 2nd Offense (Europe)">
+	<game name="Vigilante 8 - 2nd Offense (Europe)" id="0806">
 		<description>Vigilante 8 - 2nd Offense (Europe)</description>
 		<rom name="Vigilante 8 - 2nd Offense (Europe).n64" />
-		<release name="Vigilante 8 - 2nd Offense (Europe)" region="EUR" />
-		<rom name="Vigilante 8 - 2nd Offense (Europe).z64" size="12582912" crc="691aa971" md5="47661ef1964524b6319b759913f08b62" sha1="a2841a8b4c29481d05b52227442c0e419c574e2d" />
+		<rom name="Vigilante 8 - 2nd Offense (Europe).z64" size="12582912" crc="691aa971" md5="47661ef1964524b6319b759913f08b62" sha1="a2841a8b4c29481d05b52227442c0e419c574e2d" sha256="f752fbc6ba026fe4efef6f79df7a8e509762507ad5442ad0aa09a68da484d9e7" status="verified" serial="NVGP" />
 	</game>
-	<game name="Vigilante 8 - 2nd Offense (USA)" cloneof="Vigilante 8 - 2nd Offense (Europe)">
+	<game name="Vigilante 8 - 2nd Offense (USA)" id="0807" cloneofid="0806">
 		<description>Vigilante 8 - 2nd Offense (USA)</description>
 		<rom name="Vigilante 8 - 2nd Offense (USA).n64" />
-		<release name="Vigilante 8 - 2nd Offense (USA)" region="USA" />
-		<rom name="Vigilante 8 - 2nd Offense (USA).z64" size="12582912" crc="0293203f" md5="60cdf7445fad2aba05c958f46691501b" sha1="9634247ca456c82a65bb33f552db036ba6f33f79" />
+		<rom name="Vigilante 8 - 2nd Offense (USA).z64" size="12582912" crc="0293203f" md5="60cdf7445fad2aba05c958f46691501b" sha1="9634247ca456c82a65bb33f552db036ba6f33f79" serial="NVGE" />
 	</game>
-	<game name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Violence Killer - Turok New Generation (Japan)" id="0808" cloneofid="0786">
+		<description>Violence Killer - Turok New Generation (Japan)</description>
+		<rom name="Violence Killer - Turok New Generation (Japan).n64" />
+		<rom name="Violence Killer - Turok New Generation (Japan).z64" size="33554432" crc="097f139f" md5="c3005d76af42e929e5c67421a19f8235" sha1="2dd9771030500a4e4512e76209267e358a4a0ae6" serial="NT2J" />
+	</game>
+	<game name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)" id="0809">
 		<description>Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl).z64" size="4194304" crc="aae15243" md5="e790be1a5b883beba44bc0d2666c65f5" sha1="0899017b0a5231ecbb084abff2303d9c25342828" />
+		<rom name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl).z64" size="4194304" crc="aae15243" md5="e790be1a5b883beba44bc0d2666c65f5" sha1="0899017b0a5231ecbb084abff2303d9c25342828" sha256="520a4f53ca23cad5cafb03025117858a1fe474146bd49ace2d270161da4e992c" status="verified" serial="NVCP" />
 	</game>
-	<game name="Virtual Chess 64 (USA) (En,Fr,Es)" cloneof="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Virtual Chess 64 (USA) (En,Fr,Es)" id="0810" cloneofid="0809">
 		<description>Virtual Chess 64 (USA) (En,Fr,Es)</description>
 		<rom name="Virtual Chess 64 (USA) (En,Fr,Es).n64" />
-		<release name="Virtual Chess 64 (USA) (En,Fr,Es)" region="USA" />
-		<rom name="Virtual Chess 64 (USA) (En,Fr,Es).z64" size="4194304" crc="620de0b7" md5="f8a35270279b277586d7210fd15134ff" sha1="b3f84937813eb76f94dfcf1dbea69b11bdbf7e4f" />
+		<rom name="Virtual Chess 64 (USA) (En,Fr,Es).z64" size="4194304" crc="620de0b7" md5="f8a35270279b277586d7210fd15134ff" sha1="b3f84937813eb76f94dfcf1dbea69b11bdbf7e4f" serial="NVCE" />
 	</game>
-	<game name="Virtual Pool 64 (Europe)">
+	<game name="Virtual Chess 64 (USA) (En,Fr,Es) (LodgeNet)" id="1162" cloneofid="0809">
+		<category>Games</category>
+		<rom name="Virtual Chess 64 (USA) (En,Fr,Es) (LodgeNet).n64" />
+		<description>Virtual Chess 64 (USA) (En,Fr,Es) (LodgeNet)</description>
+		<rom name="Virtual Chess 64 (USA) (En,Fr,Es) (LodgeNet).i64" size="64" crc="e59ad6fb" md5="f9d376af6ce69aefe6b69958c6ae8eda" sha1="8ff65140eeb055798663a0cdcac8ebcdc90cefd8" />
+		<rom name="Virtual Chess 64 (USA) (En,Fr,Es) (LodgeNet).z64" size="4194304" crc="ac7aa76d" md5="c14d21a693135284a708feb3f80f487e" sha1="90a012eb6a0cb1ac158492a6c2683f181c5b0205" />
+	</game>
+	<game name="Virtual Pool 64 (USA) (LodgeNet)" id="1163" cloneofid="0811">
+		<category>Games</category>
+		<rom name="Virtual Pool 64 (USA) (LodgeNet).n64" />
+		<description>Virtual Pool 64 (USA) (LodgeNet)</description>
+		<rom name="Virtual Pool 64 (USA) (LodgeNet).i64" size="64" crc="fdc31374" md5="5361cf84568f4affc02f8486bd902453" sha1="0ece94752fcb28e08c4c311bc3f5d545f3b7517a" />
+		<rom name="Virtual Pool 64 (USA) (LodgeNet).z64" size="4194304" crc="b58fc734" md5="8e7d473161cb685909bc762a32aa850d" sha1="b595e31c1599d52ef363c974ea54e52f201795f2" />
+	</game>
+	<game name="Virtual Pool 64 (Europe)" id="0811">
 		<description>Virtual Pool 64 (Europe)</description>
 		<rom name="Virtual Pool 64 (Europe).n64" />
-		<release name="Virtual Pool 64 (Europe)" region="EUR" />
-		<rom name="Virtual Pool 64 (Europe).z64" size="4194304" crc="9a6fb0bc" md5="ab68fb43f012c1a45af1dbcc8e8c109c" sha1="70bd9ece445d6b66ef65afc19b5ea9df5a75dba4" />
+		<rom name="Virtual Pool 64 (Europe).z64" size="4194304" crc="9a6fb0bc" md5="ab68fb43f012c1a45af1dbcc8e8c109c" sha1="70bd9ece445d6b66ef65afc19b5ea9df5a75dba4" sha256="06b14029b7ae53de5d3097b2641563eb2bf402f9920779faada96dc380c082f3" status="verified" serial="NVRP" />
 	</game>
-	<game name="Virtual Pool 64 (USA)" cloneof="Virtual Pool 64 (Europe)">
+	<game name="Virtual Pool 64 (USA)" id="0812" cloneofid="0811">
 		<description>Virtual Pool 64 (USA)</description>
 		<rom name="Virtual Pool 64 (USA).n64" />
-		<release name="Virtual Pool 64 (USA)" region="USA" />
-		<rom name="Virtual Pool 64 (USA).z64" size="4194304" crc="ad628ded" md5="6d3db67319da339df4b68ad0084904d5" sha1="4fed63f7ee35f4d3941f0d61175057481d91d2e0" />
+		<rom name="Virtual Pool 64 (USA).z64" size="4194304" crc="ad628ded" md5="6d3db67319da339df4b68ad0084904d5" sha1="4fed63f7ee35f4d3941f0d61175057481d91d2e0" sha256="e263c17be9deae7acf8eb1850948c179ec45a1409cd373682cc37c0251881efe" serial="NVRE" />
 	</game>
-	<game name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan)">
+	<game name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan)" id="0813">
 		<description>Virtual Pro Wrestling 2 - Oudou Keishou (Japan)</description>
 		<rom name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan).n64" />
-		<release name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan)" region="JPN" />
-		<rom name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan).z64" size="33554432" crc="f620835d" md5="90002501777e3237739f5ed9b0e349e2" sha1="82dd25a044689eab57ab362fe10c0da6388c217a" />
+		<rom name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan).z64" size="33554432" crc="f620835d" md5="90002501777e3237739f5ed9b0e349e2" sha1="82dd25a044689eab57ab362fe10c0da6388c217a" serial="NA2J" />
 	</game>
-	<game name="Virtual Pro Wrestling 64 (Japan)">
+	<game name="Virtual Pro Wrestling 64 (Japan)" id="0814">
 		<description>Virtual Pro Wrestling 64 (Japan)</description>
 		<rom name="Virtual Pro Wrestling 64 (Japan).n64" />
-		<release name="Virtual Pro Wrestling 64 (Japan)" region="JPN" />
-		<rom name="Virtual Pro Wrestling 64 (Japan).z64" size="16777216" crc="e6651803" md5="5e6202200af40a8f026780edfe1e15d0" sha1="f9e9fa2ed819c3a39db5cb6afeca186f021db5ed" />
+		<rom name="Virtual Pro Wrestling 64 (Japan).z64" size="16777216" crc="e6651803" md5="5e6202200af40a8f026780edfe1e15d0" sha1="f9e9fa2ed819c3a39db5cb6afeca186f021db5ed" serial="NVPJ" />
 	</game>
-	<game name="Waialae Country Club - True Golf Classics (Europe) (Rev 1)">
-		<description>Waialae Country Club - True Golf Classics (Europe) (Rev 1)</description>
-		<rom name="Waialae Country Club - True Golf Classics (Europe) (Rev 1).n64" />
-		<release name="Waialae Country Club - True Golf Classics (Europe) (Rev 1)" region="EUR" />
-		<rom name="Waialae Country Club - True Golf Classics (Europe) (Rev 1).z64" size="16777216" crc="6cb097b3" md5="f7c1b1ee1ce37ce09aa48c7e0a115efa" sha1="074d13da1ac91167654a8047eb72d732fbcb5121" />
-	</game>
-	<game name="Waialae Country Club - True Golf Classics (Europe)" cloneof="Waialae Country Club - True Golf Classics (Europe) (Rev 1)">
+	<game name="Waialae Country Club - True Golf Classics (Europe)" id="0815" cloneofid="0816">
 		<description>Waialae Country Club - True Golf Classics (Europe)</description>
 		<rom name="Waialae Country Club - True Golf Classics (Europe).n64" />
-		<rom name="Waialae Country Club - True Golf Classics (Europe).z64" size="16777216" crc="6858759a" md5="5f1906df4eb30537c2ac2fcbd005907d" sha1="a06f905f4466637012adb5eb56ccdcbee2e7ac72" />
+		<rom name="Waialae Country Club - True Golf Classics (Europe).z64" size="16777216" crc="6858759a" md5="5f1906df4eb30537c2ac2fcbd005907d" sha1="a06f905f4466637012adb5eb56ccdcbee2e7ac72" sha256="054aa1854980abaf7bbc4f7d5dba719ad60dac36ae0da75de0129c9c81b52b35" status="verified" serial="NWLP" />
 	</game>
-	<game name="Waialae Country Club - True Golf Classics (USA)" cloneof="Waialae Country Club - True Golf Classics (Europe) (Rev 1)">
+	<game name="Waialae Country Club - True Golf Classics (Europe) (Rev 1)" id="0816">
+		<description>Waialae Country Club - True Golf Classics (Europe) (Rev 1)</description>
+		<rom name="Waialae Country Club - True Golf Classics (Europe) (Rev 1).n64" />
+		<rom name="Waialae Country Club - True Golf Classics (Europe) (Rev 1).z64" size="16777216" crc="6cb097b3" md5="f7c1b1ee1ce37ce09aa48c7e0a115efa" sha1="074d13da1ac91167654a8047eb72d732fbcb5121" serial="NWLP" />
+	</game>
+	<game name="Waialae Country Club - True Golf Classics (USA)" id="0817" cloneofid="0816">
 		<description>Waialae Country Club - True Golf Classics (USA)</description>
 		<rom name="Waialae Country Club - True Golf Classics (USA).n64" />
-		<rom name="Waialae Country Club - True Golf Classics (USA).z64" size="16777216" crc="ccab08d7" md5="dd8154d507c88694afd69c7af16a8cd6" sha1="f8609f518d60c87cb6a4e257633e8a1be957311c" />
+		<rom name="Waialae Country Club - True Golf Classics (USA).z64" size="16777216" crc="ccab08d7" md5="dd8154d507c88694afd69c7af16a8cd6" sha1="f8609f518d60c87cb6a4e257633e8a1be957311c" sha256="75532cf3a0931e848cfcf22677e2c4356fcd691d9ed5b2d0d0268777ee4aefb9" status="verified" serial="NWLE" />
 	</game>
-	<game name="Waialae Country Club - True Golf Classics (USA) (Rev 1)" cloneof="Waialae Country Club - True Golf Classics (Europe) (Rev 1)">
+	<game name="Waialae Country Club - True Golf Classics (USA) (Rev 1)" id="0881" cloneofid="0816">
 		<description>Waialae Country Club - True Golf Classics (USA) (Rev 1)</description>
 		<rom name="Waialae Country Club - True Golf Classics (USA) (Rev 1).n64" />
-		<release name="Waialae Country Club - True Golf Classics (USA) (Rev 1)" region="USA" />
-		<rom name="Waialae Country Club - True Golf Classics (USA) (Rev 1).z64" size="16777216" crc="c65ee122" md5="67f75c4dd30922a001c8c32aeb9333ac" sha1="45c9e0ca0d41b47bb59d36cebb1d2a9db7c8278b" />
+		<rom name="Waialae Country Club - True Golf Classics (USA) (Rev 1).z64" size="16777216" crc="c65ee122" md5="67f75c4dd30922a001c8c32aeb9333ac" sha1="45c9e0ca0d41b47bb59d36cebb1d2a9db7c8278b" serial="NWLE" />
 	</game>
-	<game name="War Gods (Europe)">
+	<game name="War Gods (Europe)" id="0818">
 		<description>War Gods (Europe)</description>
 		<rom name="War Gods (Europe).n64" />
-		<release name="War Gods (Europe)" region="EUR" />
-		<rom name="War Gods (Europe).z64" size="12582912" crc="c73010c8" md5="d25dd15903bdcb7724a2e8a02561987f" sha1="c9bdd7e5af853135fc4cbd72e461fc227f7498e3" />
+		<rom name="War Gods (Europe).z64" size="12582912" crc="c73010c8" md5="d25dd15903bdcb7724a2e8a02561987f" sha1="c9bdd7e5af853135fc4cbd72e461fc227f7498e3" sha256="f6a18d9691aecf0e3491b8dfa67cd83d23464d026d9cb03809ab0b980f21f54f" status="verified" serial="NWAP" />
 	</game>
-	<game name="War Gods (USA)" cloneof="War Gods (Europe)">
+	<game name="War Gods (USA)" id="0819" cloneofid="0818">
 		<description>War Gods (USA)</description>
 		<rom name="War Gods (USA).n64" />
-		<release name="War Gods (USA)" region="USA" />
-		<rom name="War Gods (USA).z64" size="12582912" crc="ffacf993" md5="9ff2ba3c8408de9f0edb6d764a97c197" sha1="829c4f0f1caa72a2fbabaee5651e2acc695d3921" />
+		<rom name="War Gods (USA).z64" size="12582912" crc="ffacf993" md5="9ff2ba3c8408de9f0edb6d764a97c197" sha1="829c4f0f1caa72a2fbabaee5651e2acc695d3921" sha256="7247b79c49474c468e448b5ba58a28f8d1556139bfd08fb19770fad3db8b25f6" status="verified" serial="NWAE" />
 	</game>
-	<game name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
+	<game name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)" id="0820">
 		<description>Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)</description>
 		<rom name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De).n64" />
-		<release name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)" region="EUR" />
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De).z64" size="8388608" crc="fb289893" md5="310659115e9939f219a783abdd456ce9" sha1="c20aa97dc25aec7a9b9c6889286bbd216fc7caa4" status="verified" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De).z64" size="8388608" crc="fb289893" md5="310659115e9939f219a783abdd456ce9" sha1="c20aa97dc25aec7a9b9c6889286bbd216fc7caa4" sha256="8897da0cb6e286659ac4d72c5737f6fe97a51bcdfc6e2328ae7dfc0715bf1761" status="verified" serial="NWRP" />
 	</game>
-	<game name="Shuishang Motuo (China) (iQue)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
-		<description>Shuishang Motuo (China) (iQue)</description>
-		<rom name="Shuishang Motuo (China) (iQue).n64" />
-		<rom name="Shuishang Motuo (China) (iQue).z64" size="8159232" crc="30f45e87" md5="1f83663b2c84512fc3706a6cacc1a9f3" sha1="19c2e84440ebec5b6a349ec96cdc629e03491a19" />
-	</game>
-	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
+	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan)" id="0821" cloneofid="0820">
 		<description>Wave Race 64 - Kawasaki Jet Ski (Japan)</description>
 		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan).n64" />
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan).z64" size="8388608" crc="6c93ff83" md5="b32e555bc1a375256e8a4021a25339be" sha1="05d40e57c9cb29a8992595afdde6653936e16729" status="verified" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan).z64" size="8388608" crc="6c93ff83" md5="b32e555bc1a375256e8a4021a25339be" sha1="05d40e57c9cb29a8992595afdde6653936e16729" status="verified" serial="NWRJ" />
 	</game>
-	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
+	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition)" id="0822" cloneofid="0820">
 		<description>Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition)</description>
 		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition).n64" />
-		<release name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition)" region="JPN" />
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition).z64" size="8388608" crc="90044c4b" md5="ff67df97476c210d158779ae6142f239" sha1="445ecb4904cc0ab6b81fb415a35072e99f18b545" status="verified" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition).z64" size="8388608" crc="90044c4b" md5="ff67df97476c210d158779ae6142f239" sha1="445ecb4904cc0ab6b81fb415a35072e99f18b545" sha256="c53b79a5e6014b5e03b016fadbd5c493270162c17c9624530fc726ea5e3f7b81" serial="NWRJ" />
 	</game>
-	<game name="Wave Race 64 - Kawasaki Jet Ski (USA)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
+	<game name="Wave Race 64 - Kawasaki Jet Ski (USA)" id="0823" cloneofid="0820">
 		<description>Wave Race 64 - Kawasaki Jet Ski (USA)</description>
 		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA).n64" />
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA).z64" size="8388608" crc="74a7b725" md5="ae480013f39d4aec86eea1b4995600d1" sha1="887ab588c2ecc64c52fb2065f06b0a1ee4af13dc" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA).z64" size="8388608" crc="74a7b725" md5="ae480013f39d4aec86eea1b4995600d1" sha1="887ab588c2ecc64c52fb2065f06b0a1ee4af13dc" serial="NWRE" />
 	</game>
-	<game name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
+	<game name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1)" id="0824" cloneofid="0820">
 		<description>Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1)</description>
 		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1).n64" />
-		<release name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1)" region="USA" />
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1).z64" size="8388608" crc="394948c4" md5="2048a640c12d1cf2052ba1629937d2ff" sha1="508dfc2d4caa42b6f6de5263d0aed5e44ac7966a" status="verified" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1).z64" size="8388608" crc="394948c4" md5="2048a640c12d1cf2052ba1629937d2ff" sha1="508dfc2d4caa42b6f6de5263d0aed5e44ac7966a" sha256="f35d2423ebcb86eaf86fa935b613c7532b123a7bc50fb74996984c3b02fc3999" status="verified" serial="NWRE" />
 	</game>
-	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
+	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1)" id="0886" cloneofid="0820">
 		<description>Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1)</description>
 		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1).n64" />
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1).z64" size="8388608" crc="54d190a8" md5="d05c6f3caf9059b306cc13535e2a8ba6" sha1="4b6cd84b40dd2f4fbe55c6e10f298f33f9184a9a" status="verified" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1).z64" size="8388608" crc="54d190a8" md5="d05c6f3caf9059b306cc13535e2a8ba6" sha1="4b6cd84b40dd2f4fbe55c6e10f298f33f9184a9a" status="verified" serial="NWRJ" />
 	</game>
-	<game name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)">
+	<game name="Wave Race 64 - Kawasaki Jet Ski (USA) (LodgeNet)" id="1164" cloneofid="0820">
+		<category>Games</category>
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (LodgeNet).n64" />
+		<description>Wave Race 64 - Kawasaki Jet Ski (USA) (LodgeNet)</description>
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (LodgeNet).i64" size="64" crc="7940a187" md5="dcabfa22f0c6231ddc85f8978cb1640d" sha1="7954964efb9f8cbba9d1385c2a24007714cd5966" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (LodgeNet).z64" size="8388608" crc="6def22dc" md5="365ac892b951eed7b227f4a200b7ea53" sha1="895c70d2280d5d6cc0bd7013a135c21b688f9f80" />
+	</game>
+	<game name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)" id="0827">
 		<description>Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)</description>
 		<rom name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es).n64" />
-		<release name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es).z64" size="8388608" crc="442a4f5f" md5="319816aaa30e512827be7b7f81f80d86" sha1="d9a6ba9a6e75a198e995af3c4c81f4cfb3830c64" status="verified" />
+		<rom name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es).z64" size="8388608" crc="442a4f5f" md5="319816aaa30e512827be7b7f81f80d86" sha1="d9a6ba9a6e75a198e995af3c4c81f4cfb3830c64" sha256="8a4bda81962af21548c70f6c239290e03ed5fe7492ed6e1074ba002aa631dd89" status="verified" serial="NWGP" />
 	</game>
-	<game name="Wayne Gretzky's 3D Hockey (Japan)" cloneof="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)">
+	<game name="Wayne Gretzky's 3D Hockey (Japan)" id="0828" cloneofid="0827">
 		<description>Wayne Gretzky's 3D Hockey (Japan)</description>
 		<rom name="Wayne Gretzky's 3D Hockey (Japan).n64" />
-		<release name="Wayne Gretzky's 3D Hockey (Japan)" region="JPN" />
-		<rom name="Wayne Gretzky's 3D Hockey (Japan).z64" size="8388608" crc="485275ed" md5="61e637b542d5df178040454075c28e19" sha1="d8edc3b462bf80b48c98fb36032b8aca95164055" />
+		<rom name="Wayne Gretzky's 3D Hockey (Japan).z64" size="8388608" crc="485275ed" md5="61e637b542d5df178040454075c28e19" sha1="d8edc3b462bf80b48c98fb36032b8aca95164055" serial="NWGJ" />
 	</game>
-	<game name="Wayne Gretzky's 3D Hockey (USA)" cloneof="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)">
+	<game name="Wayne Gretzky's 3D Hockey (USA)" id="0829" cloneofid="0827">
 		<description>Wayne Gretzky's 3D Hockey (USA)</description>
 		<rom name="Wayne Gretzky's 3D Hockey (USA).n64" />
-		<rom name="Wayne Gretzky's 3D Hockey (USA).z64" size="8388608" crc="9781f88d" md5="6df0d6259261d0096c90bbc6aa037d8e" sha1="400aa84811f1f2f6c62c756b43b54d534d5a5ec8" />
+		<rom name="Wayne Gretzky's 3D Hockey (USA).z64" size="8388608" crc="9781f88d" md5="6df0d6259261d0096c90bbc6aa037d8e" sha1="400aa84811f1f2f6c62c756b43b54d534d5a5ec8" serial="NWGE" />
 	</game>
-	<game name="Wayne Gretzky's 3D Hockey (USA) (Rev 1)" cloneof="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)">
+	<game name="Wayne Gretzky's 3D Hockey (USA) (Rev 1)" id="0830" cloneofid="0827">
 		<description>Wayne Gretzky's 3D Hockey (USA) (Rev 1)</description>
 		<rom name="Wayne Gretzky's 3D Hockey (USA) (Rev 1).n64" />
-		<release name="Wayne Gretzky's 3D Hockey (USA) (Rev 1)" region="USA" />
-		<rom name="Wayne Gretzky's 3D Hockey (USA) (Rev 1).z64" size="8388608" crc="c2678971" md5="04e650b7742a69dae98f125d1b492d78" sha1="91f33097c5da2c3480e0a9f04f7463cea16b176b" />
+		<rom name="Wayne Gretzky's 3D Hockey (USA) (Rev 1).z64" size="8388608" crc="c2678971" md5="04e650b7742a69dae98f125d1b492d78" sha1="91f33097c5da2c3480e0a9f04f7463cea16b176b" serial="NWGE" />
 	</game>
-	<game name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)">
+	<game name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)" id="0825">
 		<description>Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)</description>
 		<rom name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es).n64" />
-		<release name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)" region="EUR" />
-		<rom name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es).z64" size="8388608" crc="6f6dc53d" md5="24a0d8c8cabc22116e469476ff6c691d" sha1="3eb1a78c0480af0cc6f2180f87260790c37367d0" />
+		<rom name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es).z64" size="8388608" crc="6f6dc53d" md5="24a0d8c8cabc22116e469476ff6c691d" sha1="3eb1a78c0480af0cc6f2180f87260790c37367d0" sha256="8d772114b3511a65c586145035d90ef5bc44ba691bf65304fbb581b41df1f19f" status="verified" serial="NW8P" />
 	</game>
-	<game name="Wayne Gretzky's 3D Hockey '98 (USA)" cloneof="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)">
+	<game name="Wayne Gretzky's 3D Hockey '98 (USA)" id="0826" cloneofid="0825">
 		<description>Wayne Gretzky's 3D Hockey '98 (USA)</description>
 		<rom name="Wayne Gretzky's 3D Hockey '98 (USA).n64" />
-		<release name="Wayne Gretzky's 3D Hockey '98 (USA)" region="USA" />
-		<rom name="Wayne Gretzky's 3D Hockey '98 (USA).z64" size="8388608" crc="355fb089" md5="810f8bc2c8c66bda3b206c7dd4b6d42f" sha1="1af0be9568f8ace865d5cf76fd241da741154b0f" />
+		<rom name="Wayne Gretzky's 3D Hockey '98 (USA).z64" size="8388608" crc="355fb089" md5="810f8bc2c8c66bda3b206c7dd4b6d42f" sha1="1af0be9568f8ace865d5cf76fd241da741154b0f" sha256="7dbcc38d473efaf9c524274dcbd3cbd267d2d43e65c674c667c3843622bd726a" serial="NW8E" />
 	</game>
-	<game name="WCW Backstage Assault (USA)">
+	<game name="WCW Backstage Assault (USA)" id="0831">
 		<description>WCW Backstage Assault (USA)</description>
 		<rom name="WCW Backstage Assault (USA).n64" />
-		<release name="WCW Backstage Assault (USA)" region="USA" />
-		<rom name="WCW Backstage Assault (USA).z64" size="33554432" crc="5dcc2e4e" md5="02aed169eb579494ace75d22e10d789b" sha1="34f793d55770d5eb112cff0e28cb0a35e0ec7385" />
+		<rom name="WCW Backstage Assault (USA).z64" size="33554432" crc="5dcc2e4e" md5="02aed169eb579494ace75d22e10d789b" sha1="34f793d55770d5eb112cff0e28cb0a35e0ec7385" serial="NWVE" />
 	</game>
-	<game name="WCW Mayhem (Europe)">
+	<game name="WCW Mayhem (Europe)" id="0832">
 		<description>WCW Mayhem (Europe)</description>
 		<rom name="WCW Mayhem (Europe).n64" />
-		<release name="WCW Mayhem (Europe)" region="EUR" />
-		<rom name="WCW Mayhem (Europe).z64" size="16777216" crc="864e066e" md5="9e943752bcf4fba9ca3028e596f4eb4a" sha1="594b273ee9d6e174cfd9b33d4fd6aa86cd3e2442" />
+		<rom name="WCW Mayhem (Europe).z64" size="16777216" crc="864e066e" md5="9e943752bcf4fba9ca3028e596f4eb4a" sha1="594b273ee9d6e174cfd9b33d4fd6aa86cd3e2442" sha256="d8c97d05f5050636a5756ddac73d1983ab636544f996a6a5d3dd5d15a14339b2" status="verified" serial="NWMP" />
 	</game>
-	<game name="WCW Mayhem (USA)" cloneof="WCW Mayhem (Europe)">
+	<game name="WCW Mayhem (USA)" id="0833" cloneofid="0832">
 		<description>WCW Mayhem (USA)</description>
 		<rom name="WCW Mayhem (USA).n64" />
-		<release name="WCW Mayhem (USA)" region="USA" />
-		<rom name="WCW Mayhem (USA).z64" size="16777216" crc="f1f9b6eb" md5="87bf3784709cd09693cd7bcc08460c63" sha1="83382ee31db3dccd598d8af55607e70db1bcbbb6" />
+		<rom name="WCW Mayhem (USA).z64" size="16777216" crc="f1f9b6eb" md5="87bf3784709cd09693cd7bcc08460c63" sha1="83382ee31db3dccd598d8af55607e70db1bcbbb6" serial="NWME" />
 	</game>
-	<game name="WCW Nitro (USA)">
+	<game name="WCW Nitro (USA)" id="0834">
 		<description>WCW Nitro (USA)</description>
 		<rom name="WCW Nitro (USA).n64" />
-		<release name="WCW Nitro (USA)" region="USA" />
-		<rom name="WCW Nitro (USA).z64" size="12582912" crc="455b0830" md5="1e9fead701fe5aaaa248d4713891775d" sha1="1f3b1a9e348506ae3d2a79216b0bc6e69d04a4f9" />
+		<rom name="WCW Nitro (USA).z64" size="12582912" crc="455b0830" md5="1e9fead701fe5aaaa248d4713891775d" sha1="1f3b1a9e348506ae3d2a79216b0bc6e69d04a4f9" serial="NW3E" />
 	</game>
-	<game name="WCW vs. nWo - World Tour (Europe)">
+	<game name="WCW vs. nWo - World Tour (Europe)" id="0836">
 		<description>WCW vs. nWo - World Tour (Europe)</description>
 		<rom name="WCW vs. nWo - World Tour (Europe).n64" />
-		<release name="WCW vs. nWo - World Tour (Europe)" region="EUR" />
-		<rom name="WCW vs. nWo - World Tour (Europe).z64" size="12582912" crc="37f358eb" md5="553d8d5347969c66e5d91c3fe35208b9" sha1="840b8b6303acaceb49619eb1533cb4221cdec474" />
+		<rom name="WCW vs. nWo - World Tour (Europe).z64" size="12582912" crc="37f358eb" md5="553d8d5347969c66e5d91c3fe35208b9" sha1="840b8b6303acaceb49619eb1533cb4221cdec474" sha256="177b179b78c86b97ac5ee21d7eed543ddd1a1a71a41d74adcb4c7bbdfff5f479" status="verified" serial="NWNP" />
 	</game>
-	<game name="WCW vs. nWo - World Tour (USA)" cloneof="WCW vs. nWo - World Tour (Europe)">
+	<game name="WCW vs. nWo - World Tour (USA)" id="0837" cloneofid="0836">
 		<description>WCW vs. nWo - World Tour (USA)</description>
 		<rom name="WCW vs. nWo - World Tour (USA).n64" />
-		<rom name="WCW vs. nWo - World Tour (USA).z64" size="12582912" crc="dfbfc61f" md5="203c3bbfdd10c5a0b7c5d0cdb085d853" sha1="5ad2d8359058c8bb71f08e3d3433b7a50d3bb645" />
+		<rom name="WCW vs. nWo - World Tour (USA).z64" size="12582912" crc="dfbfc61f" md5="203c3bbfdd10c5a0b7c5d0cdb085d853" sha1="5ad2d8359058c8bb71f08e3d3433b7a50d3bb645" sha256="852dc6478e55c13da60080c1ed468ecf6aa2f370c1bb8ba16720622fa931763a" serial="NWNE" />
 	</game>
-	<game name="WCW vs. nWo - World Tour (USA) (Rev 1)" cloneof="WCW vs. nWo - World Tour (Europe)">
+	<game name="WCW vs. nWo - World Tour (USA) (Rev 1)" id="0838" cloneofid="0836">
 		<description>WCW vs. nWo - World Tour (USA) (Rev 1)</description>
 		<rom name="WCW vs. nWo - World Tour (USA) (Rev 1).n64" />
-		<release name="WCW vs. nWo - World Tour (USA) (Rev 1)" region="USA" />
-		<rom name="WCW vs. nWo - World Tour (USA) (Rev 1).z64" size="12582912" crc="a74da07a" md5="b7a220b59303d47f3beae233ca868cfd" sha1="60814fb3ad2dd206badbeee47c07636357dd0d7e" />
+		<rom name="WCW vs. nWo - World Tour (USA) (Rev 1).z64" size="12582912" crc="a74da07a" md5="b7a220b59303d47f3beae233ca868cfd" sha1="60814fb3ad2dd206badbeee47c07636357dd0d7e" serial="NWNE" />
 	</game>
-	<game name="WCW-nWo Revenge (Europe)">
+	<game name="WCW-nWo Revenge (Europe)" id="0839">
 		<description>WCW-nWo Revenge (Europe)</description>
 		<rom name="WCW-nWo Revenge (Europe).n64" />
-		<release name="WCW-nWo Revenge (Europe)" region="EUR" />
-		<rom name="WCW-nWo Revenge (Europe).z64" size="16777216" crc="8af0f964" md5="30c6676ec1d62122f4e7607ef3abbd41" sha1="c59315a3e7a6e8124495477656a77e4619dac104" />
+		<rom name="WCW-nWo Revenge (Europe).z64" size="16777216" crc="8af0f964" md5="30c6676ec1d62122f4e7607ef3abbd41" sha1="c59315a3e7a6e8124495477656a77e4619dac104" sha256="e4bd4f49d6e2217294cd2f9178488349eabd44155e4ad0436a9d1ddef58c53da" status="verified" serial="NW2P" />
 	</game>
-	<game name="WCW-nWo Revenge (USA)" cloneof="WCW-nWo Revenge (Europe)">
+	<game name="WCW-nWo Revenge (USA)" id="0840" cloneofid="0839">
 		<description>WCW-nWo Revenge (USA)</description>
 		<rom name="WCW-nWo Revenge (USA).n64" />
-		<release name="WCW-nWo Revenge (USA)" region="USA" />
-		<rom name="WCW-nWo Revenge (USA).z64" size="16777216" crc="54cbaaa8" md5="c1384f3637d7a381b29341fed3ef3ceb" sha1="e1711a2511394b9357b5f1ac8ca5cc17bd674836" />
+		<rom name="WCW-nWo Revenge (USA).z64" size="16777216" crc="54cbaaa8" md5="c1384f3637d7a381b29341fed3ef3ceb" sha1="e1711a2511394b9357b5f1ac8ca5cc17bd674836" sha256="66c137d326565c6f31f992daba8f67c0aee7f025a142dd249d27019708014b60" status="verified" serial="NW2E" />
 	</game>
-	<game name="Wetrix (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Wetrix (Europe) (En,Fr,De,Es,It,Nl)" id="0841">
 		<description>Wetrix (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Wetrix (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Wetrix (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Wetrix (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="eddc5b06" md5="a99e2cb6acef7a004961de5f6dfeeff0" sha1="4cc1b6e3aa150cd79093f21e3fbe91a72fb86ad6" />
+		<rom name="Wetrix (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="eddc5b06" md5="a99e2cb6acef7a004961de5f6dfeeff0" sha1="4cc1b6e3aa150cd79093f21e3fbe91a72fb86ad6" sha256="17d5917ec3235e9e8aff54201d78bd01aa36377f81ac133ed0248d8ab1c61de5" status="verified" serial="NWTP" />
 	</game>
-	<game name="Wetrix (Japan)" cloneof="Wetrix (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Wetrix (Japan)" id="0842" cloneofid="0841">
 		<description>Wetrix (Japan)</description>
 		<rom name="Wetrix (Japan).n64" />
-		<release name="Wetrix (Japan)" region="JPN" />
-		<rom name="Wetrix (Japan).z64" size="4194304" crc="bad08218" md5="e8997bf5662540b184fbf8277d260984" sha1="1b1635546cb973ebaa0a4a0940a363ec2c074053" />
+		<rom name="Wetrix (Japan).z64" size="4194304" crc="bad08218" md5="e8997bf5662540b184fbf8277d260984" sha1="1b1635546cb973ebaa0a4a0940a363ec2c074053" sha256="799b8544502af901572ca54e210c082280f57695b538ed6c3a87cccefe840522" status="verified" serial="NWTJ" />
 	</game>
-	<game name="Wetrix (USA) (En,Fr,De,Es,It,Nl)" cloneof="Wetrix (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Wetrix (USA) (En,Fr,De,Es,It,Nl)" id="0843" cloneofid="0841">
 		<description>Wetrix (USA) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Wetrix (USA) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Wetrix (USA) (En,Fr,De,Es,It,Nl)" region="USA" />
-		<rom name="Wetrix (USA) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="50cd1f71" md5="6e81d3056e409208e4af2d39a2ff0f03" sha1="6e40312cf88a9182e93b396b9d82457b1aba7cd6" />
+		<rom name="Wetrix (USA) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="50cd1f71" md5="6e81d3056e409208e4af2d39a2ff0f03" sha1="6e40312cf88a9182e93b396b9d82457b1aba7cd6" sha256="790f36a3ddd64e4dcd08c479b0b66f9080d0191473e92fa895f53d15706167bb" status="verified" serial="NWTE" />
 	</game>
-	<game name="Wheel of Fortune (USA)">
+	<game name="Whack 'n' Roll (USA) (v0.8.2) (Beta) (1998-02-05)" id="1051" cloneofid="0265">
+		<description>Whack 'n' Roll (USA) (v0.8.2) (Beta) (1998-02-05)</description>
+		<rom name="Whack 'n' Roll (USA) (v0.8.2) (Beta) (1998-02-05).n64" />
+		<rom name="Whack 'n' Roll (USA) (v0.8.2) (Beta) (1998-02-05).z64" size="3823288" crc="74df67bb" md5="aab9c595a91b9f26e12cae2ff2649881" sha1="1d8f3b0cc37dc357cddc8075fc749bc7d66b5331" sha256="ff781fc0998e8cff0e76d576ce77ebee7420c43765187f54400161195f07b323" serial="!none" />
+	</game>
+	<game name="Wheel of Fortune (USA)" id="0844">
 		<description>Wheel of Fortune (USA)</description>
 		<rom name="Wheel of Fortune (USA).n64" />
-		<release name="Wheel of Fortune (USA)" region="USA" />
-		<rom name="Wheel of Fortune (USA).z64" size="4194304" crc="8d3efa8d" md5="2abe36754e866b9b6c4bdcffc1d11abf" sha1="b51b28660699bf029f862f51c319a5962fe9de9b" />
+		<rom name="Wheel of Fortune (USA).z64" size="4194304" crc="8d3efa8d" md5="2abe36754e866b9b6c4bdcffc1d11abf" sha1="b51b28660699bf029f862f51c319a5962fe9de9b" sha256="5da09844f1f63270830836c42787046d48d72c125a50ae91d46327a93a25e383" serial="NWFE" />
 	</game>
-	<game name="Wildwaters (USA) (Proto) (1999-06-15)">
-		<description>Wildwaters (USA) (Proto) (1999-06-15)</description>
-		<rom name="Wildwaters (USA) (Proto) (1999-06-15).n64" />
-		<release name="Wildwaters (USA) (Proto) (1999-06-15)" region="USA" />
-		<rom name="Wildwaters (USA) (Proto) (1999-06-15).z64" size="16777216" crc="40443c67" md5="b867880c96c9e8d3130dde5526c95439" sha1="3ff76b30a9179f1ac116cc04d560ce333db443af" />
+	<game name="Wide-Boy64 AGB (World) (v0.00b) (Beta)" id="1126" cloneofid="1128">
+		<category>Applications</category>
+		<rom name="Wide-Boy64 AGB (World) (v0.00b) (Beta).n64" />
+		<description>Wide-Boy64 AGB (World) (v0.00b) (Beta)</description>
+		<rom name="Wide-Boy64 AGB (World) (v0.00b) (Beta).z64" size="4194304" crc="39c3a534" md5="1708e096772201a5cd6e085c79cb194c" sha1="9980e316e985aac8a04ec589622957692d1d84c9" sha256="9e56f37b24f149bd752a27dd581b418a70b3754f2fb9bb1b218afcdffbfe2c28" serial="!none" />
 	</game>
-	<game name="Wipeout 64 (Europe)">
+	<game name="Wide-Boy64 AGB (World) (v0.02c)" id="1128">
+		<description>Wide-Boy64 AGB (World) (v0.02c)</description>
+		<rom name="Wide-Boy64 AGB (World) (v0.02c).n64" />
+		<rom name="Wide-Boy64 AGB (World) (v0.02c).z64" size="4194304" crc="47a12d39" md5="20897007193c2ac449ebc98084354988" sha1="e23a60306490f49444297afc1cf685e5ec20dd11" sha256="e342bb94e57deaaa7a438acb01e34cdcdd1126251aeafb5061e30210bcbbe61b" />
+	</game>
+	<game name="Wide-Boy64 AGB (World) (v0.04c)" id="1129" cloneofid="1128">
+		<description>Wide-Boy64 AGB (World) (v0.04c)</description>
+		<rom name="Wide-Boy64 AGB (World) (v0.04c).n64" />
+		<rom name="Wide-Boy64 AGB (World) (v0.04c).z64" size="4194304" crc="2f681410" md5="dddaecedbdea61182efb30adc217baf2" sha1="f5d4908c141f55bf4aff6d21e8f4d514310dd26e" sha256="41e9dec235448a9fd983930997ae229921ce779ef22f0a9cd75620ab6ea693f8" />
+	</game>
+	<game name="Wide-Boy64 CGB (World) (v1.02)" id="1130">
+		<description>Wide-Boy64 CGB (World) (v1.02)</description>
+		<rom name="Wide-Boy64 CGB (World) (v1.02).n64" />
+		<rom name="Wide-Boy64 CGB (World) (v1.02).z64" size="4194304" crc="ab9f83de" md5="e529b3c207db945e9631faf231964cc7" sha1="7c5771ae6f1b54ae46adc7fd50bb9c187c836eb5" sha256="bec59ebd23fad5906f9dfb2ddab06a64c843752b5002993cdeea8a011bb3fc56" />
+	</game>
+	<game name="Wild Choppers (Japan)" id="0845" cloneofid="0126">
+		<description>Wild Choppers (Japan)</description>
+		<rom name="Wild Choppers (Japan).n64" />
+		<rom name="Wild Choppers (Japan).z64" size="8388608" crc="d6136dc5" md5="f85f2a2b6ca64898f0add2a78ccdccf3" sha1="9ed151fce580f875f09cb250d2bb9c18c8d549c0" serial="NWCJ" />
+	</game>
+	<game name="Wildwaters (USA) (1999-06-15) (Proto)" id="0921">
+		<description>Wildwaters (USA) (1999-06-15) (Proto)</description>
+		<rom name="Wildwaters (USA) (1999-06-15) (Proto).n64" />
+		<rom name="Wildwaters (USA) (1999-06-15) (Proto).z64" size="16777216" crc="40443c67" md5="b867880c96c9e8d3130dde5526c95439" sha1="3ff76b30a9179f1ac116cc04d560ce333db443af" />
+	</game>
+	<game name="WinBack (Japan)" id="0846" cloneofid="0534">
+		<description>WinBack (Japan)</description>
+		<rom name="WinBack (Japan).n64" />
+		<rom name="WinBack (Japan).z64" size="16777216" crc="d35360b0" md5="ee3d3550acc463ca57408bf14e541f68" sha1="d6db9e2509b760403f5db330142055af842fb52c" serial="NWDJ" />
+	</game>
+	<game name="WinBack (Japan) (Rev 1)" id="0901" cloneofid="0534">
+		<description>WinBack (Japan) (Rev 1)</description>
+		<rom name="WinBack (Japan) (Rev 1).n64" />
+		<rom name="WinBack (Japan) (Rev 1).z64" size="16777216" crc="927383bb" md5="9789a48e1d9e42c2f69c59964371089f" sha1="660f8778bc816046e1bcc11e1a975fed5db17410" serial="NWDJ" />
+	</game>
+	<game name="WinBack - Covert Operations (USA)" id="0847" cloneofid="0534">
+		<description>WinBack - Covert Operations (USA)</description>
+		<rom name="WinBack - Covert Operations (USA).n64" />
+		<rom name="WinBack - Covert Operations (USA).z64" size="16777216" crc="64c817c5" md5="48da6cdcab838153caa2ecc3dd592a65" sha1="fa04477b321a95e1f7a2edcac5c09bfa6ef72041" serial="NWDE" />
+	</game>
+	<game name="Wipeout 64 (Europe)" id="0848">
 		<description>Wipeout 64 (Europe)</description>
 		<rom name="Wipeout 64 (Europe).n64" />
-		<release name="Wipeout 64 (Europe)" region="EUR" />
-		<rom name="Wipeout 64 (Europe).z64" size="8388608" crc="38111048" md5="5783373634b11f81c86908c3d81ca988" sha1="3eef8ec7d0009ee67d604aaca2bb61b7397ba862" status="verified" />
+		<rom name="Wipeout 64 (Europe).z64" size="8388608" crc="38111048" md5="5783373634b11f81c86908c3d81ca988" sha1="3eef8ec7d0009ee67d604aaca2bb61b7397ba862" status="verified" serial="NWPP" />
 	</game>
-	<game name="Wipeout 64 (USA)" cloneof="Wipeout 64 (Europe)">
+	<game name="Wipeout 64 (USA)" id="0849" cloneofid="0848">
 		<description>Wipeout 64 (USA)</description>
 		<rom name="Wipeout 64 (USA).n64" />
-		<release name="Wipeout 64 (USA)" region="USA" />
-		<rom name="Wipeout 64 (USA).z64" size="8388608" crc="4888d0fe" md5="73c6d87dbe50f73f3b44e0f237a546d7" sha1="54e4795aba4fc326f79d0703ffdb51a212dd4b5c" />
+		<rom name="Wipeout 64 (USA).z64" size="8388608" crc="4888d0fe" md5="73c6d87dbe50f73f3b44e0f237a546d7" sha1="54e4795aba4fc326f79d0703ffdb51a212dd4b5c" sha256="fdcf4ae70d90abef4f299b04664e009a967e55f97a065b43f596b749dd7d6b15" status="verified" serial="NWPE" />
 	</game>
-	<game name="Wipeout 64 (Europe) (Beta)" cloneof="Wipeout 64 (Europe)">
+	<game name="Wipeout 64 (Europe) (Beta)" id="1019" cloneofid="0848">
 		<description>Wipeout 64 (Europe) (Beta)</description>
 		<rom name="Wipeout 64 (Europe) (Beta).n64" />
-		<rom name="Wipeout 64 (Europe) (Beta).z64" size="16777216" crc="944b258f" md5="7260da1cecd0d8844c5e29aa63476def" sha1="a05a1f4c9f4ee67159db0cd15c37e05f255d35d0" />
+		<rom name="Wipeout 64 (Europe) (Beta).z64" size="16777216" crc="944b258f" md5="7260da1cecd0d8844c5e29aa63476def" sha1="a05a1f4c9f4ee67159db0cd15c37e05f255d35d0" serial="NWPP" />
 	</game>
-	<game name="Wonder Project J2 - Koruro no Mori no Jozet (Japan)">
+	<game name="Wonder Project J2 - Koruro no Mori no Jozet (Japan)" id="0850">
 		<description>Wonder Project J2 - Koruro no Mori no Jozet (Japan)</description>
 		<rom name="Wonder Project J2 - Koruro no Mori no Jozet (Japan).n64" />
-		<release name="Wonder Project J2 - Koruro no Mori no Jozet (Japan)" region="JPN" />
-		<rom name="Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size="8388608" crc="5e8fc436" md5="0ff1f8628d8fe69582db54572d2bea79" sha1="3a311ec0d77d4e0fc425a99cb6b9416f072e268e" status="verified" />
+		<rom name="Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size="8388608" crc="5e8fc436" md5="0ff1f8628d8fe69582db54572d2bea79" sha1="3a311ec0d77d4e0fc425a99cb6b9416f072e268e" status="verified" serial="NJ2J" />
 	</game>
-	<game name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)">
+	<game name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)" id="0851">
 		<description>World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)</description>
 		<rom name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).n64" />
-		<release name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)" region="EUR" />
-		<rom name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).z64" size="12582912" crc="79f483f7" md5="3aa263aca66f3a07bb081b575d66deeb" sha1="cd92b2cbb253411fc66544649567d9b1c44bb210" />
+		<rom name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).z64" size="12582912" crc="79f483f7" md5="3aa263aca66f3a07bb081b575d66deeb" sha1="cd92b2cbb253411fc66544649567d9b1c44bb210" sha256="8f99290db186f35b4dd96562edc12138146157df5f48ca4b389a8cef1afe7a49" status="verified" serial="N8WP" />
 	</game>
-	<game name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)" cloneof="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)">
+	<game name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)" id="0852" cloneofid="0851">
 		<description>World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)</description>
 		<rom name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da).n64" />
-		<release name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)" region="USA" />
-		<rom name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da).z64" size="12582912" crc="13930c26" md5="4bef5e9aa9e71205dac1a7060e778235" sha1="b496edee84e5e84ead8da6f57a765936b2af2f9f" />
+		<rom name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da).z64" size="12582912" crc="13930c26" md5="4bef5e9aa9e71205dac1a7060e778235" sha1="b496edee84e5e84ead8da6f57a765936b2af2f9f" sha256="45f7895bbf19f4f0c0b41e6a32f847236aef08b85d49b8475357ea846c717daa" serial="N8WE" />
 	</game>
-	<game name="World Driver Championship (Europe) (En,Fr,De,Es,It)">
+	<game name="World Driver Championship (Europe) (En,Fr,De,Es,It)" id="0853">
 		<description>World Driver Championship (Europe) (En,Fr,De,Es,It)</description>
 		<rom name="World Driver Championship (Europe) (En,Fr,De,Es,It).n64" />
-		<release name="World Driver Championship (Europe) (En,Fr,De,Es,It)" region="EUR" />
-		<rom name="World Driver Championship (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="76151df6" md5="431de8f6611a8131b536f0ede1f330d9" sha1="7b054d1580cc263429eb6961ad6ed6e0140e1df0" />
+		<rom name="World Driver Championship (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="76151df6" md5="431de8f6611a8131b536f0ede1f330d9" sha1="7b054d1580cc263429eb6961ad6ed6e0140e1df0" sha256="535c6b9430f74e36e1347f20e656eeb662af699c40a868e1d4a6bdd3c577f7d4" status="verified" serial="NWOP" />
 	</game>
-	<game name="World Driver Championship (USA)" cloneof="World Driver Championship (Europe) (En,Fr,De,Es,It)">
+	<game name="World Driver Championship (USA)" id="0854" cloneofid="0853">
 		<description>World Driver Championship (USA)</description>
 		<rom name="World Driver Championship (USA).n64" />
-		<release name="World Driver Championship (USA)" region="USA" />
-		<rom name="World Driver Championship (USA).z64" size="16777216" crc="5e4acbfa" md5="7c567a5bb1ad4cbe414fb6bbff66e336" sha1="93227776f59b42e9fb1c942eba9d5b465eeb3979" />
+		<rom name="World Driver Championship (USA).z64" size="16777216" crc="5e4acbfa" md5="7c567a5bb1ad4cbe414fb6bbff66e336" sha1="93227776f59b42e9fb1c942eba9d5b465eeb3979" serial="NWOE" />
 	</game>
-	<game name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)" id="0855">
 		<description>Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)</description>
 		<rom name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl).n64" />
-		<release name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
-		<rom name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="6bfff27b" md5="44fc2a7f028f0b6f71b255f672c8b495" sha1="34042046e3cfa44723c32f6d366052483edb80d7" />
+		<rom name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="6bfff27b" md5="44fc2a7f028f0b6f71b255f672c8b495" sha1="34042046e3cfa44723c32f6d366052483edb80d7" sha256="d79ebabeef2d0a913c910497e73bf7d188c012fd578ec66a855d7bdbaa6d5bdc" status="verified" serial="NWUP" />
 	</game>
-	<game name="Worms Armageddon (USA) (En,Fr,Es)" cloneof="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)">
+	<game name="Worms Armageddon (USA) (En,Fr,Es)" id="0856" cloneofid="0855">
 		<description>Worms Armageddon (USA) (En,Fr,Es)</description>
 		<rom name="Worms Armageddon (USA) (En,Fr,Es).n64" />
-		<release name="Worms Armageddon (USA) (En,Fr,Es)" region="USA" />
-		<rom name="Worms Armageddon (USA) (En,Fr,Es).z64" size="12582912" crc="5471ae3b" md5="491d4db6718302489bf05fb962c73651" sha1="3b17b36ba91737b86aa56ecb1b48a89444b53572" />
+		<rom name="Worms Armageddon (USA) (En,Fr,Es).z64" size="12582912" crc="5471ae3b" md5="491d4db6718302489bf05fb962c73651" sha1="3b17b36ba91737b86aa56ecb1b48a89444b53572" serial="NADE" />
 	</game>
-	<game name="WWF Attitude (Europe)">
+	<game name="WWF Attitude (Europe)" id="0857">
 		<description>WWF Attitude (Europe)</description>
 		<rom name="WWF Attitude (Europe).n64" />
-		<release name="WWF Attitude (Europe)" region="EUR" />
-		<rom name="WWF Attitude (Europe).z64" size="33554432" crc="804fe494" md5="3fdb2e5f9982fda2c2344a883b8ab6ef" sha1="880d3aacae0b3792235404decd294afdad51a0a6" />
+		<rom name="WWF Attitude (Europe).z64" size="33554432" crc="804fe494" md5="3fdb2e5f9982fda2c2344a883b8ab6ef" sha1="880d3aacae0b3792235404decd294afdad51a0a6" sha256="403189fe4c003396404f12589e29ec9d6342d908ef87d9d3fc315aa3fa555c06" status="verified" serial="NTIP" />
 	</game>
-	<game name="WWF Attitude (Germany)" cloneof="WWF Attitude (Europe)">
+	<game name="WWF Attitude (Germany)" id="0858" cloneofid="0857">
 		<description>WWF Attitude (Germany)</description>
 		<rom name="WWF Attitude (Germany).n64" />
-		<release name="WWF Attitude (Germany)" region="GER" />
-		<rom name="WWF Attitude (Germany).z64" size="33554432" crc="ea5d8359" md5="b86ec8d19d7d1a50ea900ea10355a735" sha1="40c2c6309589755c4cfdbf3e4e39b3788820b199" />
+		<rom name="WWF Attitude (Germany).z64" size="33554432" crc="ea5d8359" md5="b86ec8d19d7d1a50ea900ea10355a735" sha1="40c2c6309589755c4cfdbf3e4e39b3788820b199" serial="NTID" />
 	</game>
-	<game name="WWF Attitude (USA)" cloneof="WWF Attitude (Europe)">
+	<game name="WWF Attitude (USA)" id="0859" cloneofid="0857">
 		<description>WWF Attitude (USA)</description>
 		<rom name="WWF Attitude (USA).n64" />
-		<release name="WWF Attitude (USA)" region="USA" />
-		<rom name="WWF Attitude (USA).z64" size="33554432" crc="7a4b3686" md5="9faf514cb3dbb742c129deb395dca342" sha1="259973eb0ba1d01f1a5fbf3039ed511e6b705f26" />
+		<rom name="WWF Attitude (USA).z64" size="33554432" crc="7a4b3686" md5="9faf514cb3dbb742c129deb395dca342" sha1="259973eb0ba1d01f1a5fbf3039ed511e6b705f26" sha256="a6702c3a7a535b785ad4bd75cdca2e1f15fca59556824b7c54bdae56ecae34d3" serial="NTIE" />
 	</game>
-	<game name="WWF No Mercy (Europe) (Rev 1)">
-		<description>WWF No Mercy (Europe) (Rev 1)</description>
-		<rom name="WWF No Mercy (Europe) (Rev 1).n64" />
-		<release name="WWF No Mercy (Europe) (Rev 1)" region="EUR" />
-		<rom name="WWF No Mercy (Europe) (Rev 1).z64" size="33554432" crc="43ba9e7e" md5="400a14f132d993f5544f8b008ec136fa" sha1="cc8b9863c0e96d1b6a611d6ac2238e38b247ea5d" />
-	</game>
-	<game name="WWF No Mercy (Europe)" cloneof="WWF No Mercy (Europe) (Rev 1)">
+	<game name="WWF No Mercy (Europe)" id="0860" cloneofid="0861">
 		<description>WWF No Mercy (Europe)</description>
 		<rom name="WWF No Mercy (Europe).n64" />
-		<rom name="WWF No Mercy (Europe).z64" size="33554432" crc="e88d7e16" md5="d94a8f78178473d4ba4bed62fa8e2e66" sha1="15ad0a48dbb2da32b39601e6bfb5d7b381853529" />
+		<rom name="WWF No Mercy (Europe).z64" size="33554432" crc="e88d7e16" md5="d94a8f78178473d4ba4bed62fa8e2e66" sha1="15ad0a48dbb2da32b39601e6bfb5d7b381853529" serial="NW4P" />
 	</game>
-	<game name="WWF No Mercy (USA)" cloneof="WWF No Mercy (Europe) (Rev 1)">
+	<game name="WWF No Mercy (Europe) (Rev 1)" id="0861">
+		<description>WWF No Mercy (Europe) (Rev 1)</description>
+		<rom name="WWF No Mercy (Europe) (Rev 1).n64" />
+		<rom name="WWF No Mercy (Europe) (Rev 1).z64" size="33554432" crc="43ba9e7e" md5="400a14f132d993f5544f8b008ec136fa" sha1="cc8b9863c0e96d1b6a611d6ac2238e38b247ea5d" sha256="381d46cfdf108122d8e41a3e0a45b2c8fb9d0429f130dde5d6d58e6d81da07c0" status="verified" serial="NW4P" />
+	</game>
+	<game name="WWF No Mercy (USA)" id="0862" cloneofid="0861">
 		<description>WWF No Mercy (USA)</description>
 		<rom name="WWF No Mercy (USA).n64" />
-		<rom name="WWF No Mercy (USA).z64" size="33554432" crc="b33f44f0" md5="04c492be7f89fc6f425238bd67629544" sha1="3566d9b5723291937582453ad0453ce517cfc358" />
+		<rom name="WWF No Mercy (USA).z64" size="33554432" crc="b33f44f0" md5="04c492be7f89fc6f425238bd67629544" sha1="3566d9b5723291937582453ad0453ce517cfc358" serial="NW4E" />
 	</game>
-	<game name="WWF No Mercy (USA) (Rev 1)" cloneof="WWF No Mercy (Europe) (Rev 1)">
+	<game name="WWF No Mercy (USA) (Rev 1)" id="0882" cloneofid="0861">
 		<description>WWF No Mercy (USA) (Rev 1)</description>
 		<rom name="WWF No Mercy (USA) (Rev 1).n64" />
-		<release name="WWF No Mercy (USA) (Rev 1)" region="USA" />
-		<rom name="WWF No Mercy (USA) (Rev 1).z64" size="33554432" crc="baceea13" md5="66b8ec24557a50514a814f15429bd559" sha1="91cee3d096f4a76644d8b35b9aead6448909abd1" />
+		<rom name="WWF No Mercy (USA) (Rev 1).z64" size="33554432" crc="baceea13" md5="66b8ec24557a50514a814f15429bd559" sha1="91cee3d096f4a76644d8b35b9aead6448909abd1" serial="NW4E" />
 	</game>
-	<game name="WWF War Zone (Europe)">
+	<game name="WWF No Mercy (USA) (Beta) (2000-09-11)" id="1112" cloneofid="0861">
+		<description>WWF No Mercy (USA) (Beta) (2000-09-11)</description>
+		<rom name="WWF No Mercy (USA) (Beta) (2000-09-11).n64" />
+		<rom name="WWF No Mercy (USA) (Beta) (2000-09-11).z64" size="33554432" crc="a526ff27" md5="5ce490cf86cfeabf28c19b4c8afc3f24" sha1="1c2c5969f176a3a781cfc4d8a8e44daf3632ad64" sha256="3dd1f846c6ba859fbfee64f1171ad134969931321ac2d9d33c6f45c5b264f269" serial="!none" />
+	</game>
+	<game name="WWF War Zone (Europe)" id="0863">
 		<description>WWF War Zone (Europe)</description>
 		<rom name="WWF War Zone (Europe).n64" />
-		<release name="WWF War Zone (Europe)" region="EUR" />
-		<rom name="WWF War Zone (Europe).z64" size="12582912" crc="90a0b609" md5="ebc0cf55fc58845c6ee86cf8b2d87303" sha1="808a8997aa8d717aac2a9a0c476b901338ac626e" />
+		<rom name="WWF War Zone (Europe).z64" size="12582912" crc="90a0b609" md5="ebc0cf55fc58845c6ee86cf8b2d87303" sha1="808a8997aa8d717aac2a9a0c476b901338ac626e" sha256="75539b5fa0bcb196d7dae076d9317ac21864f953b63dcb78c85e7f4fb4144501" status="verified" serial="NWWP" />
 	</game>
-	<game name="WWF War Zone (USA)" cloneof="WWF War Zone (Europe)">
+	<game name="WWF War Zone (USA)" id="0864" cloneofid="0863">
 		<description>WWF War Zone (USA)</description>
 		<rom name="WWF War Zone (USA).n64" />
-		<release name="WWF War Zone (USA)" region="USA" />
-		<rom name="WWF War Zone (USA).z64" size="12582912" crc="2fbb5507" md5="2322da2b9e7dc74678cd683b7a246b49" sha1="8700f89cd7cfa873452117f6b2a648d32796111c" />
+		<rom name="WWF War Zone (USA).z64" size="12582912" crc="2fbb5507" md5="2322da2b9e7dc74678cd683b7a246b49" sha1="8700f89cd7cfa873452117f6b2a648d32796111c" sha256="ee4f5a036423b78449475fa09471de6148ff6972d0510098943bc83092f990b5" status="verified" serial="NWWE" />
 	</game>
-	<game name="WWF WrestleMania 2000 (Europe)">
+	<game name="WWF WrestleMania 2000 (Europe)" id="0865">
 		<description>WWF WrestleMania 2000 (Europe)</description>
 		<rom name="WWF WrestleMania 2000 (Europe).n64" />
-		<release name="WWF WrestleMania 2000 (Europe)" region="EUR" />
-		<rom name="WWF WrestleMania 2000 (Europe).z64" size="33554432" crc="09d710c7" md5="b75149f87cc5f3a508643ac377f2fcc9" sha1="d37c4100d967cb8b71852993b947619467ffcaf7" />
+		<rom name="WWF WrestleMania 2000 (Europe).z64" size="33554432" crc="09d710c7" md5="b75149f87cc5f3a508643ac377f2fcc9" sha1="d37c4100d967cb8b71852993b947619467ffcaf7" sha256="8f759c230e6c261eb77cff7906740173132c7051fcaed10dea71d78e375e45c7" status="verified" serial="NWXP" />
 	</game>
-	<game name="WWF WrestleMania 2000 (Japan)" cloneof="WWF WrestleMania 2000 (Europe)">
+	<game name="WWF WrestleMania 2000 (Japan)" id="0866" cloneofid="0865">
 		<description>WWF WrestleMania 2000 (Japan)</description>
 		<rom name="WWF WrestleMania 2000 (Japan).n64" />
-		<release name="WWF WrestleMania 2000 (Japan)" region="JPN" />
-		<rom name="WWF WrestleMania 2000 (Japan).z64" size="33554432" crc="c2034d24" md5="11eee2f34bf8da05a1b8f4fb9fe9f74c" sha1="e020c26dede0c349181cf08a3541816dc47f63a8" />
+		<rom name="WWF WrestleMania 2000 (Japan).z64" size="33554432" crc="c2034d24" md5="11eee2f34bf8da05a1b8f4fb9fe9f74c" sha1="e020c26dede0c349181cf08a3541816dc47f63a8" serial="NWXJ" />
 	</game>
-	<game name="WWF WrestleMania 2000 (USA)" cloneof="WWF WrestleMania 2000 (Europe)">
+	<game name="WWF WrestleMania 2000 (USA)" id="0867" cloneofid="0865">
 		<description>WWF WrestleMania 2000 (USA)</description>
 		<rom name="WWF WrestleMania 2000 (USA).n64" />
-		<release name="WWF WrestleMania 2000 (USA)" region="USA" />
-		<rom name="WWF WrestleMania 2000 (USA).z64" size="33554432" crc="0b50b4c6" md5="d9030ca30e4d1af805acce1bfed988cc" sha1="442d417a52ed672ca1a47e7261a5414debb1e27a" />
+		<rom name="WWF WrestleMania 2000 (USA).z64" size="33554432" crc="0b50b4c6" md5="d9030ca30e4d1af805acce1bfed988cc" sha1="442d417a52ed672ca1a47e7261a5414debb1e27a" serial="NWXE" />
 	</game>
-	<game name="Xena - Warrior Princess - The Talisman of Fate (Europe)">
+	<game name="X'treme Roller (USA) (Proto)" id="1072">
+		<description>X'treme Roller (USA) (Proto)</description>
+		<rom name="X'treme Roller (USA) (Proto).n64" />
+		<rom name="X'treme Roller (USA) (Proto).z64" size="25165824" crc="fce6875f" md5="1878c3d3cc1bfb7a40fcdbaf4f1b1db5" sha1="e8355739333860342bf87505aca2da83ff62ced4" sha256="1465517b5c2486b4ba83b1b03ca2b140fd46e3da37d8a9987c6c0b1b92613a77" serial="!none" />
+	</game>
+	<game name="Xena - Warrior Princess - The Talisman of Fate (Europe)" id="0868">
 		<description>Xena - Warrior Princess - The Talisman of Fate (Europe)</description>
 		<rom name="Xena - Warrior Princess - The Talisman of Fate (Europe).n64" />
-		<release name="Xena - Warrior Princess - The Talisman of Fate (Europe)" region="EUR" />
-		<rom name="Xena - Warrior Princess - The Talisman of Fate (Europe).z64" size="12582912" crc="d3932f88" md5="ec2bcb1b7fc7d068be1f39e79e49a842" sha1="2fa884f36bd370d844ed1e57c4357510584fe3e2" />
+		<rom name="Xena - Warrior Princess - The Talisman of Fate (Europe).z64" size="12582912" crc="d3932f88" md5="ec2bcb1b7fc7d068be1f39e79e49a842" sha1="2fa884f36bd370d844ed1e57c4357510584fe3e2" sha256="07173ba69bda3c300c2c2353a241fcaa1d9fe5eaf9abb56fe815433fc1343696" status="verified" serial="NXFP" />
 	</game>
-	<game name="Xena - Warrior Princess - The Talisman of Fate (USA)" cloneof="Xena - Warrior Princess - The Talisman of Fate (Europe)">
+	<game name="Xena - Warrior Princess - The Talisman of Fate (USA)" id="0869" cloneofid="0868">
 		<description>Xena - Warrior Princess - The Talisman of Fate (USA)</description>
 		<rom name="Xena - Warrior Princess - The Talisman of Fate (USA).n64" />
-		<release name="Xena - Warrior Princess - The Talisman of Fate (USA)" region="USA" />
-		<rom name="Xena - Warrior Princess - The Talisman of Fate (USA).z64" size="12582912" crc="7da93999" md5="1ac234649d28f09e82c0d11abb17f03b" sha1="e3316269b8466fe1fb968ac9338e6acdc0379970" />
+		<rom name="Xena - Warrior Princess - The Talisman of Fate (USA).z64" size="12582912" crc="7da93999" md5="1ac234649d28f09e82c0d11abb17f03b" sha1="e3316269b8466fe1fb968ac9338e6acdc0379970" sha256="d336e2c20edb20d68b9bb8e725c2661e8da8c54598b786ac01b02da86830e71f" serial="NXFE" />
 	</game>
-	<game name="Xingji Huohu (China) (v4) (iQue) (Manual)">
-		<description>Xingji Huohu (China) (v4) (iQue) (Manual)</description>
-		<rom name="Xingji Huohu (China) (v4) (iQue) (Manual).n64" />
-		<release name="Xingji Huohu (China) (v4) (iQue) (Manual)" region="CHN" />
-		<rom name="Xingji Huohu (China) (v4) (iQue) (Manual).z64" size="229376" crc="28cda0eb" md5="3dcd5e15aa35a73c68db4f56e2670fa2" sha1="12811f1b0f69cad88022bcf36f158865c8f89f32" />
-	</game>
-	<game name="Xplorer 64 (Germany) (v1.067) (Unl)">
-		<description>Xplorer 64 (Germany) (v1.067) (Unl)</description>
-		<rom name="Xplorer 64 (Germany) (v1.067) (Unl).z64" />
-		<rom name="Xplorer 64 (Germany) (v1.067) (Unl).n64" />
-		<release name="Xplorer 64 (Germany) (v1.067) (Unl)" region="GER" />
-		<rom name="Xplorer 64 (Germany) (v1.067) (Unl).bin" size="262144" crc="656acdf5" md5="9137129a586e1bcab6ae81bac6b01275" sha1="3a13b42074c2b6948f55f22d3e4fe44fbf2cde6a" />
-	</game>
-	<game name="Yakouchuu II - Satsujin Kouro (Japan)">
+	<game name="Yakouchuu II - Satsujin Kouro (Japan)" id="0870">
 		<description>Yakouchuu II - Satsujin Kouro (Japan)</description>
 		<rom name="Yakouchuu II - Satsujin Kouro (Japan).n64" />
-		<release name="Yakouchuu II - Satsujin Kouro (Japan)" region="JPN" />
-		<rom name="Yakouchuu II - Satsujin Kouro (Japan).z64" size="33554432" crc="4538c41a" md5="e24942948f7140ee4260268db763d0fd" sha1="09929ca361d47fb9fc0eb4077cf1fb77cb843cef" />
+		<rom name="Yakouchuu II - Satsujin Kouro (Japan).z64" size="33554432" crc="4538c41a" md5="e24942948f7140ee4260268db763d0fd" sha1="09929ca361d47fb9fc0eb4077cf1fb77cb843cef" sha256="c6a52c2377f3d6236ba2d29557461b9af106d99afeba2156e21e2477b00ddffd" status="verified" serial="NYKJ" />
 	</game>
-	<game name="Yaoxi Gushi (China) (v6) (iQue) (Manual)">
-		<description>Yaoxi Gushi (China) (v6) (iQue) (Manual)</description>
-		<rom name="Yaoxi Gushi (China) (v6) (iQue) (Manual).n64" />
-		<release name="Yaoxi Gushi (China) (v6) (iQue) (Manual)" region="CHN" />
-		<rom name="Yaoxi Gushi (China) (v6) (iQue) (Manual).z64" size="425984" crc="5cef9b96" md5="85a90c61b65b56334e00950210c6cfc4" sha1="3f2d73aab7732d5448881df99d6f131c7354b6b8" />
-	</game>
-	<game name="Yaoxi Gushi (China) (v2) (iQue) (Manual)" cloneof="Yaoxi Gushi (China) (v6) (iQue) (Manual)">
-		<description>Yaoxi Gushi (China) (v2) (iQue) (Manual)</description>
-		<rom name="Yaoxi Gushi (China) (v2) (iQue) (Manual).n64" />
-		<rom name="Yaoxi Gushi (China) (v2) (iQue) (Manual).z64" size="196608" crc="4b5ae477" md5="df8164da753c9ef0b7c2611f584e81a9" sha1="9c9635ba9f35f01a55a92153987d831113d454d3" />
-	</game>
-	<game name="Yaoxi Gushi (China) (v4) (iQue) (Manual)" cloneof="Yaoxi Gushi (China) (v6) (iQue) (Manual)">
-		<description>Yaoxi Gushi (China) (v4) (iQue) (Manual)</description>
-		<rom name="Yaoxi Gushi (China) (v4) (iQue) (Manual).n64" />
-		<rom name="Yaoxi Gushi (China) (v4) (iQue) (Manual).z64" size="245760" crc="5d76a1c1" md5="d6778d9d560dec35d8c05af4738e27aa" sha1="7eca70394a089f4058b67b1678e3f33c75fae738" />
-	</game>
-	<game name="Yoshi's Story (Europe) (En,Fr,De)">
-		<description>Yoshi's Story (Europe) (En,Fr,De)</description>
-		<rom name="Yoshi's Story (Europe) (En,Fr,De).n64" />
-		<release name="Yoshi's Story (Europe) (En,Fr,De)" region="EUR" />
-		<rom name="Yoshi's Story (Europe) (En,Fr,De).z64" size="16777216" crc="f9ffc760" md5="2524e5fb8ed4bb8c831c5ac057e8f344" sha1="5b56ec1da78456f968129baddc1f233e1fb4f4f3" status="verified" />
-	</game>
-	<game name="Yaoxi Gushi (China) (iQue)" cloneof="Yoshi's Story (Europe) (En,Fr,De)">
-		<description>Yaoxi Gushi (China) (iQue)</description>
-		<rom name="Yaoxi Gushi (China) (iQue).n64" />
-		<rom name="Yaoxi Gushi (China) (iQue).z64" size="16023552" crc="9a579a29" md5="f7aa4f819f41cb4236792a8145684627" sha1="f04aabaca4d107f3ce35ed234698d30a79394431" />
-	</game>
-	<game name="Yoshi Story (Japan)" cloneof="Yoshi's Story (Europe) (En,Fr,De)">
+	<game name="Yoshi Story (Japan)" id="0871" cloneofid="0872">
 		<description>Yoshi Story (Japan)</description>
 		<rom name="Yoshi Story (Japan).n64" />
-		<release name="Yoshi Story (Japan)" region="JPN" />
-		<rom name="Yoshi Story (Japan).z64" size="16777216" crc="4f44a9ef" md5="dd8a0e5472f13ea87b176f0155fa0c66" sha1="ff320b4122894c773f465a8996e82a00f3116e83" status="verified" />
+		<rom name="Yoshi Story (Japan).z64" size="16777216" crc="4f44a9ef" md5="dd8a0e5472f13ea87b176f0155fa0c66" sha1="ff320b4122894c773f465a8996e82a00f3116e83" sha256="52acf92dc66018b3ed84b334cb511ed956db8b3013ffc4e8586ae00bd93b0c95" status="verified" serial="NYSJ" />
 	</game>
-	<game name="Yoshi's Story (USA) (En,Ja)" cloneof="Yoshi's Story (Europe) (En,Fr,De)">
+	<game name="Yoshi's Story (Europe) (En,Fr,De)" id="0872">
+		<description>Yoshi's Story (Europe) (En,Fr,De)</description>
+		<rom name="Yoshi's Story (Europe) (En,Fr,De).n64" />
+		<rom name="Yoshi's Story (Europe) (En,Fr,De).z64" size="16777216" crc="f9ffc760" md5="2524e5fb8ed4bb8c831c5ac057e8f344" sha1="5b56ec1da78456f968129baddc1f233e1fb4f4f3" sha256="19d5e75ab2ace98294b7d9c7a5e57955d5f8be8d8d188e288eb31a27555ec5dd" status="verified" serial="NYSP" />
+	</game>
+	<game name="Yoshi's Story (USA) (En,Ja)" id="0873" cloneofid="0872">
 		<description>Yoshi's Story (USA) (En,Ja)</description>
 		<rom name="Yoshi's Story (USA) (En,Ja).n64" />
-		<release name="Yoshi's Story (USA) (En,Ja)" region="USA" />
-		<rom name="Yoshi's Story (USA) (En,Ja).z64" size="16777216" crc="a1453e0d" md5="586a092e22604840973b82dfaceac77a" sha1="b13072fef6c6df48c07d8822c01e5bc59036f6da" status="verified" />
+		<rom name="Yoshi's Story (USA) (En,Ja).z64" size="16777216" crc="a1453e0d" md5="586a092e22604840973b82dfaceac77a" sha1="b13072fef6c6df48c07d8822c01e5bc59036f6da" sha256="e8a63388c38f8f0bea37e9b13a97f0898ac5496e08ca2028afb8db9a866e0ce9" status="verified" serial="NYSE" />
 	</game>
-	<game name="Yueye Motuo (China) (iQue) (Manual)">
-		<description>Yueye Motuo (China) (iQue) (Manual)</description>
-		<rom name="Yueye Motuo (China) (iQue) (Manual).n64" />
-		<release name="Yueye Motuo (China) (iQue) (Manual)" region="CHN" />
-		<rom name="Yueye Motuo (China) (iQue) (Manual).z64" size="262144" crc="3863dfe0" md5="876f87c91a4b6339daa8fc1f41eb7acd" sha1="312ee2f121983f148644d49a1f742dad3920f5d7" />
+	<game name="Yoshi's Story (USA) (En,Ja) (LodgeNet)" id="1165" cloneofid="0872">
+		<category>Games</category>
+		<rom name="Yoshi's Story (USA) (En,Ja) (LodgeNet).n64" />
+		<description>Yoshi's Story (USA) (En,Ja) (LodgeNet)</description>
+		<rom name="Yoshi's Story (USA) (En,Ja) (LodgeNet).i64" size="64" crc="57c2cf72" md5="711bdc795fef69d94a9ca00d68a2d4b3" sha1="0c721086f560a6faf9e8b1476d033e261d3f24cc" />
+		<rom name="Yoshi's Story (USA) (En,Ja) (LodgeNet).z64" size="16777216" crc="19a7091e" md5="0543ffdc399361740a5b24b364aba6a6" sha1="f489a3cdef729cd1ade23996096fe88501e75079" />
 	</game>
-	<game name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)">
-		<description>Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)</description>
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual).n64" />
-		<release name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)" region="CHN" />
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual).z64" size="425984" crc="07e6c6e6" md5="912628118e67fea670ed2c63f7a7b003" sha1="5d50125c3f7c916f49e95806c651afb3ed4f74ad" />
+	<game name="Yuke Yuke!! Trouble Makers (Japan)" id="0874" cloneofid="0440">
+		<description>Yuke Yuke!! Trouble Makers (Japan)</description>
+		<rom name="Yuke Yuke!! Trouble Makers (Japan).n64" />
+		<rom name="Yuke Yuke!! Trouble Makers (Japan).z64" size="8388608" crc="b69d3068" md5="2ae35bdf163613024d876a09f25063f3" sha1="039a75636c34d219d489d0a84a671d00dc23e7c4" serial="NTMJ" />
 	</game>
-	<game name="Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual)" cloneof="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)">
-		<description>Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual)</description>
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual).n64" />
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual).z64" size="278528" crc="f8d9250d" md5="9729a68f40f197d4d040fa641ff099e7" sha1="b5ed1ed47e0876bbc0eeb10f5ccc28cd31bed0fa" />
+	<game name="Zelda no Densetsu - Mujura no Kamen (Japan)" id="0875" cloneofid="0371">
+		<description>Zelda no Densetsu - Mujura no Kamen (Japan)</description>
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan).n64" />
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan).z64" size="33554432" crc="0d33e1db" md5="15d1a2217cad61c39cfecbffa0703e25" sha1="5fb2301aacbf85278af30dca3e4194ad48599e36" status="verified" serial="NZSJ" />
 	</game>
-	<game name="Zhi Pian Mario (China) (v4) (iQue) (Manual)">
-		<description>Zhi Pian Mario (China) (v4) (iQue) (Manual)</description>
-		<rom name="Zhi Pian Mario (China) (v4) (iQue) (Manual).n64" />
-		<release name="Zhi Pian Mario (China) (v4) (iQue) (Manual)" region="CHN" />
-		<rom name="Zhi Pian Mario (China) (v4) (iQue) (Manual).z64" size="376832" crc="b370284f" md5="d9597922207298a87fa46878c017e6da" sha1="02a3eb14d2646ea7651f5ad9af58bf374f7bb023" />
+	<game name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)" id="0876" cloneofid="0371">
+		<description>Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)</description>
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1).n64" />
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1).z64" size="33554432" crc="356c2e19" md5="c38a7f6f6b61862ea383a75cdf888279" sha1="41fdb879ab422ec158b4eafea69087f255ea8589" sha256="7f81367323b3face9dff8961abe1937df9f87a13c558ec038838c25490029bf3" status="verified" serial="NZSJ" />
 	</game>
-	<game name="Zhi Pian Mario (China) (v2) (iQue) (Manual)" cloneof="Zhi Pian Mario (China) (v4) (iQue) (Manual)">
-		<description>Zhi Pian Mario (China) (v2) (iQue) (Manual)</description>
-		<rom name="Zhi Pian Mario (China) (v2) (iQue) (Manual).n64" />
-		<rom name="Zhi Pian Mario (China) (v2) (iQue) (Manual).z64" size="376832" crc="977e9a2f" md5="c4d652425aa4f2fc1d12564df01f8a04" sha1="5dc7d52a4545eeb9daddcae110a60e7e488d755a" />
+	<game name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube)" id="0934" cloneofid="0371">
+		<description>Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube)</description>
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube).n64" />
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube).z64" size="33554432" crc="b9bf76df" md5="d3929aadf7640f8c5b4ce8321ad4393a" sha1="1438fd501e3e5b25461770af88c02ab1e41d3a7e" serial="NZSJ" />
 	</game>
-	<game name="Zool - Majuu Tsukai Densetsu (Japan)">
+	<game name="Zelda no Densetsu - Toki no Ocarina (Japan)" id="0877" cloneofid="0375">
+		<description>Zelda no Densetsu - Toki no Ocarina (Japan)</description>
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan).z64" size="33554432" crc="d423e8b0" md5="9f04c8e68534b870f707c247fa4b50fc" sha1="c892bbda3993e66bd0d56a10ecd30b1ee612210f" sha256="d38fd6ff19daf05320b3c23f9adc119b017408686e12aaf32f313a7582b020af" status="verified" serial="CZLJ" />
+	</game>
+	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1)" id="0878" cloneofid="0375">
+		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1)</description>
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1).z64" size="33554432" crc="26e73887" md5="1bf5f42b98c3e97948f01155f12e2d88" sha1="dbfc81f655187dc6fefd93fa6798face770d579d" status="verified" serial="CZLJ" />
+	</game>
+	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)" id="0879" cloneofid="0375">
+		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)</description>
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2).z64" size="33554432" crc="2b2721ba" md5="2258052847bdd056c8406a9ef6427f13" sha1="fa5f5942b27480d60243c2d52c0e93e26b9e6b86" sha256="10833ee97cdfa1bb9b248839946992b86ec60342846682aeca06049adb5365e5" serial="CZLJ" />
+	</game>
+	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection)" id="1020" cloneofid="0375">
+		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection)</description>
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection).z64" size="33554432" crc="8c5b90c1" md5="0c13e0449a28ea5b925cdb8af8d29768" sha1="2ce2d1a9f0534c9cd9fa04ea5317b80da21e5e73" serial="CZLJ" />
+	</game>
+	<game name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube)" id="0930" cloneofid="0375">
+		<description>Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube)</description>
+		<rom name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube).z64" size="33554432" crc="1c6ce8cb" md5="33fb7852c180b18ea0b9620b630f413f" sha1="0769c84615422d60f16925cd859593cdfa597f84" serial="CZLJ" />
+	</game>
+	<game name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)" id="0932" cloneofid="0931">
+		<description>Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)</description>
+		<rom name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube).z64" size="33554432" crc="122ff261" md5="69895c5c78442260f6eafb2506dc482a" sha1="dd14e143c4275861fe93ea79d0c02e36ae8c6c2f" serial="CZLJ" />
+	</game>
+	<game name="Zool - Majuu Tsukai Densetsu (Japan)" id="0880">
 		<description>Zool - Majuu Tsukai Densetsu (Japan)</description>
 		<rom name="Zool - Majuu Tsukai Densetsu (Japan).n64" />
-		<release name="Zool - Majuu Tsukai Densetsu (Japan)" region="JPN" />
-		<rom name="Zool - Majuu Tsukai Densetsu (Japan).z64" size="12582912" crc="756ba26d" md5="692a33b0d7456fc733a81ab83c20382b" sha1="2d6efdb155f6726478ad255e76220a95b559be40" />
-	</game>
-	<game name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual)">
-		<description>Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual)</description>
-		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual).n64" />
-		<release name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual)" region="CHN" />
-		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual).z64" size="245760" crc="f336cc75" md5="9abb0f6f79e01fc9a942d6027719c3e4" sha1="0ac28c05e402820d6b65722a813f8bdb25db890c" />
+		<rom name="Zool - Majuu Tsukai Densetsu (Japan).z64" size="12582912" crc="756ba26d" md5="692a33b0d7456fc733a81ab83c20382b" sha1="2d6efdb155f6726478ad255e76220a95b559be40" serial="NMZJ" />
 	</game>
 </datafile>

--- a/Nintendo - Nintendo 64.dat
+++ b/Nintendo - Nintendo 64.dat
@@ -4,5077 +4,6137 @@
 	<header>
 		<name>Nintendo - Nintendo 64 (BigEndian) (Parent-Clone)</name>
 		<description>Nintendo - Nintendo 64 (BigEndian) (Parent-Clone)</description>
-		<version>20210430-080604</version>
+		<version>20210430-080604 Ludo Custom</version>
 		<date>20210430-080604</date>
-		<author>alexian, kazumi213</author>
+		<author>Ludo Nintendo 64 Customizer</author>
 		<url>www.no-intro.org</url>
 	</header>
 	<game name="007 - The World Is Not Enough (Europe) (En,Fr,De)">
 		<description>007 - The World Is Not Enough (Europe) (En,Fr,De)</description>
-		<release name="007 - The World Is Not Enough (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="007 - The World Is Not Enough (Europe) (En,Fr,De).z64" size="33554432" crc="002c3b2a" md5="34ab1dea3111a233a8b5c5679de22e83" sha1="7fde668850a7e1a8402ab94bb09538a537a7e38b" status="verified"/>
+		<rom name="007 - The World Is Not Enough (Europe) (En,Fr,De).n64" />
+		<release name="007 - The World Is Not Enough (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="007 - The World Is Not Enough (Europe) (En,Fr,De).z64" size="33554432" crc="002c3b2a" md5="34ab1dea3111a233a8b5c5679de22e83" sha1="7fde668850a7e1a8402ab94bb09538a537a7e38b" status="verified" />
 	</game>
 	<game name="007 - The World Is Not Enough (USA)" cloneof="007 - The World Is Not Enough (Europe) (En,Fr,De)">
 		<description>007 - The World Is Not Enough (USA)</description>
-		<release name="007 - The World Is Not Enough (USA)" region="USA"/>
-		<rom name="007 - The World Is Not Enough (USA).z64" size="33554432" crc="26360987" md5="9d58996a8aa91263b5cd45c385f45fe4" sha1="d347159808f0374a93cf44cfb6135d8f56279f7b"/>
+		<rom name="007 - The World Is Not Enough (USA).n64" />
+		<release name="007 - The World Is Not Enough (USA)" region="USA" />
+		<rom name="007 - The World Is Not Enough (USA).z64" size="33554432" crc="26360987" md5="9d58996a8aa91263b5cd45c385f45fe4" sha1="d347159808f0374a93cf44cfb6135d8f56279f7b" />
 	</game>
 	<game name="007 - The World Is Not Enough (USA) (v21) (Beta)" cloneof="007 - The World Is Not Enough (Europe) (En,Fr,De)">
 		<description>007 - The World Is Not Enough (USA) (v21) (Beta)</description>
-		<rom name="007 - The World Is Not Enough (USA) (v21) (Beta).z64" size="33554432" crc="f0b6bf59" md5="12bd3fafb4e064b6b0c07b7ee156243b" sha1="53c6de60383517f38d27e449d47bced319f8e87a"/>
+		<rom name="007 - The World Is Not Enough (USA) (v21) (Beta).n64" />
+		<rom name="007 - The World Is Not Enough (USA) (v21) (Beta).z64" size="33554432" crc="f0b6bf59" md5="12bd3fafb4e064b6b0c07b7ee156243b" sha1="53c6de60383517f38d27e449d47bced319f8e87a" />
 	</game>
 	<game name="007 - The World Is Not Enough (USA) (v2) (Beta)" cloneof="007 - The World Is Not Enough (Europe) (En,Fr,De)">
 		<description>007 - The World Is Not Enough (USA) (v2) (Beta)</description>
-		<rom name="007 - The World Is Not Enough (USA) (v2) (Beta).z64" size="16777216" crc="6c180fef" md5="39abe0c383a44c464b408be3e1d6766e" sha1="376042ddedfd4f738786500531d67d5c299577be"/>
+		<rom name="007 - The World Is Not Enough (USA) (v2) (Beta).n64" />
+		<rom name="007 - The World Is Not Enough (USA) (v2) (Beta).z64" size="16777216" crc="6c180fef" md5="39abe0c383a44c464b408be3e1d6766e" sha1="376042ddedfd4f738786500531d67d5c299577be" />
 	</game>
 	<game name="1080 Snowboarding (Europe) (En,Ja,Fr,De)">
 		<description>1080 Snowboarding (Europe) (En,Ja,Fr,De)</description>
-		<release name="1080 Snowboarding (Europe) (En,Ja,Fr,De)" region="EUR"/>
-		<rom name="1080 Snowboarding (Europe) (En,Ja,Fr,De).z64" size="16777216" crc="75a21679" md5="632c98cf281cda776e66685b278a4fa6" sha1="637d92b08dbfe7c2f9d5e338835b1fce5f4a87d0" status="verified"/>
+		<rom name="1080 Snowboarding (Europe) (En,Ja,Fr,De).n64" />
+		<release name="1080 Snowboarding (Europe) (En,Ja,Fr,De)" region="EUR" />
+		<rom name="1080 Snowboarding (Europe) (En,Ja,Fr,De).z64" size="16777216" crc="75a21679" md5="632c98cf281cda776e66685b278a4fa6" sha1="637d92b08dbfe7c2f9d5e338835b1fce5f4a87d0" status="verified" />
 	</game>
 	<game name="1080 Snowboarding (Japan, USA) (En,Ja)" cloneof="1080 Snowboarding (Europe) (En,Ja,Fr,De)">
 		<description>1080 Snowboarding (Japan, USA) (En,Ja)</description>
-		<release name="1080 Snowboarding (Japan, USA) (En,Ja)" region="JPN"/>
-		<release name="1080 Snowboarding (Japan, USA) (En,Ja)" region="USA"/>
-		<rom name="1080 Snowboarding (Japan, USA) (En,Ja).z64" size="16777216" crc="08fe81c7" md5="fa27089c425dbab99f19245c5c997613" sha1="79cd1166c365e5809dec9b62e6d40d6032d5db3a" status="verified"/>
+		<rom name="1080 Snowboarding (Japan, USA) (En,Ja).n64" />
+		<release name="1080 Snowboarding (Japan, USA) (En,Ja)" region="JPN" />
+		<release name="1080 Snowboarding (Japan, USA) (En,Ja)" region="USA" />
+		<rom name="1080 Snowboarding (Japan, USA) (En,Ja).z64" size="16777216" crc="08fe81c7" md5="fa27089c425dbab99f19245c5c997613" sha1="79cd1166c365e5809dec9b62e6d40d6032d5db3a" status="verified" />
 	</game>
 	<game name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07)">
 		<description>40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07)</description>
-		<release name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07)" region="EUR"/>
-		<rom name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07).z64" size="33554432" crc="7e718143" md5="0a5acfea0c7cf68ae25202040d5ad1eb" sha1="3774e87aa383220060d330314f2c5bbb872f72ce"/>
+		<rom name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07).n64" />
+		<release name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07)" region="EUR" />
+		<rom name="40 Winks (Europe) (En,Es,It) (Proto) (1999-10-07).z64" size="33554432" crc="7e718143" md5="0a5acfea0c7cf68ae25202040d5ad1eb" sha1="3774e87aa383220060d330314f2c5bbb872f72ce" />
 	</game>
 	<game name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)">
 		<description>64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)</description>
-		<release name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)" region="JPN"/>
-		<rom name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan).z64" size="12582912" crc="67a789e5" md5="ea6a92de5a221a00814f7448bf6f1b31" sha1="35f7e37c62ae36eb29aad0d9da0ae83d57f6d8bd"/>
+		<rom name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan).n64" />
+		<release name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan)" region="JPN" />
+		<rom name="64 de Hakken!! Tamagotchi - Minna de Tamagotchi World (Japan).z64" size="12582912" crc="67a789e5" md5="ea6a92de5a221a00814f7448bf6f1b31" sha1="35f7e37c62ae36eb29aad0d9da0ae83d57f6d8bd" />
 	</game>
 	<game name="64 Hanafuda - Tenshi no Yakusoku (Japan)">
 		<description>64 Hanafuda - Tenshi no Yakusoku (Japan)</description>
-		<release name="64 Hanafuda - Tenshi no Yakusoku (Japan)" region="JPN"/>
-		<rom name="64 Hanafuda - Tenshi no Yakusoku (Japan).z64" size="8388608" crc="60a680e7" md5="66335f4dc6ab27034398bc26f263b897" sha1="36d1b4ef15cda8139face7e118cb34727c30bf29"/>
+		<rom name="64 Hanafuda - Tenshi no Yakusoku (Japan).n64" />
+		<release name="64 Hanafuda - Tenshi no Yakusoku (Japan)" region="JPN" />
+		<rom name="64 Hanafuda - Tenshi no Yakusoku (Japan).z64" size="8388608" crc="60a680e7" md5="66335f4dc6ab27034398bc26f263b897" sha1="36d1b4ef15cda8139face7e118cb34727c30bf29" />
 	</game>
 	<game name="64 Oozumou (Japan)">
 		<description>64 Oozumou (Japan)</description>
-		<release name="64 Oozumou (Japan)" region="JPN"/>
-		<rom name="64 Oozumou (Japan).z64" size="16777216" crc="742e31fb" md5="2cf9edb51ada9de2ae7ad9fd5acc5580" sha1="e77fe9f2c32870eb7acbcf6a13d26dd022bafe5d"/>
+		<rom name="64 Oozumou (Japan).n64" />
+		<release name="64 Oozumou (Japan)" region="JPN" />
+		<rom name="64 Oozumou (Japan).z64" size="16777216" crc="742e31fb" md5="2cf9edb51ada9de2ae7ad9fd5acc5580" sha1="e77fe9f2c32870eb7acbcf6a13d26dd022bafe5d" />
 	</game>
 	<game name="64 Oozumou 2 (Japan)">
 		<description>64 Oozumou 2 (Japan)</description>
-		<release name="64 Oozumou 2 (Japan)" region="JPN"/>
-		<rom name="64 Oozumou 2 (Japan).z64" size="16777216" crc="c1bc6fd8" md5="f7c796371e77e0a6fbd02eb866341952" sha1="6d524e0d0dd610dfb0c3bccaa88ef1e7aeceab98"/>
+		<rom name="64 Oozumou 2 (Japan).n64" />
+		<release name="64 Oozumou 2 (Japan)" region="JPN" />
+		<rom name="64 Oozumou 2 (Japan).z64" size="16777216" crc="c1bc6fd8" md5="f7c796371e77e0a6fbd02eb866341952" sha1="6d524e0d0dd610dfb0c3bccaa88ef1e7aeceab98" />
 	</game>
 	<game name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan)">
 		<description>64 Trump Collection - Alice no Wakuwaku Trump World (Japan)</description>
-		<release name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan)" region="JPN"/>
-		<rom name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan).z64" size="12582912" crc="dca7f4eb" md5="6b947f654775cf5dacd1e5d53d577da7" sha1="b5cf2c98d60ad8e6fad450681f9cefd63f4e5939"/>
+		<rom name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan).n64" />
+		<release name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan)" region="JPN" />
+		<rom name="64 Trump Collection - Alice no Wakuwaku Trump World (Japan).z64" size="12582912" crc="dca7f4eb" md5="6b947f654775cf5dacd1e5d53d577da7" sha1="b5cf2c98d60ad8e6fad450681f9cefd63f4e5939" />
 	</game>
 	<game name="Action Replay Pro 64 (Europe) (v3.3) (Unl)">
 		<description>Action Replay Pro 64 (Europe) (v3.3) (Unl)</description>
-		<release name="Action Replay Pro 64 (Europe) (v3.3) (Unl)" region="EUR"/>
-		<rom name="Action Replay Pro 64 (Europe) (v3.3) (Unl).bin" size="262144" crc="9fbabfda" md5="67afa5df80a5cfc91fce1dc918ea0a4f" sha1="c3426114f5da1fb7abde15a766d362698ad07166"/>
+		<rom name="Action Replay Pro 64 (Europe) (v3.3) (Unl).z64" />
+		<rom name="Action Replay Pro 64 (Europe) (v3.3) (Unl).n64" />
+		<release name="Action Replay Pro 64 (Europe) (v3.3) (Unl)" region="EUR" />
+		<rom name="Action Replay Pro 64 (Europe) (v3.3) (Unl).bin" size="262144" crc="9fbabfda" md5="67afa5df80a5cfc91fce1dc918ea0a4f" sha1="c3426114f5da1fb7abde15a766d362698ad07166" />
 	</game>
 	<game name="Action Replay Pro 64 (Europe) (v3.0) (Unl)" cloneof="Action Replay Pro 64 (Europe) (v3.3) (Unl)">
 		<description>Action Replay Pro 64 (Europe) (v3.0) (Unl)</description>
-		<rom name="Action Replay Pro 64 (Europe) (v3.0) (Unl).bin" size="262144" crc="c992dfb4" md5="35ba407ea9e4ef7c0ace8b4f58beec41" sha1="d5e4e8c875d6bda0afafb1b2513b16b1cb88dfc1"/>
+		<rom name="Action Replay Pro 64 (Europe) (v3.0) (Unl).z64" />
+		<rom name="Action Replay Pro 64 (Europe) (v3.0) (Unl).n64" />
+		<rom name="Action Replay Pro 64 (Europe) (v3.0) (Unl).bin" size="262144" crc="c992dfb4" md5="35ba407ea9e4ef7c0ace8b4f58beec41" sha1="d5e4e8c875d6bda0afafb1b2513b16b1cb88dfc1" />
 	</game>
 	<game name="GameShark Pro (USA) (v2.0) (Unl)" cloneof="Action Replay Pro 64 (Europe) (v3.3) (Unl)">
 		<description>GameShark Pro (USA) (v2.0) (Unl)</description>
-		<rom name="GameShark Pro (USA) (v2.0) (Unl).bin" size="262144" crc="ef9edf87" md5="437efd7fd7f84f4c0f802d3bf1f8464e" sha1="19148a009ef8e1013ab35c8141781184b141699f"/>
+		<rom name="GameShark Pro (USA) (v2.0) (Unl).z64" />
+		<rom name="GameShark Pro (USA) (v2.0) (Unl).n64" />
+		<rom name="GameShark Pro (USA) (v2.0) (Unl).bin" size="262144" crc="ef9edf87" md5="437efd7fd7f84f4c0f802d3bf1f8464e" sha1="19148a009ef8e1013ab35c8141781184b141699f" />
 	</game>
 	<game name="GameShark Pro (USA) (v3.3) (Unl)" cloneof="Action Replay Pro 64 (Europe) (v3.3) (Unl)">
 		<description>GameShark Pro (USA) (v3.3) (Unl)</description>
-		<release name="GameShark Pro (USA) (v3.3) (Unl)" region="USA"/>
-		<rom name="GameShark Pro (USA) (v3.3) (Unl).bin" size="262144" crc="7cc07bbc" md5="9f556d184d945369ddd11b5f815814a8" sha1="3b5046ae8129fd226eb7b02bc2c26cc7548fe6f2"/>
+		<rom name="GameShark Pro (USA) (v3.3) (Unl).z64" />
+		<rom name="GameShark Pro (USA) (v3.3) (Unl).n64" />
+		<release name="GameShark Pro (USA) (v3.3) (Unl)" region="USA" />
+		<rom name="GameShark Pro (USA) (v3.3) (Unl).bin" size="262144" crc="7cc07bbc" md5="9f556d184d945369ddd11b5f815814a8" sha1="3b5046ae8129fd226eb7b02bc2c26cc7548fe6f2" />
 	</game>
 	<game name="AeroFighters Assault (Europe) (En,Fr,De)">
 		<description>AeroFighters Assault (Europe) (En,Fr,De)</description>
-		<release name="AeroFighters Assault (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="AeroFighters Assault (Europe) (En,Fr,De).z64" size="12582912" crc="6a2b08da" md5="7558e3da7225712936d3ba3dce210c36" sha1="f1057a278a06dcfbc7eb8b6b7679ab879255f977"/>
+		<rom name="AeroFighters Assault (Europe) (En,Fr,De).n64" />
+		<release name="AeroFighters Assault (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="AeroFighters Assault (Europe) (En,Fr,De).z64" size="12582912" crc="6a2b08da" md5="7558e3da7225712936d3ba3dce210c36" sha1="f1057a278a06dcfbc7eb8b6b7679ab879255f977" />
 	</game>
 	<game name="AeroFighters Assault (USA)" cloneof="AeroFighters Assault (Europe) (En,Fr,De)">
 		<description>AeroFighters Assault (USA)</description>
-		<release name="AeroFighters Assault (USA)" region="USA"/>
-		<rom name="AeroFighters Assault (USA).z64" size="8388608" crc="4370d7e3" md5="79fb6e2452af077c5ef1dde5fc810f04" sha1="6742f67d7d2639072e186d240237be1c662cb25a"/>
+		<rom name="AeroFighters Assault (USA).n64" />
+		<release name="AeroFighters Assault (USA)" region="USA" />
+		<rom name="AeroFighters Assault (USA).z64" size="8388608" crc="4370d7e3" md5="79fb6e2452af077c5ef1dde5fc810f04" sha1="6742f67d7d2639072e186d240237be1c662cb25a" />
 	</game>
 	<game name="Sonic Wings Assault (Japan)" cloneof="AeroFighters Assault (Europe) (En,Fr,De)">
 		<description>Sonic Wings Assault (Japan)</description>
-		<release name="Sonic Wings Assault (Japan)" region="JPN"/>
-		<rom name="Sonic Wings Assault (Japan).z64" size="8388608" crc="fc73fb79" md5="7d47911b5c3d91a303ef19e764f3c02b" sha1="978936613096d1ebe49fec3ef50e3c870ce165b6"/>
+		<rom name="Sonic Wings Assault (Japan).n64" />
+		<release name="Sonic Wings Assault (Japan)" region="JPN" />
+		<rom name="Sonic Wings Assault (Japan).z64" size="8388608" crc="fc73fb79" md5="7d47911b5c3d91a303ef19e764f3c02b" sha1="978936613096d1ebe49fec3ef50e3c870ce165b6" />
 	</game>
 	<game name="AeroGauge (Europe) (En,Fr,De)">
 		<description>AeroGauge (Europe) (En,Fr,De)</description>
-		<release name="AeroGauge (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="AeroGauge (Europe) (En,Fr,De).z64" size="8388608" crc="040b0046" md5="05056045447bf1fba8f9878a7f6009f3" sha1="38aadd684ad7662b02bbc29edddade9c9e16a3c0" status="verified"/>
+		<rom name="AeroGauge (Europe) (En,Fr,De).n64" />
+		<release name="AeroGauge (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="AeroGauge (Europe) (En,Fr,De).z64" size="8388608" crc="040b0046" md5="05056045447bf1fba8f9878a7f6009f3" sha1="38aadd684ad7662b02bbc29edddade9c9e16a3c0" status="verified" />
 	</game>
 	<game name="AeroGauge (Japan) (Demo) (Kiosk)" cloneof="AeroGauge (Europe) (En,Fr,De)">
 		<description>AeroGauge (Japan) (Demo) (Kiosk)</description>
-		<rom name="AeroGauge (Japan) (Demo) (Kiosk).z64" size="8388608" crc="6ee3b932" md5="e970af3de25bb5ae1154010e26af776f" sha1="0253c33355986ddda18a7a72b81b91ddc1bed978"/>
+		<rom name="AeroGauge (Japan) (Demo) (Kiosk).n64" />
+		<rom name="AeroGauge (Japan) (Demo) (Kiosk).z64" size="8388608" crc="6ee3b932" md5="e970af3de25bb5ae1154010e26af776f" sha1="0253c33355986ddda18a7a72b81b91ddc1bed978" />
 	</game>
 	<game name="AeroGauge (Japan) (Rev 1)" cloneof="AeroGauge (Europe) (En,Fr,De)">
 		<description>AeroGauge (Japan) (Rev 1)</description>
-		<release name="AeroGauge (Japan) (Rev 1)" region="JPN"/>
-		<rom name="AeroGauge (Japan) (Rev 1).z64" size="8388608" crc="f322b641" md5="0620c2d134a0430f4afa208ffeda67b8" sha1="f7c2d4b0e77cc02deafe2e5fd95152b7e8bf86cf"/>
+		<rom name="AeroGauge (Japan) (Rev 1).n64" />
+		<release name="AeroGauge (Japan) (Rev 1)" region="JPN" />
+		<rom name="AeroGauge (Japan) (Rev 1).z64" size="8388608" crc="f322b641" md5="0620c2d134a0430f4afa208ffeda67b8" sha1="f7c2d4b0e77cc02deafe2e5fd95152b7e8bf86cf" />
 	</game>
 	<game name="AeroGauge (USA)" cloneof="AeroGauge (Europe) (En,Fr,De)">
 		<description>AeroGauge (USA)</description>
-		<release name="AeroGauge (USA)" region="USA"/>
-		<rom name="AeroGauge (USA).z64" size="8388608" crc="198b9e0e" md5="72c7ffcea6c1430616867616f5e9d51a" sha1="77626171c35fb1a4dfebb0927280897f362225ed"/>
+		<rom name="AeroGauge (USA).n64" />
+		<release name="AeroGauge (USA)" region="USA" />
+		<rom name="AeroGauge (USA).z64" size="8388608" crc="198b9e0e" md5="72c7ffcea6c1430616867616f5e9d51a" sha1="77626171c35fb1a4dfebb0927280897f362225ed" />
 	</game>
 	<game name="AI Shougi 3 (Japan)">
 		<description>AI Shougi 3 (Japan)</description>
-		<release name="AI Shougi 3 (Japan)" region="JPN"/>
-		<rom name="AI Shougi 3 (Japan).z64" size="8388608" crc="86df90e6" md5="4a5c509a20db7a429dc1dd4e219ad4a2" sha1="8d87d888e8916c4c148dad32ee0519dd297d1fa6"/>
+		<rom name="AI Shougi 3 (Japan).n64" />
+		<release name="AI Shougi 3 (Japan)" region="JPN" />
+		<rom name="AI Shougi 3 (Japan).z64" size="8388608" crc="86df90e6" md5="4a5c509a20db7a429dc1dd4e219ad4a2" sha1="8d87d888e8916c4c148dad32ee0519dd297d1fa6" />
 	</game>
 	<game name="Aidyn Chronicles - The First Mage (Europe)">
 		<description>Aidyn Chronicles - The First Mage (Europe)</description>
-		<release name="Aidyn Chronicles - The First Mage (Europe)" region="EUR"/>
-		<rom name="Aidyn Chronicles - The First Mage (Europe).z64" size="33554432" crc="be7e230d" md5="54d0a39123c15f74aabb1ecc24d4d6a0" sha1="e3a1e26f4c10a6767612d1a8462689e86d09dc0b"/>
+		<rom name="Aidyn Chronicles - The First Mage (Europe).n64" />
+		<release name="Aidyn Chronicles - The First Mage (Europe)" region="EUR" />
+		<rom name="Aidyn Chronicles - The First Mage (Europe).z64" size="33554432" crc="be7e230d" md5="54d0a39123c15f74aabb1ecc24d4d6a0" sha1="e3a1e26f4c10a6767612d1a8462689e86d09dc0b" />
 	</game>
 	<game name="Aidyn Chronicles - The First Mage (USA)" cloneof="Aidyn Chronicles - The First Mage (Europe)">
 		<description>Aidyn Chronicles - The First Mage (USA)</description>
-		<rom name="Aidyn Chronicles - The First Mage (USA).z64" size="33554432" crc="b1f18186" md5="af149336b3ddb899598e7be8740d7dc6" sha1="47ae795a2b12783a13e2b8d03439ce9a39fc826c"/>
+		<rom name="Aidyn Chronicles - The First Mage (USA).n64" />
+		<rom name="Aidyn Chronicles - The First Mage (USA).z64" size="33554432" crc="b1f18186" md5="af149336b3ddb899598e7be8740d7dc6" sha1="47ae795a2b12783a13e2b8d03439ce9a39fc826c" />
 	</game>
 	<game name="Aidyn Chronicles - The First Mage (USA) (Rev 1)" cloneof="Aidyn Chronicles - The First Mage (Europe)">
 		<description>Aidyn Chronicles - The First Mage (USA) (Rev 1)</description>
-		<release name="Aidyn Chronicles - The First Mage (USA) (Rev 1)" region="USA"/>
-		<rom name="Aidyn Chronicles - The First Mage (USA) (Rev 1).z64" size="33554432" crc="d5051096" md5="e8cddf0c52b72453d52da385322dfe15" sha1="f80e135e7e962308f51bb9f7600b25213549c688"/>
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Rev 1).n64" />
+		<release name="Aidyn Chronicles - The First Mage (USA) (Rev 1)" region="USA" />
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Rev 1).z64" size="33554432" crc="d5051096" md5="e8cddf0c52b72453d52da385322dfe15" sha1="f80e135e7e962308f51bb9f7600b25213549c688" />
 	</game>
 	<game name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10)" cloneof="Aidyn Chronicles - The First Mage (Europe)">
 		<description>Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10)</description>
-		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10).z64" size="33554432" crc="c46d84a0" md5="cd24763becfa1d0053e5438b0ef5e75e" sha1="6e8e1d2a40076b8503a433947658456ef5b833b9"/>
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10).n64" />
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-02-10).z64" size="33554432" crc="c46d84a0" md5="cd24763becfa1d0053e5438b0ef5e75e" sha1="6e8e1d2a40076b8503a433947658456ef5b833b9" />
 	</game>
 	<game name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09)" cloneof="Aidyn Chronicles - The First Mage (Europe)">
 		<description>Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09)</description>
-		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09).z64" size="33554432" crc="abd43f3f" md5="cc6eae9ed582044cc27945684fd396cd" sha1="d741ceac3cf6b14ab16a1f8d4f1bf9858bbf6c3d"/>
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09).n64" />
+		<rom name="Aidyn Chronicles - The First Mage (USA) (Beta) (2000-05-09).z64" size="33554432" crc="abd43f3f" md5="cc6eae9ed582044cc27945684fd396cd" sha1="d741ceac3cf6b14ab16a1f8d4f1bf9858bbf6c3d" />
 	</game>
 	<game name="Airboarder 64 (Europe)">
 		<description>Airboarder 64 (Europe)</description>
-		<release name="Airboarder 64 (Europe)" region="EUR"/>
-		<rom name="Airboarder 64 (Europe).z64" size="8388608" crc="c14d45ac" md5="e8891f8f498a615a6cbaf75b7ddc9fa6" sha1="2171fe2c0a9253cba56828f24a5e6153726c1516"/>
+		<rom name="Airboarder 64 (Europe).n64" />
+		<release name="Airboarder 64 (Europe)" region="EUR" />
+		<rom name="Airboarder 64 (Europe).z64" size="8388608" crc="c14d45ac" md5="e8891f8f498a615a6cbaf75b7ddc9fa6" sha1="2171fe2c0a9253cba56828f24a5e6153726c1516" />
 	</game>
 	<game name="Air Boarder 64 (Japan)" cloneof="Airboarder 64 (Europe)">
 		<description>Air Boarder 64 (Japan)</description>
-		<release name="Air Boarder 64 (Japan)" region="JPN"/>
-		<rom name="Air Boarder 64 (Japan).z64" size="8388608" crc="58fcb771" md5="ccee2fcf38dc2200128d75d15db53283" sha1="4a70c9ca027ecc8d05337993204e1ef76f5f0ac9"/>
+		<rom name="Air Boarder 64 (Japan).n64" />
+		<release name="Air Boarder 64 (Japan)" region="JPN" />
+		<rom name="Air Boarder 64 (Japan).z64" size="8388608" crc="58fcb771" md5="ccee2fcf38dc2200128d75d15db53283" sha1="4a70c9ca027ecc8d05337993204e1ef76f5f0ac9" />
 	</game>
 	<game name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It)">
 		<description>All Star Tennis '99 (Europe) (En,Fr,De,Es,It)</description>
-		<release name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="996e845f" md5="e3f4c868917a12bd5e84d94d1c260c7d" sha1="09ddbd45f4962735def65399b5792e3bb5bd7d3c"/>
+		<rom name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="All Star Tennis '99 (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="996e845f" md5="e3f4c868917a12bd5e84d94d1c260c7d" sha1="09ddbd45f4962735def65399b5792e3bb5bd7d3c" />
 	</game>
 	<game name="All Star Tennis 99 (USA)" cloneof="All Star Tennis '99 (Europe) (En,Fr,De,Es,It)">
 		<description>All Star Tennis 99 (USA)</description>
-		<release name="All Star Tennis 99 (USA)" region="USA"/>
-		<rom name="All Star Tennis 99 (USA).z64" size="8388608" crc="a7dcf638" md5="afc3dc9bb737d81903f6ce4875b63ae9" sha1="3a6446409d63dcac0d5c860a3e2888a378474887"/>
+		<rom name="All Star Tennis 99 (USA).n64" />
+		<release name="All Star Tennis 99 (USA)" region="USA" />
+		<rom name="All Star Tennis 99 (USA).z64" size="8388608" crc="a7dcf638" md5="afc3dc9bb737d81903f6ce4875b63ae9" sha1="3a6446409d63dcac0d5c860a3e2888a378474887" />
 	</game>
 	<game name="All-Star Baseball 2000 (Europe)">
 		<description>All-Star Baseball 2000 (Europe)</description>
-		<release name="All-Star Baseball 2000 (Europe)" region="EUR"/>
-		<rom name="All-Star Baseball 2000 (Europe).z64" size="16777216" crc="d3c29aa4" md5="90448c4175ee9d0247674474dcabdfed" sha1="c8f41a27b9509da422b7ecf32f64df3e213194ea"/>
+		<rom name="All-Star Baseball 2000 (Europe).n64" />
+		<release name="All-Star Baseball 2000 (Europe)" region="EUR" />
+		<rom name="All-Star Baseball 2000 (Europe).z64" size="16777216" crc="d3c29aa4" md5="90448c4175ee9d0247674474dcabdfed" sha1="c8f41a27b9509da422b7ecf32f64df3e213194ea" />
 	</game>
 	<game name="All-Star Baseball 2000 (USA)" cloneof="All-Star Baseball 2000 (Europe)">
 		<description>All-Star Baseball 2000 (USA)</description>
-		<release name="All-Star Baseball 2000 (USA)" region="USA"/>
-		<rom name="All-Star Baseball 2000 (USA).z64" size="16777216" crc="69e88471" md5="aada358ce97f06c4df5bf55987268844" sha1="4256a23902e22e6e8291f1931f8de4b2716fe480"/>
+		<rom name="All-Star Baseball 2000 (USA).n64" />
+		<release name="All-Star Baseball 2000 (USA)" region="USA" />
+		<rom name="All-Star Baseball 2000 (USA).z64" size="16777216" crc="69e88471" md5="aada358ce97f06c4df5bf55987268844" sha1="4256a23902e22e6e8291f1931f8de4b2716fe480" />
 	</game>
 	<game name="All-Star Baseball 2001 (USA)">
 		<description>All-Star Baseball 2001 (USA)</description>
-		<release name="All-Star Baseball 2001 (USA)" region="USA"/>
-		<rom name="All-Star Baseball 2001 (USA).z64" size="16777216" crc="4d659e85" md5="6e01b8d425ae74ef5a0f875c700a3b18" sha1="4f1b8635322190bb3d0c6fc7d3ba844941f05574"/>
+		<rom name="All-Star Baseball 2001 (USA).n64" />
+		<release name="All-Star Baseball 2001 (USA)" region="USA" />
+		<rom name="All-Star Baseball 2001 (USA).z64" size="16777216" crc="4d659e85" md5="6e01b8d425ae74ef5a0f875c700a3b18" sha1="4f1b8635322190bb3d0c6fc7d3ba844941f05574" />
 	</game>
 	<game name="All-Star Baseball 99 (Europe)">
 		<description>All-Star Baseball 99 (Europe)</description>
-		<release name="All-Star Baseball 99 (Europe)" region="EUR"/>
-		<rom name="All-Star Baseball 99 (Europe).z64" size="12582912" crc="d0de3584" md5="ed5f1e12da36dbec8a0a24ed98d4aed5" sha1="3ac0d13f2260797dabf99cfedabf7e3676c5b2e2"/>
+		<rom name="All-Star Baseball 99 (Europe).n64" />
+		<release name="All-Star Baseball 99 (Europe)" region="EUR" />
+		<rom name="All-Star Baseball 99 (Europe).z64" size="12582912" crc="d0de3584" md5="ed5f1e12da36dbec8a0a24ed98d4aed5" sha1="3ac0d13f2260797dabf99cfedabf7e3676c5b2e2" />
 	</game>
 	<game name="All-Star Baseball 99 (USA)" cloneof="All-Star Baseball 99 (Europe)">
 		<description>All-Star Baseball 99 (USA)</description>
-		<release name="All-Star Baseball 99 (USA)" region="USA"/>
-		<rom name="All-Star Baseball 99 (USA).z64" size="12582912" crc="6d25b36f" md5="78551d23f230b58b9f449cdb4a285761" sha1="aa576624f2a66034cb0d6e621ba16a0d3beaca3a"/>
+		<rom name="All-Star Baseball 99 (USA).n64" />
+		<release name="All-Star Baseball 99 (USA)" region="USA" />
+		<rom name="All-Star Baseball 99 (USA).z64" size="12582912" crc="6d25b36f" md5="78551d23f230b58b9f449cdb4a285761" sha1="aa576624f2a66034cb0d6e621ba16a0d3beaca3a" />
 	</game>
 	<game name="Armorines - Project S.W.A.R.M. (Europe)">
 		<description>Armorines - Project S.W.A.R.M. (Europe)</description>
-		<release name="Armorines - Project S.W.A.R.M. (Europe)" region="EUR"/>
-		<rom name="Armorines - Project S.W.A.R.M. (Europe).z64" size="16777216" crc="600bc49e" md5="0c2cbafec6f184ad39ef29b2b5e0f44a" sha1="66f2b431d2275b2563692bfd053d4c0118e0e0c2"/>
+		<rom name="Armorines - Project S.W.A.R.M. (Europe).n64" />
+		<release name="Armorines - Project S.W.A.R.M. (Europe)" region="EUR" />
+		<rom name="Armorines - Project S.W.A.R.M. (Europe).z64" size="16777216" crc="600bc49e" md5="0c2cbafec6f184ad39ef29b2b5e0f44a" sha1="66f2b431d2275b2563692bfd053d4c0118e0e0c2" />
 	</game>
 	<game name="Armorines - Project S.W.A.R.M. (Germany)" cloneof="Armorines - Project S.W.A.R.M. (Europe)">
 		<description>Armorines - Project S.W.A.R.M. (Germany)</description>
-		<release name="Armorines - Project S.W.A.R.M. (Germany)" region="GER"/>
-		<rom name="Armorines - Project S.W.A.R.M. (Germany).z64" size="16777216" crc="5bab9100" md5="2bc48b3e6f61896b9bc7bef5205cc49c" sha1="68f9dda2863f7625a36f115419956dd9f249afe6"/>
+		<rom name="Armorines - Project S.W.A.R.M. (Germany).n64" />
+		<release name="Armorines - Project S.W.A.R.M. (Germany)" region="GER" />
+		<rom name="Armorines - Project S.W.A.R.M. (Germany).z64" size="16777216" crc="5bab9100" md5="2bc48b3e6f61896b9bc7bef5205cc49c" sha1="68f9dda2863f7625a36f115419956dd9f249afe6" />
 	</game>
 	<game name="Armorines - Project S.W.A.R.M. (USA)" cloneof="Armorines - Project S.W.A.R.M. (Europe)">
 		<description>Armorines - Project S.W.A.R.M. (USA)</description>
-		<release name="Armorines - Project S.W.A.R.M. (USA)" region="USA"/>
-		<rom name="Armorines - Project S.W.A.R.M. (USA).z64" size="16777216" crc="630a19e2" md5="6e6e7a703c131adaddf4175e9037a2eb" sha1="d9f55acf77a54eeb7f62577aa5711769ebeadde3"/>
+		<rom name="Armorines - Project S.W.A.R.M. (USA).n64" />
+		<release name="Armorines - Project S.W.A.R.M. (USA)" region="USA" />
+		<rom name="Armorines - Project S.W.A.R.M. (USA).z64" size="16777216" crc="630a19e2" md5="6e6e7a703c131adaddf4175e9037a2eb" sha1="d9f55acf77a54eeb7f62577aa5711769ebeadde3" />
 	</game>
 	<game name="Army Men - Air Combat (USA)">
 		<description>Army Men - Air Combat (USA)</description>
-		<release name="Army Men - Air Combat (USA)" region="USA"/>
-		<rom name="Army Men - Air Combat (USA).z64" size="8388608" crc="1952cc87" md5="755df7f57edf87706d4c80ff15883312" sha1="eb9bacb12eb6665be9936a3e1dfd6d57b2eaabdb"/>
+		<rom name="Army Men - Air Combat (USA).n64" />
+		<release name="Army Men - Air Combat (USA)" region="USA" />
+		<rom name="Army Men - Air Combat (USA).z64" size="8388608" crc="1952cc87" md5="755df7f57edf87706d4c80ff15883312" sha1="eb9bacb12eb6665be9936a3e1dfd6d57b2eaabdb" />
 	</game>
 	<game name="Army Men - Sarge's Heroes (Europe) (En,Fr,De)">
 		<description>Army Men - Sarge's Heroes (Europe) (En,Fr,De)</description>
-		<release name="Army Men - Sarge's Heroes (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Army Men - Sarge's Heroes (Europe) (En,Fr,De).z64" size="8388608" crc="e79048e2" md5="53e2872612760133ab7b2cc2e22b847c" sha1="00e594fa64da61c2ad3138a31a22b9854bb3fafa"/>
+		<rom name="Army Men - Sarge's Heroes (Europe) (En,Fr,De).n64" />
+		<release name="Army Men - Sarge's Heroes (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Army Men - Sarge's Heroes (Europe) (En,Fr,De).z64" size="8388608" crc="e79048e2" md5="53e2872612760133ab7b2cc2e22b847c" sha1="00e594fa64da61c2ad3138a31a22b9854bb3fafa" />
 	</game>
 	<game name="Army Men - Sarge's Heroes (USA)" cloneof="Army Men - Sarge's Heroes (Europe) (En,Fr,De)">
 		<description>Army Men - Sarge's Heroes (USA)</description>
-		<release name="Army Men - Sarge's Heroes (USA)" region="USA"/>
-		<rom name="Army Men - Sarge's Heroes (USA).z64" size="8388608" crc="2fe786f6" md5="b8085c2edb1c6d23e52ed8c06d92b4f8" sha1="1824380911579424e50042d45aef4851f7ab25a7"/>
+		<rom name="Army Men - Sarge's Heroes (USA).n64" />
+		<release name="Army Men - Sarge's Heroes (USA)" region="USA" />
+		<rom name="Army Men - Sarge's Heroes (USA).z64" size="8388608" crc="2fe786f6" md5="b8085c2edb1c6d23e52ed8c06d92b4f8" sha1="1824380911579424e50042d45aef4851f7ab25a7" />
 	</game>
 	<game name="Army Men - Sarge's Heroes 2 (USA)">
 		<description>Army Men - Sarge's Heroes 2 (USA)</description>
-		<release name="Army Men - Sarge's Heroes 2 (USA)" region="USA"/>
-		<rom name="Army Men - Sarge's Heroes 2 (USA).z64" size="8388608" crc="79a71608" md5="6eea5c4a6256092ed8f9ba8861c689c6" sha1="f32b6de2f87928378f26ca17b68b27d87fdefce1"/>
+		<rom name="Army Men - Sarge's Heroes 2 (USA).n64" />
+		<release name="Army Men - Sarge's Heroes 2 (USA)" region="USA" />
+		<rom name="Army Men - Sarge's Heroes 2 (USA).z64" size="8388608" crc="79a71608" md5="6eea5c4a6256092ed8f9ba8861c689c6" sha1="f32b6de2f87928378f26ca17b68b27d87fdefce1" />
 	</game>
 	<game name="Asteroids Hyper 64 (USA)">
 		<description>Asteroids Hyper 64 (USA)</description>
-		<release name="Asteroids Hyper 64 (USA)" region="USA"/>
-		<rom name="Asteroids Hyper 64 (USA).z64" size="4194304" crc="f5ce3d91" md5="874c7b7b365d2c20aaa1a0c90c93f9b8" sha1="329f4d560b0ba7da622edd9b84523e86e265fffe"/>
+		<rom name="Asteroids Hyper 64 (USA).n64" />
+		<release name="Asteroids Hyper 64 (USA)" region="USA" />
+		<rom name="Asteroids Hyper 64 (USA).z64" size="4194304" crc="f5ce3d91" md5="874c7b7b365d2c20aaa1a0c90c93f9b8" sha1="329f4d560b0ba7da622edd9b84523e86e265fffe" />
 	</game>
 	<game name="Automobili Lamborghini (Europe)">
 		<description>Automobili Lamborghini (Europe)</description>
-		<release name="Automobili Lamborghini (Europe)" region="EUR"/>
-		<rom name="Automobili Lamborghini (Europe).z64" size="4194304" crc="3baf58d5" md5="7853f02dc66a35bc8c2bc33d03b8f0ca" sha1="513c9511539bf2361ff20ee1f19dc03f618b5214" status="verified"/>
+		<rom name="Automobili Lamborghini (Europe).n64" />
+		<release name="Automobili Lamborghini (Europe)" region="EUR" />
+		<rom name="Automobili Lamborghini (Europe).z64" size="4194304" crc="3baf58d5" md5="7853f02dc66a35bc8c2bc33d03b8f0ca" sha1="513c9511539bf2361ff20ee1f19dc03f618b5214" status="verified" />
 	</game>
 	<game name="Automobili Lamborghini (USA)" cloneof="Automobili Lamborghini (Europe)">
 		<description>Automobili Lamborghini (USA)</description>
-		<release name="Automobili Lamborghini (USA)" region="USA"/>
-		<rom name="Automobili Lamborghini (USA).z64" size="4194304" crc="a4374eac" md5="ec39579f066a9714ff030d07dec3c9d3" sha1="78b36b48040426478011caef5e11884af2e80375"/>
+		<rom name="Automobili Lamborghini (USA).n64" />
+		<release name="Automobili Lamborghini (USA)" region="USA" />
+		<rom name="Automobili Lamborghini (USA).z64" size="4194304" crc="a4374eac" md5="ec39579f066a9714ff030d07dec3c9d3" sha1="78b36b48040426478011caef5e11884af2e80375" />
 	</game>
 	<game name="Super Speed Race 64 (Japan)" cloneof="Automobili Lamborghini (Europe)">
 		<description>Super Speed Race 64 (Japan)</description>
-		<release name="Super Speed Race 64 (Japan)" region="JPN"/>
-		<rom name="Super Speed Race 64 (Japan).z64" size="4194304" crc="0f879a70" md5="6b5d93b3566e96147009d1ac4fb15c97" sha1="e0a49ff953b882f9f135b583ef9e09a664d24288"/>
+		<rom name="Super Speed Race 64 (Japan).n64" />
+		<release name="Super Speed Race 64 (Japan)" region="JPN" />
+		<rom name="Super Speed Race 64 (Japan).z64" size="4194304" crc="0f879a70" md5="6b5d93b3566e96147009d1ac4fb15c97" sha1="e0a49ff953b882f9f135b583ef9e09a664d24288" />
 	</game>
 	<game name="Bakuretsu Muteki Bangaioh (Japan)">
 		<description>Bakuretsu Muteki Bangaioh (Japan)</description>
-		<release name="Bakuretsu Muteki Bangaioh (Japan)" region="JPN"/>
-		<rom name="Bakuretsu Muteki Bangaioh (Japan).z64" size="12582912" crc="6ab7fec6" md5="8107825ac2a522057422463ed81e276b" sha1="2dbfe78f97b8d6e1a33b73d244be831d18b0491e"/>
+		<rom name="Bakuretsu Muteki Bangaioh (Japan).n64" />
+		<release name="Bakuretsu Muteki Bangaioh (Japan)" region="JPN" />
+		<rom name="Bakuretsu Muteki Bangaioh (Japan).z64" size="12582912" crc="6ab7fec6" md5="8107825ac2a522057422463ed81e276b" sha1="2dbfe78f97b8d6e1a33b73d244be831d18b0491e" />
 	</game>
 	<game name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)">
 		<description>Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)</description>
-		<release name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)" region="JPN"/>
-		<rom name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).z64" size="12582912" crc="ef8c2f34" md5="09fd63afa1156405e618752fc583df93" sha1="28e6d11f6f48c86a9b7c112c672109e1c2d7e5d0"/>
+		<rom name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).n64" />
+		<release name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan)" region="JPN" />
+		<rom name="Bakushou Jinsei 64 - Mezase! Resort Ou (Japan).z64" size="12582912" crc="ef8c2f34" md5="09fd63afa1156405e618752fc583df93" sha1="28e6d11f6f48c86a9b7c112c672109e1c2d7e5d0" />
 	</game>
 	<game name="Banjo-Kazooie (Europe) (En,Fr,De)">
 		<description>Banjo-Kazooie (Europe) (En,Fr,De)</description>
-		<release name="Banjo-Kazooie (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Banjo-Kazooie (Europe) (En,Fr,De).z64" size="16777216" crc="525899c9" md5="06a43bacf5c0687f596df9b018ca6d7f" sha1="bb359a75941df74bf7290212c89fbc6e2c5601fe" status="verified"/>
+		<rom name="Banjo-Kazooie (Europe) (En,Fr,De).n64" />
+		<release name="Banjo-Kazooie (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Banjo-Kazooie (Europe) (En,Fr,De).z64" size="16777216" crc="525899c9" md5="06a43bacf5c0687f596df9b018ca6d7f" sha1="bb359a75941df74bf7290212c89fbc6e2c5601fe" status="verified" />
 	</game>
 	<game name="Banjo to Kazooie no Daibouken (Japan)" cloneof="Banjo-Kazooie (Europe) (En,Fr,De)">
 		<description>Banjo to Kazooie no Daibouken (Japan)</description>
-		<release name="Banjo to Kazooie no Daibouken (Japan)" region="JPN"/>
-		<rom name="Banjo to Kazooie no Daibouken (Japan).z64" size="16777216" crc="8f7c9324" md5="3d3855a86fd5a1b4d30beb0f5a4a85af" sha1="90726d7e7cd5bf6cdfd38f45c9acbf4d45bd9fd8" status="verified"/>
+		<rom name="Banjo to Kazooie no Daibouken (Japan).n64" />
+		<release name="Banjo to Kazooie no Daibouken (Japan)" region="JPN" />
+		<rom name="Banjo to Kazooie no Daibouken (Japan).z64" size="16777216" crc="8f7c9324" md5="3d3855a86fd5a1b4d30beb0f5a4a85af" sha1="90726d7e7cd5bf6cdfd38f45c9acbf4d45bd9fd8" status="verified" />
 	</game>
 	<game name="Banjo-Kazooie (USA)" cloneof="Banjo-Kazooie (Europe) (En,Fr,De)">
 		<description>Banjo-Kazooie (USA)</description>
-		<rom name="Banjo-Kazooie (USA).z64" size="16777216" crc="ad429961" md5="b29599651a13f681c9923d69354bf4a3" sha1="1fe1632098865f639e22c11b9a81ee8f29c75d7a" status="verified"/>
+		<rom name="Banjo-Kazooie (USA).n64" />
+		<rom name="Banjo-Kazooie (USA).z64" size="16777216" crc="ad429961" md5="b29599651a13f681c9923d69354bf4a3" sha1="1fe1632098865f639e22c11b9a81ee8f29c75d7a" status="verified" />
 	</game>
 	<game name="Banjo-Kazooie (USA) (Rev 1)" cloneof="Banjo-Kazooie (Europe) (En,Fr,De)">
 		<description>Banjo-Kazooie (USA) (Rev 1)</description>
-		<release name="Banjo-Kazooie (USA) (Rev 1)" region="USA"/>
-		<rom name="Banjo-Kazooie (USA) (Rev 1).z64" size="16777216" crc="fb7ffb10" md5="b11f476d4bc8e039355241e871dc08cf" sha1="ded6ee166e740ad1bc810fd678a84b48e245ab80"/>
+		<rom name="Banjo-Kazooie (USA) (Rev 1).n64" />
+		<release name="Banjo-Kazooie (USA) (Rev 1)" region="USA" />
+		<rom name="Banjo-Kazooie (USA) (Rev 1).z64" size="16777216" crc="fb7ffb10" md5="b11f476d4bc8e039355241e871dc08cf" sha1="ded6ee166e740ad1bc810fd678a84b48e245ab80" />
 	</game>
 	<game name="Banjo-Tooie (Europe) (En,Fr,De,Es)">
 		<description>Banjo-Tooie (Europe) (En,Fr,De,Es)</description>
-		<release name="Banjo-Tooie (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Banjo-Tooie (Europe) (En,Fr,De,Es).z64" size="33554432" crc="1ec12f5a" md5="8b2e56f18421a67bca861427453a1e19" sha1="93bf2fac1387320ad07251cb4b64fd36bac1d7a6" status="verified"/>
+		<rom name="Banjo-Tooie (Europe) (En,Fr,De,Es).n64" />
+		<release name="Banjo-Tooie (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Banjo-Tooie (Europe) (En,Fr,De,Es).z64" size="33554432" crc="1ec12f5a" md5="8b2e56f18421a67bca861427453a1e19" sha1="93bf2fac1387320ad07251cb4b64fd36bac1d7a6" status="verified" />
 	</game>
 	<game name="Banjo to Kazooie no Daibouken 2 (Japan)" cloneof="Banjo-Tooie (Europe) (En,Fr,De,Es)">
 		<description>Banjo to Kazooie no Daibouken 2 (Japan)</description>
-		<release name="Banjo to Kazooie no Daibouken 2 (Japan)" region="JPN"/>
-		<rom name="Banjo to Kazooie no Daibouken 2 (Japan).z64" size="33554432" crc="258c58d0" md5="715a8816f30fa24b8d174dc5cb6f25a9" sha1="5a5172383037d171f121790959962703be1f373c"/>
+		<rom name="Banjo to Kazooie no Daibouken 2 (Japan).n64" />
+		<release name="Banjo to Kazooie no Daibouken 2 (Japan)" region="JPN" />
+		<rom name="Banjo to Kazooie no Daibouken 2 (Japan).z64" size="33554432" crc="258c58d0" md5="715a8816f30fa24b8d174dc5cb6f25a9" sha1="5a5172383037d171f121790959962703be1f373c" />
 	</game>
 	<game name="Banjo-Tooie (Australia)" cloneof="Banjo-Tooie (Europe) (En,Fr,De,Es)">
 		<description>Banjo-Tooie (Australia)</description>
-		<release name="Banjo-Tooie (Australia)" region="AUS"/>
-		<rom name="Banjo-Tooie (Australia).z64" size="33554432" crc="2736266a" md5="61b5c5c3e5e1a81e5d37072c01b39b76" sha1="4ca2d332f6e6b018777afc6a8b7880b38b6dfb79"/>
+		<rom name="Banjo-Tooie (Australia).n64" />
+		<release name="Banjo-Tooie (Australia)" region="AUS" />
+		<rom name="Banjo-Tooie (Australia).z64" size="33554432" crc="2736266a" md5="61b5c5c3e5e1a81e5d37072c01b39b76" sha1="4ca2d332f6e6b018777afc6a8b7880b38b6dfb79" />
 	</game>
 	<game name="Banjo-Tooie (USA)" cloneof="Banjo-Tooie (Europe) (En,Fr,De,Es)">
 		<description>Banjo-Tooie (USA)</description>
-		<release name="Banjo-Tooie (USA)" region="USA"/>
-		<rom name="Banjo-Tooie (USA).z64" size="33554432" crc="bab803ef" md5="40e98faa24ac3ebe1d25cb5e5ddf49e4" sha1="af1a89e12b638b8d82cc4c085c8e01d4cba03fb3"/>
+		<rom name="Banjo-Tooie (USA).n64" />
+		<release name="Banjo-Tooie (USA)" region="USA" />
+		<rom name="Banjo-Tooie (USA).z64" size="33554432" crc="bab803ef" md5="40e98faa24ac3ebe1d25cb5e5ddf49e4" sha1="af1a89e12b638b8d82cc4c085c8e01d4cba03fb3" />
 	</game>
 	<game name="Bass Rush - ECOGEAR PowerWorm Championship (Japan)">
 		<description>Bass Rush - ECOGEAR PowerWorm Championship (Japan)</description>
-		<release name="Bass Rush - ECOGEAR PowerWorm Championship (Japan)" region="JPN"/>
-		<rom name="Bass Rush - ECOGEAR PowerWorm Championship (Japan).z64" size="33554432" crc="383b86ef" md5="2c618f6c69c3b4803f08762a03835139" sha1="1718c9048cb7849a59d48138a058b20bf191ebf6"/>
+		<rom name="Bass Rush - ECOGEAR PowerWorm Championship (Japan).n64" />
+		<release name="Bass Rush - ECOGEAR PowerWorm Championship (Japan)" region="JPN" />
+		<rom name="Bass Rush - ECOGEAR PowerWorm Championship (Japan).z64" size="33554432" crc="383b86ef" md5="2c618f6c69c3b4803f08762a03835139" sha1="1718c9048cb7849a59d48138a058b20bf191ebf6" />
 	</game>
 	<game name="Bassmasters 2000 (USA)">
 		<description>Bassmasters 2000 (USA)</description>
-		<release name="Bassmasters 2000 (USA)" region="USA"/>
-		<rom name="Bassmasters 2000 (USA).z64" size="12582912" crc="6b09092e" md5="930c7f6e5863471dde1816d28a10eb88" sha1="946b3e08a1a4de4f917ad547bb24f533b737f712"/>
+		<rom name="Bassmasters 2000 (USA).n64" />
+		<release name="Bassmasters 2000 (USA)" region="USA" />
+		<rom name="Bassmasters 2000 (USA).z64" size="12582912" crc="6b09092e" md5="930c7f6e5863471dde1816d28a10eb88" sha1="946b3e08a1a4de4f917ad547bb24f533b737f712" />
 	</game>
 	<game name="Bassmasters 2000 (USA) (Beta)" cloneof="Bassmasters 2000 (USA)">
 		<description>Bassmasters 2000 (USA) (Beta)</description>
-		<rom name="Bassmasters 2000 (USA) (Beta).z64" size="33554432" crc="86f8e439" md5="684f4f7cefcc0863710799c8a43dd882" sha1="aa5e9d5eccd278bc59d995e31431715d67e93fe2"/>
+		<rom name="Bassmasters 2000 (USA) (Beta).n64" />
+		<rom name="Bassmasters 2000 (USA) (Beta).z64" size="33554432" crc="86f8e439" md5="684f4f7cefcc0863710799c8a43dd882" sha1="aa5e9d5eccd278bc59d995e31431715d67e93fe2" />
 	</game>
 	<game name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De)">
 		<description>Batman of the Future - Return of the Joker (Europe) (En,Fr,De)</description>
-		<release name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De).z64" size="4194304" crc="82a4bb8a" md5="a5ee8a6c34863e3d0eb8c06ae8668b30" sha1="3954131395f98e605072bea11cc85842da58f754"/>
+		<rom name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De).n64" />
+		<release name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Batman of the Future - Return of the Joker (Europe) (En,Fr,De).z64" size="4194304" crc="82a4bb8a" md5="a5ee8a6c34863e3d0eb8c06ae8668b30" sha1="3954131395f98e605072bea11cc85842da58f754" />
 	</game>
 	<game name="Batman Beyond - Return of the Joker (USA)" cloneof="Batman of the Future - Return of the Joker (Europe) (En,Fr,De)">
 		<description>Batman Beyond - Return of the Joker (USA)</description>
-		<release name="Batman Beyond - Return of the Joker (USA)" region="USA"/>
-		<rom name="Batman Beyond - Return of the Joker (USA).z64" size="4194304" crc="35299f9c" md5="a08676124b326b1035b202c83a97468f" sha1="f7382358250965e9757ba9a89fe42d033dbe7fe8"/>
+		<rom name="Batman Beyond - Return of the Joker (USA).n64" />
+		<release name="Batman Beyond - Return of the Joker (USA)" region="USA" />
+		<rom name="Batman Beyond - Return of the Joker (USA).z64" size="4194304" crc="35299f9c" md5="a08676124b326b1035b202c83a97468f" sha1="f7382358250965e9757ba9a89fe42d033dbe7fe8" />
 	</game>
 	<game name="BattleTanx (USA)">
 		<description>BattleTanx (USA)</description>
-		<release name="BattleTanx (USA)" region="USA"/>
-		<rom name="BattleTanx (USA).z64" size="8388608" crc="6c230765" md5="3406a505c22bac2f40d9bfc6ff08cf86" sha1="535860d941738ac1210c20a9b80114fea0e0ff17"/>
+		<rom name="BattleTanx (USA).n64" />
+		<release name="BattleTanx (USA)" region="USA" />
+		<rom name="BattleTanx (USA).z64" size="8388608" crc="6c230765" md5="3406a505c22bac2f40d9bfc6ff08cf86" sha1="535860d941738ac1210c20a9b80114fea0e0ff17" />
 	</game>
 	<game name="BattleTanx - Global Assault (Europe) (En,Fr,De)">
 		<description>BattleTanx - Global Assault (Europe) (En,Fr,De)</description>
-		<release name="BattleTanx - Global Assault (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="BattleTanx - Global Assault (Europe) (En,Fr,De).z64" size="8388608" crc="c99c6030" md5="d6e667fe10afe8f7116888efde98ae0e" sha1="aefade7a37a4716ddc82a6b67ba085cbf7c27259"/>
+		<rom name="BattleTanx - Global Assault (Europe) (En,Fr,De).n64" />
+		<release name="BattleTanx - Global Assault (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="BattleTanx - Global Assault (Europe) (En,Fr,De).z64" size="8388608" crc="c99c6030" md5="d6e667fe10afe8f7116888efde98ae0e" sha1="aefade7a37a4716ddc82a6b67ba085cbf7c27259" />
 	</game>
 	<game name="BattleTanx - Global Assault (USA)" cloneof="BattleTanx - Global Assault (Europe) (En,Fr,De)">
 		<description>BattleTanx - Global Assault (USA)</description>
-		<release name="BattleTanx - Global Assault (USA)" region="USA"/>
-		<rom name="BattleTanx - Global Assault (USA).z64" size="8388608" crc="31beb053" md5="654557c316f901a2ca6f7f4b43343147" sha1="805248fb0a0ee694cad8d7dc927b631d860dd8cf"/>
+		<rom name="BattleTanx - Global Assault (USA).n64" />
+		<release name="BattleTanx - Global Assault (USA)" region="USA" />
+		<rom name="BattleTanx - Global Assault (USA).z64" size="8388608" crc="31beb053" md5="654557c316f901a2ca6f7f4b43343147" sha1="805248fb0a0ee694cad8d7dc927b631d860dd8cf" />
 	</game>
 	<game name="Battlezone - Rise of the Black Dogs (USA)">
 		<description>Battlezone - Rise of the Black Dogs (USA)</description>
-		<release name="Battlezone - Rise of the Black Dogs (USA)" region="USA"/>
-		<rom name="Battlezone - Rise of the Black Dogs (USA).z64" size="16777216" crc="736f9d5c" md5="266c0989ed0929df499389954779ea97" sha1="85b4febbe6fbd1ecfc883905e43e68e7188c44f9"/>
+		<rom name="Battlezone - Rise of the Black Dogs (USA).n64" />
+		<release name="Battlezone - Rise of the Black Dogs (USA)" region="USA" />
+		<rom name="Battlezone - Rise of the Black Dogs (USA).z64" size="16777216" crc="736f9d5c" md5="266c0989ed0929df499389954779ea97" sha1="85b4febbe6fbd1ecfc883905e43e68e7188c44f9" />
 	</game>
 	<game name="Beetle Adventure Racing! (Europe) (En,Fr,De)">
 		<description>Beetle Adventure Racing! (Europe) (En,Fr,De)</description>
-		<release name="Beetle Adventure Racing! (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Beetle Adventure Racing! (Europe) (En,Fr,De).z64" size="16777216" crc="5b6c6e4c" md5="a94135d163e6091c960adc918c1fb8a7" sha1="85b3b95d587d2646f781b04cf5239804d105685a"/>
+		<rom name="Beetle Adventure Racing! (Europe) (En,Fr,De).n64" />
+		<release name="Beetle Adventure Racing! (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Beetle Adventure Racing! (Europe) (En,Fr,De).z64" size="16777216" crc="5b6c6e4c" md5="a94135d163e6091c960adc918c1fb8a7" sha1="85b3b95d587d2646f781b04cf5239804d105685a" />
 	</game>
 	<game name="Beetle Adventure Racing! (Japan)" cloneof="Beetle Adventure Racing! (Europe) (En,Fr,De)">
 		<description>Beetle Adventure Racing! (Japan)</description>
-		<release name="Beetle Adventure Racing! (Japan)" region="JPN"/>
-		<rom name="Beetle Adventure Racing! (Japan).z64" size="16777216" crc="49e75825" md5="5ffd43089b7334072b2b74421618d973" sha1="d6e943a8733d3c09795f4be24b75c7fb0c30a27d"/>
+		<rom name="Beetle Adventure Racing! (Japan).n64" />
+		<release name="Beetle Adventure Racing! (Japan)" region="JPN" />
+		<rom name="Beetle Adventure Racing! (Japan).z64" size="16777216" crc="49e75825" md5="5ffd43089b7334072b2b74421618d973" sha1="d6e943a8733d3c09795f4be24b75c7fb0c30a27d" />
 	</game>
 	<game name="Beetle Adventure Racing! (USA) (En,Fr,De)" cloneof="Beetle Adventure Racing! (Europe) (En,Fr,De)">
 		<description>Beetle Adventure Racing! (USA) (En,Fr,De)</description>
-		<release name="Beetle Adventure Racing! (USA) (En,Fr,De)" region="USA"/>
-		<rom name="Beetle Adventure Racing! (USA) (En,Fr,De).z64" size="16777216" crc="f4a97c73" md5="cf97c336479ddbf1217e4dde89d9d2d3" sha1="e5ab4d226c08d22f68a2edcc48870203e67454b8"/>
+		<rom name="Beetle Adventure Racing! (USA) (En,Fr,De).n64" />
+		<release name="Beetle Adventure Racing! (USA) (En,Fr,De)" region="USA" />
+		<rom name="Beetle Adventure Racing! (USA) (En,Fr,De).z64" size="16777216" crc="f4a97c73" md5="cf97c336479ddbf1217e4dde89d9d2d3" sha1="e5ab4d226c08d22f68a2edcc48870203e67454b8" />
 	</game>
 	<game name="HSV Adventure Racing! (Australia)" cloneof="Beetle Adventure Racing! (Europe) (En,Fr,De)">
 		<description>HSV Adventure Racing! (Australia)</description>
-		<release name="HSV Adventure Racing! (Australia)" region="AUS"/>
-		<rom name="HSV Adventure Racing! (Australia).z64" size="16777216" crc="c0ba9440" md5="26f7d8f4640ebdfa823f84e5f89d62bf" sha1="8a9cdc2a7d98c354ba4b31cea644dbd5153880ae" status="verified"/>
+		<rom name="HSV Adventure Racing! (Australia).n64" />
+		<release name="HSV Adventure Racing! (Australia)" region="AUS" />
+		<rom name="HSV Adventure Racing! (Australia).z64" size="16777216" crc="c0ba9440" md5="26f7d8f4640ebdfa823f84e5f89d62bf" sha1="8a9cdc2a7d98c354ba4b31cea644dbd5153880ae" status="verified" />
 	</game>
 	<game name="Big Mountain 2000 (USA)">
 		<description>Big Mountain 2000 (USA)</description>
-		<release name="Big Mountain 2000 (USA)" region="USA"/>
-		<rom name="Big Mountain 2000 (USA).z64" size="12582912" crc="3ac924bc" md5="bf6780e2982c16d4a4fdb553be8f9226" sha1="e28f3ebfb7bc706cce639fc1874243e1d4995d1d"/>
+		<rom name="Big Mountain 2000 (USA).n64" />
+		<release name="Big Mountain 2000 (USA)" region="USA" />
+		<rom name="Big Mountain 2000 (USA).z64" size="12582912" crc="3ac924bc" md5="bf6780e2982c16d4a4fdb553be8f9226" sha1="e28f3ebfb7bc706cce639fc1874243e1d4995d1d" />
 	</game>
 	<game name="Snow Speeder (Japan)" cloneof="Big Mountain 2000 (USA)">
 		<description>Snow Speeder (Japan)</description>
-		<release name="Snow Speeder (Japan)" region="JPN"/>
-		<rom name="Snow Speeder (Japan).z64" size="12582912" crc="30ea3fd7" md5="f7e66da23c8bb8e59f641a636a9cae82" sha1="0e7df6a6f053f37a168ec33af8ce5240cb18f0ee"/>
+		<rom name="Snow Speeder (Japan).n64" />
+		<release name="Snow Speeder (Japan)" region="JPN" />
+		<rom name="Snow Speeder (Japan).z64" size="12582912" crc="30ea3fd7" md5="f7e66da23c8bb8e59f641a636a9cae82" sha1="0e7df6a6f053f37a168ec33af8ce5240cb18f0ee" />
 	</game>
 	<game name="Bio F.R.E.A.K.S. (Europe)">
 		<description>Bio F.R.E.A.K.S. (Europe)</description>
-		<release name="Bio F.R.E.A.K.S. (Europe)" region="EUR"/>
-		<rom name="Bio F.R.E.A.K.S. (Europe).z64" size="16777216" crc="2c4eb906" md5="42672ba5e98cd21d7f3e3745e69038dd" sha1="8a85ec7d68954a36569f28f6a26981d6f283fd6d"/>
+		<rom name="Bio F.R.E.A.K.S. (Europe).n64" />
+		<release name="Bio F.R.E.A.K.S. (Europe)" region="EUR" />
+		<rom name="Bio F.R.E.A.K.S. (Europe).z64" size="16777216" crc="2c4eb906" md5="42672ba5e98cd21d7f3e3745e69038dd" sha1="8a85ec7d68954a36569f28f6a26981d6f283fd6d" />
 	</game>
 	<game name="Bio F.R.E.A.K.S. (USA)" cloneof="Bio F.R.E.A.K.S. (Europe)">
 		<description>Bio F.R.E.A.K.S. (USA)</description>
-		<release name="Bio F.R.E.A.K.S. (USA)" region="USA"/>
-		<rom name="Bio F.R.E.A.K.S. (USA).z64" size="16777216" crc="dfbf448c" md5="b90ab8f7605d971cc7a6d9ba5e67d1af" sha1="e20e9124480b559aa7148412c8993804501e180d"/>
+		<rom name="Bio F.R.E.A.K.S. (USA).n64" />
+		<release name="Bio F.R.E.A.K.S. (USA)" region="USA" />
+		<rom name="Bio F.R.E.A.K.S. (USA).z64" size="16777216" crc="dfbf448c" md5="b90ab8f7605d971cc7a6d9ba5e67d1af" sha1="e20e9124480b559aa7148412c8993804501e180d" />
 	</game>
 	<game name="Blast Corps (Europe) (En,De)">
 		<description>Blast Corps (Europe) (En,De)</description>
-		<release name="Blast Corps (Europe) (En,De)" region="EUR"/>
-		<rom name="Blast Corps (Europe) (En,De).z64" size="8388608" crc="4c820695" md5="889d4d337ad11ce94357511c725eab6a" sha1="460212600f8b9f0da95219c4c7330f2e626d9a7e" status="verified"/>
+		<rom name="Blast Corps (Europe) (En,De).n64" />
+		<release name="Blast Corps (Europe) (En,De)" region="EUR" />
+		<rom name="Blast Corps (Europe) (En,De).z64" size="8388608" crc="4c820695" md5="889d4d337ad11ce94357511c725eab6a" sha1="460212600f8b9f0da95219c4c7330f2e626d9a7e" status="verified" />
 	</game>
 	<game name="Blast Corps (USA)" cloneof="Blast Corps (Europe) (En,De)">
 		<description>Blast Corps (USA)</description>
-		<rom name="Blast Corps (USA).z64" size="8388608" crc="767a95e7" md5="a8dfdff49144627492da9b0b65b91845" sha1="185a6ef7ba1adb243278062c81a7d4e119bda58c"/>
+		<rom name="Blast Corps (USA).n64" />
+		<rom name="Blast Corps (USA).z64" size="8388608" crc="767a95e7" md5="a8dfdff49144627492da9b0b65b91845" sha1="185a6ef7ba1adb243278062c81a7d4e119bda58c" />
 	</game>
 	<game name="Blast Corps (USA) (Rev 1)" cloneof="Blast Corps (Europe) (En,De)">
 		<description>Blast Corps (USA) (Rev 1)</description>
-		<release name="Blast Corps (USA) (Rev 1)" region="USA"/>
-		<rom name="Blast Corps (USA) (Rev 1).z64" size="8388608" crc="9cbbccf1" md5="5875fc73069077c93e214233b60f0bdc" sha1="483f7161aea39de8b45c9fbc70a2c3883c4dea8c"/>
+		<rom name="Blast Corps (USA) (Rev 1).n64" />
+		<release name="Blast Corps (USA) (Rev 1)" region="USA" />
+		<rom name="Blast Corps (USA) (Rev 1).z64" size="8388608" crc="9cbbccf1" md5="5875fc73069077c93e214233b60f0bdc" sha1="483f7161aea39de8b45c9fbc70a2c3883c4dea8c" />
 	</game>
 	<game name="Blastdozer (Japan)" cloneof="Blast Corps (Europe) (En,De)">
 		<description>Blastdozer (Japan)</description>
-		<release name="Blastdozer (Japan)" region="JPN"/>
-		<rom name="Blastdozer (Japan).z64" size="8388608" crc="081a3641" md5="16b82d53d7f038a8fe67a78027720516" sha1="b147fdbeb661c89107c440b00dc4810508f58636"/>
+		<rom name="Blastdozer (Japan).n64" />
+		<release name="Blastdozer (Japan)" region="JPN" />
+		<rom name="Blastdozer (Japan).z64" size="8388608" crc="081a3641" md5="16b82d53d7f038a8fe67a78027720516" sha1="b147fdbeb661c89107c440b00dc4810508f58636" />
 	</game>
 	<game name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="8fb41658" md5="31b4a8ed52b48e756b344c9f22736e50" sha1="d641afca71a7d83587f9d7105d5e6dffdeaa8016"/>
+		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="8fb41658" md5="31b4a8ed52b48e756b344c9f22736e50" sha1="d641afca71a7d83587f9d7105d5e6dffdeaa8016" />
 	</game>
 	<game name="Blues Brothers 2000 (USA)" cloneof="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Blues Brothers 2000 (USA)</description>
-		<release name="Blues Brothers 2000 (USA)" region="USA"/>
-		<rom name="Blues Brothers 2000 (USA).z64" size="16777216" crc="c6f49764" md5="997fd8f79cd6f3cd1c1c1fd21e358717" sha1="ed0fe7c9a2e8015bdf8262d35065f53c6fcea60f"/>
+		<rom name="Blues Brothers 2000 (USA).n64" />
+		<release name="Blues Brothers 2000 (USA)" region="USA" />
+		<rom name="Blues Brothers 2000 (USA).z64" size="16777216" crc="c6f49764" md5="997fd8f79cd6f3cd1c1c1fd21e358717" sha1="ed0fe7c9a2e8015bdf8262d35065f53c6fcea60f" />
 	</game>
 	<game name="Blues Brothers 2000 (USA) (Beta) (2000-01-15)" cloneof="Blues Brothers 2000 (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Blues Brothers 2000 (USA) (Beta) (2000-01-15)</description>
-		<rom name="Blues Brothers 2000 (USA) (Beta) (2000-01-15).z64" size="33554432" crc="bb1ca04d" md5="410bf50920c28ce6d2c36174f659b0d7" sha1="b0f2546c0dbc4d8cc095337a288736e785219d02"/>
+		<rom name="Blues Brothers 2000 (USA) (Beta) (2000-01-15).n64" />
+		<rom name="Blues Brothers 2000 (USA) (Beta) (2000-01-15).z64" size="33554432" crc="bb1ca04d" md5="410bf50920c28ce6d2c36174f659b0d7" sha1="b0f2546c0dbc4d8cc095337a288736e785219d02" />
 	</game>
 	<game name="Body Harvest (Europe) (En,Fr,De)">
 		<description>Body Harvest (Europe) (En,Fr,De)</description>
-		<release name="Body Harvest (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Body Harvest (Europe) (En,Fr,De).z64" size="12582912" crc="6a04cdae" md5="b27fa5e9ad0cb47bb3a74ffac7bc8edf" sha1="67750e2e7ab46fedf65a271ab7f4c7aad92ae355" status="verified"/>
+		<rom name="Body Harvest (Europe) (En,Fr,De).n64" />
+		<release name="Body Harvest (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Body Harvest (Europe) (En,Fr,De).z64" size="12582912" crc="6a04cdae" md5="b27fa5e9ad0cb47bb3a74ffac7bc8edf" sha1="67750e2e7ab46fedf65a271ab7f4c7aad92ae355" status="verified" />
 	</game>
 	<game name="Body Harvest (USA)" cloneof="Body Harvest (Europe) (En,Fr,De)">
 		<description>Body Harvest (USA)</description>
-		<release name="Body Harvest (USA)" region="USA"/>
-		<rom name="Body Harvest (USA).z64" size="12582912" crc="fabbdf02" md5="3b8585ed03e8ddb89d7de456317545e7" sha1="bbb6666f5014a473747ee4145f036d9fb25d7348"/>
+		<rom name="Body Harvest (USA).n64" />
+		<release name="Body Harvest (USA)" region="USA" />
+		<rom name="Body Harvest (USA).z64" size="12582912" crc="fabbdf02" md5="3b8585ed03e8ddb89d7de456317545e7" sha1="bbb6666f5014a473747ee4145f036d9fb25d7348" />
 	</game>
 	<game name="Bomberman 64 (Europe)">
 		<description>Bomberman 64 (Europe)</description>
-		<release name="Bomberman 64 (Europe)" region="EUR"/>
-		<rom name="Bomberman 64 (Europe).z64" size="8388608" crc="525339c5" md5="b68f49aa8f6f7499184ac6b7b8570f2b" sha1="01e50f41733994bf229bee3b3d8aa9fd46441175" status="verified"/>
+		<rom name="Bomberman 64 (Europe).n64" />
+		<release name="Bomberman 64 (Europe)" region="EUR" />
+		<rom name="Bomberman 64 (Europe).z64" size="8388608" crc="525339c5" md5="b68f49aa8f6f7499184ac6b7b8570f2b" sha1="01e50f41733994bf229bee3b3d8aa9fd46441175" status="verified" />
 	</game>
 	<game name="Baku Bomberman (Japan)" cloneof="Bomberman 64 (Europe)">
 		<description>Baku Bomberman (Japan)</description>
-		<release name="Baku Bomberman (Japan)" region="JPN"/>
-		<rom name="Baku Bomberman (Japan).z64" size="8388608" crc="22f54a52" md5="8183688a4b7d0a390496b5655bcd252e" sha1="4813b147d552f72fdb0b306469bf9aa0f820fd5b"/>
+		<rom name="Baku Bomberman (Japan).n64" />
+		<release name="Baku Bomberman (Japan)" region="JPN" />
+		<rom name="Baku Bomberman (Japan).z64" size="8388608" crc="22f54a52" md5="8183688a4b7d0a390496b5655bcd252e" sha1="4813b147d552f72fdb0b306469bf9aa0f820fd5b" />
 	</game>
 	<game name="Bomberman 64 (USA)" cloneof="Bomberman 64 (Europe)">
 		<description>Bomberman 64 (USA)</description>
-		<release name="Bomberman 64 (USA)" region="USA"/>
-		<rom name="Bomberman 64 (USA).z64" size="8388608" crc="3ed0e0dc" md5="093058ece14c8cc1a887b2087eb5cfe9" sha1="8a7648d8105ac4fc1ad942291b2ef89aeca921c9"/>
+		<rom name="Bomberman 64 (USA).n64" />
+		<release name="Bomberman 64 (USA)" region="USA" />
+		<rom name="Bomberman 64 (USA).z64" size="8388608" crc="3ed0e0dc" md5="093058ece14c8cc1a887b2087eb5cfe9" sha1="8a7648d8105ac4fc1ad942291b2ef89aeca921c9" />
 	</game>
 	<game name="Bomberman 64 (Japan)">
 		<description>Bomberman 64 (Japan)</description>
-		<release name="Bomberman 64 (Japan)" region="JPN"/>
-		<rom name="Bomberman 64 (Japan).z64" size="12582912" crc="7e74eedc" md5="08e491f87445c6e5c168d982fc665d5f" sha1="1f2e0598730a2f7ea1987603e505af45879e194a"/>
+		<rom name="Bomberman 64 (Japan).n64" />
+		<release name="Bomberman 64 (Japan)" region="JPN" />
+		<rom name="Bomberman 64 (Japan).z64" size="12582912" crc="7e74eedc" md5="08e491f87445c6e5c168d982fc665d5f" sha1="1f2e0598730a2f7ea1987603e505af45879e194a" />
 	</game>
 	<game name="Bomberman 64 - The Second Attack! (USA)">
 		<description>Bomberman 64 - The Second Attack! (USA)</description>
-		<release name="Bomberman 64 - The Second Attack! (USA)" region="USA"/>
-		<rom name="Bomberman 64 - The Second Attack! (USA).z64" size="16777216" crc="57550007" md5="aec1fdb0f1caad86c9f457989a4ce482" sha1="66b1fd763793ecc6e03aa6c5d023df8de5351b9e"/>
+		<rom name="Bomberman 64 - The Second Attack! (USA).n64" />
+		<release name="Bomberman 64 - The Second Attack! (USA)" region="USA" />
+		<rom name="Bomberman 64 - The Second Attack! (USA).z64" size="16777216" crc="57550007" md5="aec1fdb0f1caad86c9f457989a4ce482" sha1="66b1fd763793ecc6e03aa6c5d023df8de5351b9e" />
 	</game>
 	<game name="Baku Bomberman 2 (Japan)" cloneof="Bomberman 64 - The Second Attack! (USA)">
 		<description>Baku Bomberman 2 (Japan)</description>
-		<release name="Baku Bomberman 2 (Japan)" region="JPN"/>
-		<rom name="Baku Bomberman 2 (Japan).z64" size="16777216" crc="86bbc278" md5="ca956015b6820dcff1c814f3532e18b1" sha1="179cab7426755f14bd3f4999f3789eb6d7af64c4"/>
+		<rom name="Baku Bomberman 2 (Japan).n64" />
+		<release name="Baku Bomberman 2 (Japan)" region="JPN" />
+		<rom name="Baku Bomberman 2 (Japan).z64" size="16777216" crc="86bbc278" md5="ca956015b6820dcff1c814f3532e18b1" sha1="179cab7426755f14bd3f4999f3789eb6d7af64c4" />
 	</game>
 	<game name="Bomberman Hero (Europe)">
 		<description>Bomberman Hero (Europe)</description>
-		<release name="Bomberman Hero (Europe)" region="EUR"/>
-		<rom name="Bomberman Hero (Europe).z64" size="12582912" crc="59e39947" md5="f79ef0813157880ffbad6199e07579be" sha1="ba1e6a4cc323a83d7c14573c9128ab9f9b60e5f2" status="verified"/>
+		<rom name="Bomberman Hero (Europe).n64" />
+		<release name="Bomberman Hero (Europe)" region="EUR" />
+		<rom name="Bomberman Hero (Europe).z64" size="12582912" crc="59e39947" md5="f79ef0813157880ffbad6199e07579be" sha1="ba1e6a4cc323a83d7c14573c9128ab9f9b60e5f2" status="verified" />
 	</game>
 	<game name="Bomberman Hero (USA)" cloneof="Bomberman Hero (Europe)">
 		<description>Bomberman Hero (USA)</description>
-		<release name="Bomberman Hero (USA)" region="USA"/>
-		<rom name="Bomberman Hero (USA).z64" size="12582912" crc="2cc2e634" md5="ef2453bff7ad0c4bfa9ab0bd6324ebf3" sha1="a36364b7e59351f7551ab351cb3b41ebc4be285b" status="verified"/>
+		<rom name="Bomberman Hero (USA).n64" />
+		<release name="Bomberman Hero (USA)" region="USA" />
+		<rom name="Bomberman Hero (USA).z64" size="12582912" crc="2cc2e634" md5="ef2453bff7ad0c4bfa9ab0bd6324ebf3" sha1="a36364b7e59351f7551ab351cb3b41ebc4be285b" status="verified" />
 	</game>
 	<game name="Bomberman Hero - Mirian Oujo o Sukue! (Japan)" cloneof="Bomberman Hero (Europe)">
 		<description>Bomberman Hero - Mirian Oujo o Sukue! (Japan)</description>
-		<release name="Bomberman Hero - Mirian Oujo o Sukue! (Japan)" region="JPN"/>
-		<rom name="Bomberman Hero - Mirian Oujo o Sukue! (Japan).z64" size="12582912" crc="69ceabcc" md5="ee273763c7391458865ff26c7ea0c3f1" sha1="ae3f4f7c31ddbd14843d9beb932fc5aa21746211" status="verified"/>
+		<rom name="Bomberman Hero - Mirian Oujo o Sukue! (Japan).n64" />
+		<release name="Bomberman Hero - Mirian Oujo o Sukue! (Japan)" region="JPN" />
+		<rom name="Bomberman Hero - Mirian Oujo o Sukue! (Japan).z64" size="12582912" crc="69ceabcc" md5="ee273763c7391458865ff26c7ea0c3f1" sha1="ae3f4f7c31ddbd14843d9beb932fc5aa21746211" status="verified" />
 	</game>
 	<game name="Bottom of the 9th (USA)">
 		<description>Bottom of the 9th (USA)</description>
-		<release name="Bottom of the 9th (USA)" region="USA"/>
-		<rom name="Bottom of the 9th (USA).z64" size="16777216" crc="1844c8ca" md5="fb19afd5e8c49978e6e6ae3622e0498a" sha1="4ee0e3768b9f23112e4e5ef0c81a2b29ae22eab2"/>
+		<rom name="Bottom of the 9th (USA).n64" />
+		<release name="Bottom of the 9th (USA)" region="USA" />
+		<rom name="Bottom of the 9th (USA).z64" size="16777216" crc="1844c8ca" md5="fb19afd5e8c49978e6e6ae3622e0498a" sha1="4ee0e3768b9f23112e4e5ef0c81a2b29ae22eab2" />
 	</game>
 	<game name="Brunswick Circuit Pro Bowling (USA)">
 		<description>Brunswick Circuit Pro Bowling (USA)</description>
-		<release name="Brunswick Circuit Pro Bowling (USA)" region="USA"/>
-		<rom name="Brunswick Circuit Pro Bowling (USA).z64" size="8388608" crc="80d70173" md5="62e92102d6fd1701a6e904da6ab58ae8" sha1="91f6f7843a7413126a7b4026104526615f979134"/>
+		<rom name="Brunswick Circuit Pro Bowling (USA).n64" />
+		<release name="Brunswick Circuit Pro Bowling (USA)" region="USA" />
+		<rom name="Brunswick Circuit Pro Bowling (USA).z64" size="8388608" crc="80d70173" md5="62e92102d6fd1701a6e904da6ab58ae8" sha1="91f6f7843a7413126a7b4026104526615f979134" />
 	</game>
 	<game name="Buck Bumble (Europe) (En,Fr,De,Es,It)">
 		<description>Buck Bumble (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Buck Bumble (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Buck Bumble (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="e26192ab" md5="a2e4be02876cb0f0d1e925ff95090c96" sha1="1123bfac4ec3730a54900ca83e196065cbb4b6e2" status="verified"/>
+		<rom name="Buck Bumble (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Buck Bumble (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Buck Bumble (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="e26192ab" md5="a2e4be02876cb0f0d1e925ff95090c96" sha1="1123bfac4ec3730a54900ca83e196065cbb4b6e2" status="verified" />
 	</game>
 	<game name="Buck Bumble (Japan)" cloneof="Buck Bumble (Europe) (En,Fr,De,Es,It)">
 		<description>Buck Bumble (Japan)</description>
-		<release name="Buck Bumble (Japan)" region="JPN"/>
-		<rom name="Buck Bumble (Japan).z64" size="12582912" crc="2ed81a65" md5="aee981977d8f069003574cd10a268d47" sha1="38007f846a454ad09d2090f0ef86e9762a46ccf7"/>
+		<rom name="Buck Bumble (Japan).n64" />
+		<release name="Buck Bumble (Japan)" region="JPN" />
+		<rom name="Buck Bumble (Japan).z64" size="12582912" crc="2ed81a65" md5="aee981977d8f069003574cd10a268d47" sha1="38007f846a454ad09d2090f0ef86e9762a46ccf7" />
 	</game>
 	<game name="Buck Bumble (USA)" cloneof="Buck Bumble (Europe) (En,Fr,De,Es,It)">
 		<description>Buck Bumble (USA)</description>
-		<release name="Buck Bumble (USA)" region="USA"/>
-		<rom name="Buck Bumble (USA).z64" size="12582912" crc="8ec937db" md5="41417fce2b37eaae787c5a845a0015c4" sha1="01d9497ea0e1f68ae285b8c7a57439b42b7d9a56"/>
+		<rom name="Buck Bumble (USA).n64" />
+		<release name="Buck Bumble (USA)" region="USA" />
+		<rom name="Buck Bumble (USA).z64" size="12582912" crc="8ec937db" md5="41417fce2b37eaae787c5a845a0015c4" sha1="01d9497ea0e1f68ae285b8c7a57439b42b7d9a56" />
 	</game>
 	<game name="Bug's Life, A (Europe)">
 		<description>Bug's Life, A (Europe)</description>
-		<release name="Bug's Life, A (Europe)" region="EUR"/>
-		<rom name="Bug's Life, A (Europe).z64" size="12582912" crc="791881d4" md5="ed3e962653a1cd56aab175deee6ee52a" sha1="2922c2281faa4106295830c617289292df4c377a"/>
+		<rom name="Bug's Life, A (Europe).n64" />
+		<release name="Bug's Life, A (Europe)" region="EUR" />
+		<rom name="Bug's Life, A (Europe).z64" size="12582912" crc="791881d4" md5="ed3e962653a1cd56aab175deee6ee52a" sha1="2922c2281faa4106295830c617289292df4c377a" />
 	</game>
 	<game name="Bug's Life, A (France)" cloneof="Bug's Life, A (Europe)">
 		<description>Bug's Life, A (France)</description>
-		<release name="Bug's Life, A (France)" region="FRA"/>
-		<rom name="Bug's Life, A (France).z64" size="12582912" crc="e5429094" md5="d2860d4fbd0ec4b2711a6ef8d78f9866" sha1="4970ecc65e8de25990a241b0d2ffbe274cb1619a"/>
+		<rom name="Bug's Life, A (France).n64" />
+		<release name="Bug's Life, A (France)" region="FRA" />
+		<rom name="Bug's Life, A (France).z64" size="12582912" crc="e5429094" md5="d2860d4fbd0ec4b2711a6ef8d78f9866" sha1="4970ecc65e8de25990a241b0d2ffbe274cb1619a" />
 	</game>
 	<game name="Bug's Life, A (Germany)" cloneof="Bug's Life, A (Europe)">
 		<description>Bug's Life, A (Germany)</description>
-		<release name="Bug's Life, A (Germany)" region="GER"/>
-		<rom name="Bug's Life, A (Germany).z64" size="12582912" crc="15a32836" md5="cbef54768670f4b5602ccbc90150007a" sha1="daa7114a8d16c3e636b2808d4f256e07954f05dd"/>
+		<rom name="Bug's Life, A (Germany).n64" />
+		<release name="Bug's Life, A (Germany)" region="GER" />
+		<rom name="Bug's Life, A (Germany).z64" size="12582912" crc="15a32836" md5="cbef54768670f4b5602ccbc90150007a" sha1="daa7114a8d16c3e636b2808d4f256e07954f05dd" />
 	</game>
 	<game name="Bug's Life, A (Italy)" cloneof="Bug's Life, A (Europe)">
 		<description>Bug's Life, A (Italy)</description>
-		<release name="Bug's Life, A (Italy)" region="ITA"/>
-		<rom name="Bug's Life, A (Italy).z64" size="12582912" crc="2d118764" md5="e3609fd12369c464e832c6d2a4d20790" sha1="46f9c5d7eb822b19be6910b992949def27e46887"/>
+		<rom name="Bug's Life, A (Italy).n64" />
+		<release name="Bug's Life, A (Italy)" region="ITA" />
+		<rom name="Bug's Life, A (Italy).z64" size="12582912" crc="2d118764" md5="e3609fd12369c464e832c6d2a4d20790" sha1="46f9c5d7eb822b19be6910b992949def27e46887" />
 	</game>
 	<game name="Bug's Life, A (USA)" cloneof="Bug's Life, A (Europe)">
 		<description>Bug's Life, A (USA)</description>
-		<release name="Bug's Life, A (USA)" region="USA"/>
-		<rom name="Bug's Life, A (USA).z64" size="12582912" crc="cf2ea0b6" md5="7fd6bffb80f920e01ef869829d485ea3" sha1="697c1e895fc840826fcb6a6f37411a2af6d6f47c"/>
+		<rom name="Bug's Life, A (USA).n64" />
+		<release name="Bug's Life, A (USA)" region="USA" />
+		<rom name="Bug's Life, A (USA).z64" size="12582912" crc="cf2ea0b6" md5="7fd6bffb80f920e01ef869829d485ea3" sha1="697c1e895fc840826fcb6a6f37411a2af6d6f47c" />
 	</game>
 	<game name="Bust-A-Move 2 - Arcade Edition (Europe)">
 		<description>Bust-A-Move 2 - Arcade Edition (Europe)</description>
-		<release name="Bust-A-Move 2 - Arcade Edition (Europe)" region="EUR"/>
-		<rom name="Bust-A-Move 2 - Arcade Edition (Europe).z64" size="8388608" crc="04731bab" md5="094f639a9ba63b2136d2887c8d72bca0" sha1="f92a1b19c522ba6cf20a9d7883321e6e283da32f"/>
+		<rom name="Bust-A-Move 2 - Arcade Edition (Europe).n64" />
+		<release name="Bust-A-Move 2 - Arcade Edition (Europe)" region="EUR" />
+		<rom name="Bust-A-Move 2 - Arcade Edition (Europe).z64" size="8388608" crc="04731bab" md5="094f639a9ba63b2136d2887c8d72bca0" sha1="f92a1b19c522ba6cf20a9d7883321e6e283da32f" />
 	</game>
 	<game name="Bust-A-Move 2 - Arcade Edition (USA)" cloneof="Bust-A-Move 2 - Arcade Edition (Europe)">
 		<description>Bust-A-Move 2 - Arcade Edition (USA)</description>
-		<release name="Bust-A-Move 2 - Arcade Edition (USA)" region="USA"/>
-		<rom name="Bust-A-Move 2 - Arcade Edition (USA).z64" size="8388608" crc="9f54cd2d" md5="8897a39e34aee4d3f807af255c6617d6" sha1="8f1aad51e733958d1a9a7a0cb7516fc7a293ca7b"/>
+		<rom name="Bust-A-Move 2 - Arcade Edition (USA).n64" />
+		<release name="Bust-A-Move 2 - Arcade Edition (USA)" region="USA" />
+		<rom name="Bust-A-Move 2 - Arcade Edition (USA).z64" size="8388608" crc="9f54cd2d" md5="8897a39e34aee4d3f807af255c6617d6" sha1="8f1aad51e733958d1a9a7a0cb7516fc7a293ca7b" />
 	</game>
 	<game name="Bust-A-Move 3 DX (Europe)">
 		<description>Bust-A-Move 3 DX (Europe)</description>
-		<release name="Bust-A-Move 3 DX (Europe)" region="EUR"/>
-		<rom name="Bust-A-Move 3 DX (Europe).z64" size="8388608" crc="95595889" md5="3ea21256ddc4157c3231ae5cc9c4652a" sha1="2bd376c3db3080d0a2328ef4052e59c3df71797e"/>
+		<rom name="Bust-A-Move 3 DX (Europe).n64" />
+		<release name="Bust-A-Move 3 DX (Europe)" region="EUR" />
+		<rom name="Bust-A-Move 3 DX (Europe).z64" size="8388608" crc="95595889" md5="3ea21256ddc4157c3231ae5cc9c4652a" sha1="2bd376c3db3080d0a2328ef4052e59c3df71797e" />
 	</game>
 	<game name="Bust-A-Move '99 (USA)" cloneof="Bust-A-Move 3 DX (Europe)">
 		<description>Bust-A-Move '99 (USA)</description>
-		<release name="Bust-A-Move '99 (USA)" region="USA"/>
-		<rom name="Bust-A-Move '99 (USA).z64" size="8388608" crc="c285fc69" md5="8567382d3cd5bc0406b7b4c780f621dc" sha1="8d874677cfbfa88c5e52bc13327d518be3b756ba"/>
+		<rom name="Bust-A-Move '99 (USA).n64" />
+		<release name="Bust-A-Move '99 (USA)" region="USA" />
+		<rom name="Bust-A-Move '99 (USA).z64" size="8388608" crc="c285fc69" md5="8567382d3cd5bc0406b7b4c780f621dc" sha1="8d874677cfbfa88c5e52bc13327d518be3b756ba" />
 	</game>
 	<game name="Puzzle Bobble 64 (Japan)" cloneof="Bust-A-Move 3 DX (Europe)">
 		<description>Puzzle Bobble 64 (Japan)</description>
-		<release name="Puzzle Bobble 64 (Japan)" region="JPN"/>
-		<rom name="Puzzle Bobble 64 (Japan).z64" size="8388608" crc="ea837423" md5="b478d4af60d43c38ba81de9faea6e057" sha1="9a4cdde04e6c42cf7957bf578a0b15ca90203280"/>
+		<rom name="Puzzle Bobble 64 (Japan).n64" />
+		<release name="Puzzle Bobble 64 (Japan)" region="JPN" />
+		<rom name="Puzzle Bobble 64 (Japan).z64" size="8388608" crc="ea837423" md5="b478d4af60d43c38ba81de9faea6e057" sha1="9a4cdde04e6c42cf7957bf578a0b15ca90203280" />
 	</game>
 	<game name="California Speed (USA)">
 		<description>California Speed (USA)</description>
-		<release name="California Speed (USA)" region="USA"/>
-		<rom name="California Speed (USA).z64" size="16777216" crc="6f6262cb" md5="965ad2fa317f0644e49a89a3219719cb" sha1="bd4c070a71ef58499587cb811fb7490b88dd7c0b"/>
+		<rom name="California Speed (USA).n64" />
+		<release name="California Speed (USA)" region="USA" />
+		<rom name="California Speed (USA).z64" size="16777216" crc="6f6262cb" md5="965ad2fa317f0644e49a89a3219719cb" sha1="bd4c070a71ef58499587cb811fb7490b88dd7c0b" />
 	</game>
 	<game name="California Speed (Europe) (Proto)" cloneof="California Speed (USA)">
 		<description>California Speed (Europe) (Proto)</description>
-		<rom name="California Speed (Europe) (Proto).z64" size="16777216" crc="d913b95f" md5="29b79bf5812e5f9e5ecef073d59f8915" sha1="b0ca8a5c8cbf2d18a91ac1b9df82907613bef479"/>
+		<rom name="California Speed (Europe) (Proto).n64" />
+		<rom name="California Speed (Europe) (Proto).z64" size="16777216" crc="d913b95f" md5="29b79bf5812e5f9e5ecef073d59f8915" sha1="b0ca8a5c8cbf2d18a91ac1b9df82907613bef479" />
 	</game>
 	<game name="Carmageddon 64 (Europe) (En,Fr,Es,It)">
 		<description>Carmageddon 64 (Europe) (En,Fr,Es,It)</description>
-		<release name="Carmageddon 64 (Europe) (En,Fr,Es,It)" region="EUR"/>
-		<rom name="Carmageddon 64 (Europe) (En,Fr,Es,It).z64" size="16777216" crc="8036f999" md5="59eb5646fa079bcbd7a340d7a10196dd" sha1="a26831c07ecc57dbf5846db847a30d9f735297c2"/>
+		<rom name="Carmageddon 64 (Europe) (En,Fr,Es,It).n64" />
+		<release name="Carmageddon 64 (Europe) (En,Fr,Es,It)" region="EUR" />
+		<rom name="Carmageddon 64 (Europe) (En,Fr,Es,It).z64" size="16777216" crc="8036f999" md5="59eb5646fa079bcbd7a340d7a10196dd" sha1="a26831c07ecc57dbf5846db847a30d9f735297c2" />
 	</game>
 	<game name="Carmageddon 64 (Europe) (En,Fr,De,Es)" cloneof="Carmageddon 64 (Europe) (En,Fr,Es,It)">
 		<description>Carmageddon 64 (Europe) (En,Fr,De,Es)</description>
-		<release name="Carmageddon 64 (Europe) (En,Fr,De,Es)" region="GER"/>
-		<rom name="Carmageddon 64 (Europe) (En,Fr,De,Es).z64" size="16777216" crc="8569f1a0" md5="ca21467bde6b355e7a15b8f1ada7b24d" sha1="2ab7ea2a9bc05ecf3cac026e2aff7acc9d3202e5"/>
+		<rom name="Carmageddon 64 (Europe) (En,Fr,De,Es).n64" />
+		<release name="Carmageddon 64 (Europe) (En,Fr,De,Es)" region="GER" />
+		<rom name="Carmageddon 64 (Europe) (En,Fr,De,Es).z64" size="16777216" crc="8569f1a0" md5="ca21467bde6b355e7a15b8f1ada7b24d" sha1="2ab7ea2a9bc05ecf3cac026e2aff7acc9d3202e5" />
 	</game>
 	<game name="Carmageddon 64 (USA)" cloneof="Carmageddon 64 (Europe) (En,Fr,Es,It)">
 		<description>Carmageddon 64 (USA)</description>
-		<release name="Carmageddon 64 (USA)" region="USA"/>
-		<rom name="Carmageddon 64 (USA).z64" size="16777216" crc="10c6a0a1" md5="31bb57c1fad0d47dc2353c1950b11886" sha1="dc7495093fb9a668b0c851b87c037a4cdf2ddc65"/>
+		<rom name="Carmageddon 64 (USA).n64" />
+		<release name="Carmageddon 64 (USA)" region="USA" />
+		<rom name="Carmageddon 64 (USA).z64" size="16777216" crc="10c6a0a1" md5="31bb57c1fad0d47dc2353c1950b11886" sha1="dc7495093fb9a668b0c851b87c037a4cdf2ddc65" />
 	</game>
 	<game name="Castlevania (Europe) (En,Fr,De)">
 		<description>Castlevania (Europe) (En,Fr,De)</description>
-		<release name="Castlevania (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Castlevania (Europe) (En,Fr,De).z64" size="12582912" crc="d9d76235" md5="57146b6cd8ee7d96b01a811f98a1ac61" sha1="e0da571cddcb8d069b36c2df254334f7c532133e"/>
+		<rom name="Castlevania (Europe) (En,Fr,De).n64" />
+		<release name="Castlevania (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Castlevania (Europe) (En,Fr,De).z64" size="12582912" crc="d9d76235" md5="57146b6cd8ee7d96b01a811f98a1ac61" sha1="e0da571cddcb8d069b36c2df254334f7c532133e" />
 	</game>
 	<game name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)" cloneof="Castlevania (Europe) (En,Fr,De)">
 		<description>Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)</description>
-		<release name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)" region="JPN"/>
-		<rom name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan).z64" size="12582912" crc="e349cfec" md5="256a1cb23f9e1a2762a7a171417b5d68" sha1="aa70348968589e6ba6e7091ca115fb505099cd97" status="verified"/>
+		<rom name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan).n64" />
+		<release name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan)" region="JPN" />
+		<rom name="Akumajou Dracula Mokushiroku - Real Action Adventure (Japan).z64" size="12582912" crc="e349cfec" md5="256a1cb23f9e1a2762a7a171417b5d68" sha1="aa70348968589e6ba6e7091ca115fb505099cd97" status="verified" />
 	</game>
 	<game name="Castlevania (USA)" cloneof="Castlevania (Europe) (En,Fr,De)">
 		<description>Castlevania (USA)</description>
-		<rom name="Castlevania (USA).z64" size="12582912" crc="8b0d3c00" md5="1cc5cf3b4d29d8c3ade957648b529dc1" sha1="989a28782ed6b0bc489a1bbbd7bec355d8f2707e"/>
+		<rom name="Castlevania (USA).n64" />
+		<rom name="Castlevania (USA).z64" size="12582912" crc="8b0d3c00" md5="1cc5cf3b4d29d8c3ade957648b529dc1" sha1="989a28782ed6b0bc489a1bbbd7bec355d8f2707e" />
 	</game>
 	<game name="Castlevania (USA) (Rev 2)" cloneof="Castlevania (Europe) (En,Fr,De)">
 		<description>Castlevania (USA) (Rev 2)</description>
-		<release name="Castlevania (USA) (Rev 2)" region="USA"/>
-		<rom name="Castlevania (USA) (Rev 2).z64" size="12582912" crc="83032d97" md5="06b58673f7d31c56f8fe8186e86f6bd6" sha1="ba23d0fb480b9885f0d847f7f3d67b249177c8c4"/>
+		<rom name="Castlevania (USA) (Rev 2).n64" />
+		<release name="Castlevania (USA) (Rev 2)" region="USA" />
+		<rom name="Castlevania (USA) (Rev 2).z64" size="12582912" crc="83032d97" md5="06b58673f7d31c56f8fe8186e86f6bd6" sha1="ba23d0fb480b9885f0d847f7f3d67b249177c8c4" />
 	</game>
 	<game name="Castlevania (USA) (Rev 1)" cloneof="Castlevania (Europe) (En,Fr,De)">
 		<description>Castlevania (USA) (Rev 1)</description>
-		<rom name="Castlevania (USA) (Rev 1).z64" size="12582912" crc="274d3493" md5="ce71d1ce0a2b6d597f72cb4fc08f5844" sha1="349a031320c1fe16a99801c1bab48a7aa8deac8e"/>
+		<rom name="Castlevania (USA) (Rev 1).n64" />
+		<rom name="Castlevania (USA) (Rev 1).z64" size="12582912" crc="274d3493" md5="ce71d1ce0a2b6d597f72cb4fc08f5844" sha1="349a031320c1fe16a99801c1bab48a7aa8deac8e" />
 	</game>
 	<game name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)">
 		<description>Castlevania - Legacy of Darkness (Europe) (En,Fr,De)</description>
-		<release name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De).z64" size="16777216" crc="12ab9b45" md5="78d5f8a98a5ed21d0817856bcd2ad750" sha1="0c6817082dd322477c63f3c91a99c1f34af0065c"/>
+		<rom name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De).n64" />
+		<release name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Castlevania - Legacy of Darkness (Europe) (En,Fr,De).z64" size="16777216" crc="12ab9b45" md5="78d5f8a98a5ed21d0817856bcd2ad750" sha1="0c6817082dd322477c63f3c91a99c1f34af0065c" />
 	</game>
 	<game name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)" cloneof="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)">
 		<description>Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)</description>
-		<release name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)" region="JPN"/>
-		<rom name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan).z64" size="16777216" crc="ff009c21" md5="47ea239717c4d225c9d0e9fd37b9fcb3" sha1="50439acb5784bea3a4bbba5188c2aeaa1442099d"/>
+		<rom name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan).n64" />
+		<release name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan)" region="JPN" />
+		<rom name="Akumajou Dracula Mokushiroku Gaiden - Legend of Cornell (Japan).z64" size="16777216" crc="ff009c21" md5="47ea239717c4d225c9d0e9fd37b9fcb3" sha1="50439acb5784bea3a4bbba5188c2aeaa1442099d" />
 	</game>
 	<game name="Castlevania - Legacy of Darkness (USA)" cloneof="Castlevania - Legacy of Darkness (Europe) (En,Fr,De)">
 		<description>Castlevania - Legacy of Darkness (USA)</description>
-		<release name="Castlevania - Legacy of Darkness (USA)" region="USA"/>
-		<rom name="Castlevania - Legacy of Darkness (USA).z64" size="16777216" crc="ab13028c" md5="25258460f98f567497b24844abe3a05b" sha1="879ead98f197fd05edda867655da5b1ce25aa5b8"/>
+		<rom name="Castlevania - Legacy of Darkness (USA).n64" />
+		<release name="Castlevania - Legacy of Darkness (USA)" region="USA" />
+		<rom name="Castlevania - Legacy of Darkness (USA).z64" size="16777216" crc="ab13028c" md5="25258460f98f567497b24844abe3a05b" sha1="879ead98f197fd05edda867655da5b1ce25aa5b8" />
 	</game>
 	<game name="Centre Court Tennis (Europe)">
 		<description>Centre Court Tennis (Europe)</description>
-		<release name="Centre Court Tennis (Europe)" region="EUR"/>
-		<rom name="Centre Court Tennis (Europe).z64" size="12582912" crc="b1d26f39" md5="31fb88048076ace4bd4205c5f40414ab" sha1="c6f1251b4b7841220f670d8a0af844b34c5cfada"/>
+		<rom name="Centre Court Tennis (Europe).n64" />
+		<release name="Centre Court Tennis (Europe)" region="EUR" />
+		<rom name="Centre Court Tennis (Europe).z64" size="12582912" crc="b1d26f39" md5="31fb88048076ace4bd4205c5f40414ab" sha1="c6f1251b4b7841220f670d8a0af844b34c5cfada" />
 	</game>
 	<game name="Let's Smash (Japan)" cloneof="Centre Court Tennis (Europe)">
 		<description>Let's Smash (Japan)</description>
-		<release name="Let's Smash (Japan)" region="JPN"/>
-		<rom name="Let's Smash (Japan).z64" size="12582912" crc="455a1770" md5="aee5016e6d60d12ad768e9f6d10adde8" sha1="6fda28a79cec30b6c52c3dbc96b513da16bfa4d0"/>
+		<rom name="Let's Smash (Japan).n64" />
+		<release name="Let's Smash (Japan)" region="JPN" />
+		<rom name="Let's Smash (Japan).z64" size="12582912" crc="455a1770" md5="aee5016e6d60d12ad768e9f6d10adde8" sha1="6fda28a79cec30b6c52c3dbc96b513da16bfa4d0" />
 	</game>
 	<game name="Chameleon Twist (Europe)">
 		<description>Chameleon Twist (Europe)</description>
-		<release name="Chameleon Twist (Europe)" region="EUR"/>
-		<rom name="Chameleon Twist (Europe).z64" size="12582912" crc="587dd983" md5="1cd90b13b7fd6afdcb838f801d807826" sha1="197556f41756c82edb6ba7767f0d181290c1b2c2"/>
+		<rom name="Chameleon Twist (Europe).n64" />
+		<release name="Chameleon Twist (Europe)" region="EUR" />
+		<rom name="Chameleon Twist (Europe).z64" size="12582912" crc="587dd983" md5="1cd90b13b7fd6afdcb838f801d807826" sha1="197556f41756c82edb6ba7767f0d181290c1b2c2" />
 	</game>
 	<game name="Chameleon Twist (Japan)" cloneof="Chameleon Twist (Europe)">
 		<description>Chameleon Twist (Japan)</description>
-		<release name="Chameleon Twist (Japan)" region="JPN"/>
-		<rom name="Chameleon Twist (Japan).z64" size="12582912" crc="6395c475" md5="c0eb519122d63a944a122437ec1b98ee" sha1="a1faf5c4ca961ab2c029c84ecfa556755e7f70c8"/>
+		<rom name="Chameleon Twist (Japan).n64" />
+		<release name="Chameleon Twist (Japan)" region="JPN" />
+		<rom name="Chameleon Twist (Japan).z64" size="12582912" crc="6395c475" md5="c0eb519122d63a944a122437ec1b98ee" sha1="a1faf5c4ca961ab2c029c84ecfa556755e7f70c8" />
 	</game>
 	<game name="Chameleon Twist (USA)" cloneof="Chameleon Twist (Europe)">
 		<description>Chameleon Twist (USA)</description>
-		<rom name="Chameleon Twist (USA).z64" size="12582912" crc="7fe024c9" md5="397be52d4fb7df1e26c6275e05425571" sha1="173875d2a98161228efb56841484e12446a43156"/>
+		<rom name="Chameleon Twist (USA).n64" />
+		<rom name="Chameleon Twist (USA).z64" size="12582912" crc="7fe024c9" md5="397be52d4fb7df1e26c6275e05425571" sha1="173875d2a98161228efb56841484e12446a43156" />
 	</game>
 	<game name="Chameleon Twist (USA) (Rev 1)" cloneof="Chameleon Twist (Europe)">
 		<description>Chameleon Twist (USA) (Rev 1)</description>
-		<release name="Chameleon Twist (USA) (Rev 1)" region="USA"/>
-		<rom name="Chameleon Twist (USA) (Rev 1).z64" size="12582912" crc="7ff42fd0" md5="d8a88acfcd89df7a59d9a1b050fda740" sha1="4ca6d563131b4809fe1748335182816a024999d4"/>
+		<rom name="Chameleon Twist (USA) (Rev 1).n64" />
+		<release name="Chameleon Twist (USA) (Rev 1)" region="USA" />
+		<rom name="Chameleon Twist (USA) (Rev 1).z64" size="12582912" crc="7ff42fd0" md5="d8a88acfcd89df7a59d9a1b050fda740" sha1="4ca6d563131b4809fe1748335182816a024999d4" />
 	</game>
 	<game name="Chameleon Twist 2 (Europe)">
 		<description>Chameleon Twist 2 (Europe)</description>
-		<release name="Chameleon Twist 2 (Europe)" region="EUR"/>
-		<rom name="Chameleon Twist 2 (Europe).z64" size="8388608" crc="3b53519f" md5="45d1d039ab7926adc748de640afd986a" sha1="bbca485ee38e07da78f44e5de653311b8edc18f2"/>
+		<rom name="Chameleon Twist 2 (Europe).n64" />
+		<release name="Chameleon Twist 2 (Europe)" region="EUR" />
+		<rom name="Chameleon Twist 2 (Europe).z64" size="8388608" crc="3b53519f" md5="45d1d039ab7926adc748de640afd986a" sha1="bbca485ee38e07da78f44e5de653311b8edc18f2" />
 	</game>
 	<game name="Chameleon Twist 2 (Japan)" cloneof="Chameleon Twist 2 (Europe)">
 		<description>Chameleon Twist 2 (Japan)</description>
-		<release name="Chameleon Twist 2 (Japan)" region="JPN"/>
-		<rom name="Chameleon Twist 2 (Japan).z64" size="12582912" crc="08287cc8" md5="740ad4db03952bbe997db09947a41e62" sha1="b60d0347e7b765195fb27c3ee50a806ea9977dca"/>
+		<rom name="Chameleon Twist 2 (Japan).n64" />
+		<release name="Chameleon Twist 2 (Japan)" region="JPN" />
+		<rom name="Chameleon Twist 2 (Japan).z64" size="12582912" crc="08287cc8" md5="740ad4db03952bbe997db09947a41e62" sha1="b60d0347e7b765195fb27c3ee50a806ea9977dca" />
 	</game>
 	<game name="Chameleon Twist 2 (USA)" cloneof="Chameleon Twist 2 (Europe)">
 		<description>Chameleon Twist 2 (USA)</description>
-		<release name="Chameleon Twist 2 (USA)" region="USA"/>
-		<rom name="Chameleon Twist 2 (USA).z64" size="8388608" crc="cdf26d67" md5="00327e0b5df6dce6decc31353f33a3d3" sha1="9fa379d66b218228da3cbf386c91d857c677f489"/>
+		<rom name="Chameleon Twist 2 (USA).n64" />
+		<release name="Chameleon Twist 2 (USA)" region="USA" />
+		<rom name="Chameleon Twist 2 (USA).z64" size="8388608" crc="cdf26d67" md5="00327e0b5df6dce6decc31353f33a3d3" sha1="9fa379d66b218228da3cbf386c91d857c677f489" />
 	</game>
 	<game name="Charlie Blast's Territory (Europe)">
 		<description>Charlie Blast's Territory (Europe)</description>
-		<release name="Charlie Blast's Territory (Europe)" region="EUR"/>
-		<rom name="Charlie Blast's Territory (Europe).z64" size="4194304" crc="82c1d9e1" md5="dd53e1f83e8789d23df6af942ffef236" sha1="9a0eb87ba72c1ef4dcb8b80029f29cdeea91fe49"/>
+		<rom name="Charlie Blast's Territory (Europe).n64" />
+		<release name="Charlie Blast's Territory (Europe)" region="EUR" />
+		<rom name="Charlie Blast's Territory (Europe).z64" size="4194304" crc="82c1d9e1" md5="dd53e1f83e8789d23df6af942ffef236" sha1="9a0eb87ba72c1ef4dcb8b80029f29cdeea91fe49" />
 	</game>
 	<game name="Charlie Blast's Territory (USA)" cloneof="Charlie Blast's Territory (Europe)">
 		<description>Charlie Blast's Territory (USA)</description>
-		<release name="Charlie Blast's Territory (USA)" region="USA"/>
-		<rom name="Charlie Blast's Territory (USA).z64" size="4194304" crc="ba4e65a8" md5="59fa8c6d533d36c0ffc2aafab7166e6f" sha1="e11619c7a8e1c2a280ea3ac069cf11153d4951a6"/>
+		<rom name="Charlie Blast's Territory (USA).n64" />
+		<release name="Charlie Blast's Territory (USA)" region="USA" />
+		<rom name="Charlie Blast's Territory (USA).z64" size="4194304" crc="ba4e65a8" md5="59fa8c6d533d36c0ffc2aafab7166e6f" sha1="e11619c7a8e1c2a280ea3ac069cf11153d4951a6" />
 	</game>
 	<game name="Chopper Attack (Europe)">
 		<description>Chopper Attack (Europe)</description>
-		<release name="Chopper Attack (Europe)" region="EUR"/>
-		<rom name="Chopper Attack (Europe).z64" size="8388608" crc="c1dcd7ab" md5="8f6bed633be214cf039dbdac356231ce" sha1="9688c388384edea0141fc66b20d6d0e5fe2d668f"/>
+		<rom name="Chopper Attack (Europe).n64" />
+		<release name="Chopper Attack (Europe)" region="EUR" />
+		<rom name="Chopper Attack (Europe).z64" size="8388608" crc="c1dcd7ab" md5="8f6bed633be214cf039dbdac356231ce" sha1="9688c388384edea0141fc66b20d6d0e5fe2d668f" />
 	</game>
 	<game name="Chopper Attack (USA)" cloneof="Chopper Attack (Europe)">
 		<description>Chopper Attack (USA)</description>
-		<release name="Chopper Attack (USA)" region="USA"/>
-		<rom name="Chopper Attack (USA).z64" size="8388608" crc="aa5d76a9" md5="c37e8afb4f3ecc86d01ce7388ca59347" sha1="1e3f1c94c806b2699c4e0e941190d468435b9f60"/>
+		<rom name="Chopper Attack (USA).n64" />
+		<release name="Chopper Attack (USA)" region="USA" />
+		<rom name="Chopper Attack (USA).z64" size="8388608" crc="aa5d76a9" md5="c37e8afb4f3ecc86d01ce7388ca59347" sha1="1e3f1c94c806b2699c4e0e941190d468435b9f60" />
 	</game>
 	<game name="Wild Choppers (Japan)" cloneof="Chopper Attack (Europe)">
 		<description>Wild Choppers (Japan)</description>
-		<release name="Wild Choppers (Japan)" region="JPN"/>
-		<rom name="Wild Choppers (Japan).z64" size="8388608" crc="d6136dc5" md5="f85f2a2b6ca64898f0add2a78ccdccf3" sha1="9ed151fce580f875f09cb250d2bb9c18c8d549c0"/>
+		<rom name="Wild Choppers (Japan).n64" />
+		<release name="Wild Choppers (Japan)" region="JPN" />
+		<rom name="Wild Choppers (Japan).z64" size="8388608" crc="d6136dc5" md5="f85f2a2b6ca64898f0add2a78ccdccf3" sha1="9ed151fce580f875f09cb250d2bb9c18c8d549c0" />
 	</game>
 	<game name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)">
 		<description>Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)</description>
-		<release name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)" region="JPN"/>
-		<rom name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan).z64" size="12582912" crc="5c565ad6" md5="9081370141079031ebbdbca56fc8c7d8" sha1="4532621d98b25d07e2f19aa106ff4db547104160"/>
+		<rom name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan).n64" />
+		<release name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan)" region="JPN" />
+		<rom name="Choro Q 64 2 - Hacha Mecha Grand Prix Race (Japan).z64" size="12582912" crc="5c565ad6" md5="9081370141079031ebbdbca56fc8c7d8" sha1="4532621d98b25d07e2f19aa106ff4db547104160" />
 	</game>
 	<game name="Chou Kuukan Nighter Pro Yakyuu King (Japan)">
 		<description>Chou Kuukan Nighter Pro Yakyuu King (Japan)</description>
-		<release name="Chou Kuukan Nighter Pro Yakyuu King (Japan)" region="JPN"/>
-		<rom name="Chou Kuukan Nighter Pro Yakyuu King (Japan).z64" size="8388608" crc="5f75634e" md5="78838c202c4ff5a460586451ee9182aa" sha1="a08dd769f3b885dc27f4cd14022613d1baa52b84"/>
+		<rom name="Chou Kuukan Nighter Pro Yakyuu King (Japan).n64" />
+		<release name="Chou Kuukan Nighter Pro Yakyuu King (Japan)" region="JPN" />
+		<rom name="Chou Kuukan Nighter Pro Yakyuu King (Japan).z64" size="8388608" crc="5f75634e" md5="78838c202c4ff5a460586451ee9182aa" sha1="a08dd769f3b885dc27f4cd14022613d1baa52b84" />
 	</game>
 	<game name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)">
 		<description>Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)</description>
-		<release name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)" region="JPN"/>
-		<rom name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).z64" size="16777216" crc="479643e2" md5="97eab4dc83da0ad2890de2aaaa5d109a" sha1="b8c62befe0a2bd7bcd6efb5f78b34b923b325aac"/>
+		<rom name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).n64" />
+		<release name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan)" region="JPN" />
+		<rom name="Chou Kuukan Nighter Pro Yakyuu King 2 (Japan).z64" size="16777216" crc="479643e2" md5="97eab4dc83da0ad2890de2aaaa5d109a" sha1="b8c62befe0a2bd7bcd6efb5f78b34b923b325aac" />
 	</game>
 	<game name="Clay Fighter - Sculptor's Cut (USA)">
 		<description>Clay Fighter - Sculptor's Cut (USA)</description>
-		<release name="Clay Fighter - Sculptor's Cut (USA)" region="USA"/>
-		<rom name="Clay Fighter - Sculptor's Cut (USA).z64" size="16777216" crc="434de656" md5="30e7e083b978408d5b7760d0ce4dc61d" sha1="28697fba130ded056bf7c497deaa3e154cce8022"/>
+		<rom name="Clay Fighter - Sculptor's Cut (USA).n64" />
+		<release name="Clay Fighter - Sculptor's Cut (USA)" region="USA" />
+		<rom name="Clay Fighter - Sculptor's Cut (USA).z64" size="16777216" crc="434de656" md5="30e7e083b978408d5b7760d0ce4dc61d" sha1="28697fba130ded056bf7c497deaa3e154cce8022" />
 	</game>
 	<game name="Clay Fighter 63 1-3 (Europe)">
 		<description>Clay Fighter 63 1-3 (Europe)</description>
-		<release name="Clay Fighter 63 1-3 (Europe)" region="EUR"/>
-		<rom name="Clay Fighter 63 1-3 (Europe).z64" size="12582912" crc="82263e5d" md5="41965b533f3dd95663361d9df68b0c1f" sha1="fec40ef7d8b973c5937ade10423d0cf1b5a18e3c"/>
+		<rom name="Clay Fighter 63 1-3 (Europe).n64" />
+		<release name="Clay Fighter 63 1-3 (Europe)" region="EUR" />
+		<rom name="Clay Fighter 63 1-3 (Europe).z64" size="12582912" crc="82263e5d" md5="41965b533f3dd95663361d9df68b0c1f" sha1="fec40ef7d8b973c5937ade10423d0cf1b5a18e3c" />
 	</game>
 	<game name="Clay Fighter 63 1-3 (USA)" cloneof="Clay Fighter 63 1-3 (Europe)">
 		<description>Clay Fighter 63 1-3 (USA)</description>
-		<release name="Clay Fighter 63 1-3 (USA)" region="USA"/>
-		<rom name="Clay Fighter 63 1-3 (USA).z64" size="12582912" crc="3fa647dd" md5="3207bf22e305c488109b09a03706f36f" sha1="036873ab0d3107b2d9b3225a180f67daf0899365" status="verified"/>
+		<rom name="Clay Fighter 63 1-3 (USA).n64" />
+		<release name="Clay Fighter 63 1-3 (USA)" region="USA" />
+		<rom name="Clay Fighter 63 1-3 (USA).z64" size="12582912" crc="3fa647dd" md5="3207bf22e305c488109b09a03706f36f" sha1="036873ab0d3107b2d9b3225a180f67daf0899365" status="verified" />
 	</game>
 	<game name="Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21)" cloneof="Clay Fighter 63 1-3 (Europe)">
 		<description>Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21)</description>
-		<rom name="Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21).z64" size="12582912" crc="18f4166a" md5="cbbeaff5a9074d1a5507cf46cd683d36" sha1="3307f73b8bd0795d3c7036d77fc4a78efebc4ef0"/>
+		<rom name="Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21).n64" />
+		<rom name="Clay Fighter 63 1-3 (USA) (Beta) (1997-08-21).z64" size="12582912" crc="18f4166a" md5="cbbeaff5a9074d1a5507cf46cd683d36" sha1="3307f73b8bd0795d3c7036d77fc4a78efebc4ef0" />
 	</game>
 	<game name="Command &amp; Conquer (Europe) (En,Fr)">
 		<description>Command &amp; Conquer (Europe) (En,Fr)</description>
-		<release name="Command &amp; Conquer (Europe) (En,Fr)" region="EUR"/>
-		<rom name="Command &amp; Conquer (Europe) (En,Fr).z64" size="33554432" crc="f3da8a26" md5="42da4c7d040f9e7cd046a42ec3e68027" sha1="0d5211e211e7fc063c63c3e8235b62bc288ce305" status="verified"/>
+		<rom name="Command &amp; Conquer (Europe) (En,Fr).n64" />
+		<release name="Command &amp; Conquer (Europe) (En,Fr)" region="EUR" />
+		<rom name="Command &amp; Conquer (Europe) (En,Fr).z64" size="33554432" crc="f3da8a26" md5="42da4c7d040f9e7cd046a42ec3e68027" sha1="0d5211e211e7fc063c63c3e8235b62bc288ce305" status="verified" />
 	</game>
 	<game name="Command &amp; Conquer (Germany)" cloneof="Command &amp; Conquer (Europe) (En,Fr)">
 		<description>Command &amp; Conquer (Germany)</description>
-		<release name="Command &amp; Conquer (Germany)" region="GER"/>
-		<rom name="Command &amp; Conquer (Germany).z64" size="33554432" crc="6cd0fc99" md5="1a9195662c89dcbea88bcfa99b096cde" sha1="725083ece68d5deb9724d3fa3f2a65f0291b2d5d"/>
+		<rom name="Command &amp; Conquer (Germany).n64" />
+		<release name="Command &amp; Conquer (Germany)" region="GER" />
+		<rom name="Command &amp; Conquer (Germany).z64" size="33554432" crc="6cd0fc99" md5="1a9195662c89dcbea88bcfa99b096cde" sha1="725083ece68d5deb9724d3fa3f2a65f0291b2d5d" />
 	</game>
 	<game name="Command &amp; Conquer (USA)" cloneof="Command &amp; Conquer (Europe) (En,Fr)">
 		<description>Command &amp; Conquer (USA)</description>
-		<release name="Command &amp; Conquer (USA)" region="USA"/>
-		<rom name="Command &amp; Conquer (USA).z64" size="33554432" crc="3e9069ef" md5="b436f4717ac585b0d847756468fd6393" sha1="b559e86d98de598b1d25583ca082faa4b7c62641"/>
+		<rom name="Command &amp; Conquer (USA).n64" />
+		<release name="Command &amp; Conquer (USA)" region="USA" />
+		<rom name="Command &amp; Conquer (USA).z64" size="33554432" crc="3e9069ef" md5="b436f4717ac585b0d847756468fd6393" sha1="b559e86d98de598b1d25583ca082faa4b7c62641" />
 	</game>
 	<game name="Conker's Bad Fur Day (Europe)">
 		<description>Conker's Bad Fur Day (Europe)</description>
-		<release name="Conker's Bad Fur Day (Europe)" region="EUR"/>
-		<rom name="Conker's Bad Fur Day (Europe).z64" size="67108864" crc="4667cfe9" md5="05194d49c14e52055df72a54d40791e1" sha1="ee7bc6656fd1e1d9ffb3d19add759f28b88df710"/>
+		<rom name="Conker's Bad Fur Day (Europe).n64" />
+		<release name="Conker's Bad Fur Day (Europe)" region="EUR" />
+		<rom name="Conker's Bad Fur Day (Europe).z64" size="67108864" crc="4667cfe9" md5="05194d49c14e52055df72a54d40791e1" sha1="ee7bc6656fd1e1d9ffb3d19add759f28b88df710" />
 	</game>
 	<game name="Conker's Bad Fur Day (USA)" cloneof="Conker's Bad Fur Day (Europe)">
 		<description>Conker's Bad Fur Day (USA)</description>
-		<release name="Conker's Bad Fur Day (USA)" region="USA"/>
-		<rom name="Conker's Bad Fur Day (USA).z64" size="67108864" crc="ce8cc172" md5="00e2920665f2329b95797a7eaabc2390" sha1="4cbadd3c4e0729dec46af64ad018050eada4f47a" status="verified"/>
+		<rom name="Conker's Bad Fur Day (USA).n64" />
+		<release name="Conker's Bad Fur Day (USA)" region="USA" />
+		<rom name="Conker's Bad Fur Day (USA).z64" size="67108864" crc="ce8cc172" md5="00e2920665f2329b95797a7eaabc2390" sha1="4cbadd3c4e0729dec46af64ad018050eada4f47a" status="verified" />
 	</game>
 	<game name="Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26)" cloneof="Conker's Bad Fur Day (Europe)">
 		<description>Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26)</description>
-		<rom name="Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26).z64" size="67108864" crc="e1cda95a" md5="13ecbaeef7111d5343d73a80e03e353a" sha1="06597dc935651f8995bfacc30fde6e621d44c3e1"/>
+		<rom name="Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26).n64" />
+		<rom name="Conker's Bad Fur Day (USA) (Beta) (ECTS 2000) (2000-08-26).z64" size="67108864" crc="e1cda95a" md5="13ecbaeef7111d5343d73a80e03e353a" sha1="06597dc935651f8995bfacc30fde6e621d44c3e1" />
 	</game>
 	<game name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25)" cloneof="Conker's Bad Fur Day (Europe)">
 		<description>Conker's Bad Fur Day (USA) (Beta) (2000-10-25)</description>
-		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25).z64" size="67108864" crc="4f73408c" md5="70e9eb9bf2f7bc76ca38ce450ba01c2e" sha1="3b99222ee76f6277a963142cd807b3df25d5174f"/>
+		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25).n64" />
+		<rom name="Conker's Bad Fur Day (USA) (Beta) (2000-10-25).z64" size="67108864" crc="4f73408c" md5="70e9eb9bf2f7bc76ca38ce450ba01c2e" sha1="3b99222ee76f6277a963142cd807b3df25d5174f" />
 	</game>
 	<game name="Cruis'n Exotica (USA)">
 		<description>Cruis'n Exotica (USA)</description>
-		<release name="Cruis'n Exotica (USA)" region="USA"/>
-		<rom name="Cruis'n Exotica (USA).z64" size="16777216" crc="867a2ced" md5="db7a03b77d44db81b8a3fcdfc4b72d8c" sha1="428f53a060103fd88ebfbdcc032a99caea901e17"/>
+		<rom name="Cruis'n Exotica (USA).n64" />
+		<release name="Cruis'n Exotica (USA)" region="USA" />
+		<rom name="Cruis'n Exotica (USA).z64" size="16777216" crc="867a2ced" md5="db7a03b77d44db81b8a3fcdfc4b72d8c" sha1="428f53a060103fd88ebfbdcc032a99caea901e17" />
 	</game>
 	<game name="Cruis'n USA (Europe)">
 		<description>Cruis'n USA (Europe)</description>
-		<release name="Cruis'n USA (Europe)" region="EUR"/>
-		<rom name="Cruis'n USA (Europe).z64" size="8388608" crc="8935a8d9" md5="69cd5ba6bc9310b9e37ccb1bc6bd16ad" sha1="404ab549cd148ea07f40d66c0b896a343741bbf6" status="verified"/>
+		<rom name="Cruis'n USA (Europe).n64" />
+		<release name="Cruis'n USA (Europe)" region="EUR" />
+		<rom name="Cruis'n USA (Europe).z64" size="8388608" crc="8935a8d9" md5="69cd5ba6bc9310b9e37ccb1bc6bd16ad" sha1="404ab549cd148ea07f40d66c0b896a343741bbf6" status="verified" />
 	</game>
 	<game name="Cruis'n USA (USA)" cloneof="Cruis'n USA (Europe)">
 		<description>Cruis'n USA (USA)</description>
-		<rom name="Cruis'n USA (USA).z64" size="8388608" crc="5238b727" md5="00a3e885f8d899646228a21d946b2102" sha1="aefe77a5518fe74519908b6cbc97cb81b8570897"/>
+		<rom name="Cruis'n USA (USA).n64" />
+		<rom name="Cruis'n USA (USA).z64" size="8388608" crc="5238b727" md5="00a3e885f8d899646228a21d946b2102" sha1="aefe77a5518fe74519908b6cbc97cb81b8570897" />
 	</game>
 	<game name="Cruis'n USA (USA) (Rev 1)" cloneof="Cruis'n USA (Europe)">
 		<description>Cruis'n USA (USA) (Rev 1)</description>
-		<rom name="Cruis'n USA (USA) (Rev 1).z64" size="8388608" crc="4655ba2d" md5="45fc88e2ba6711f25f0de988e719df29" sha1="71bb3d8850b6a4a294aeca2abad1f936e4f85f0f"/>
+		<rom name="Cruis'n USA (USA) (Rev 1).n64" />
+		<rom name="Cruis'n USA (USA) (Rev 1).z64" size="8388608" crc="4655ba2d" md5="45fc88e2ba6711f25f0de988e719df29" sha1="71bb3d8850b6a4a294aeca2abad1f936e4f85f0f" />
 	</game>
 	<game name="Cruis'n USA (USA) (Rev 2)" cloneof="Cruis'n USA (Europe)">
 		<description>Cruis'n USA (USA) (Rev 2)</description>
-		<release name="Cruis'n USA (USA) (Rev 2)" region="USA"/>
-		<rom name="Cruis'n USA (USA) (Rev 2).z64" size="8388608" crc="c3b52701" md5="2838a9018ad2bcb8b7f6161c746a1b71" sha1="54a875ee0b482036fa401a6bc2b242699f0259f7" status="verified"/>
+		<rom name="Cruis'n USA (USA) (Rev 2).n64" />
+		<release name="Cruis'n USA (USA) (Rev 2)" region="USA" />
+		<rom name="Cruis'n USA (USA) (Rev 2).z64" size="8388608" crc="c3b52701" md5="2838a9018ad2bcb8b7f6161c746a1b71" sha1="54a875ee0b482036fa401a6bc2b242699f0259f7" status="verified" />
 	</game>
 	<game name="Cruis'n USA (USA) (Wii Virtual Console)" cloneof="Cruis'n USA (Europe)">
 		<description>Cruis'n USA (USA) (Wii Virtual Console)</description>
-		<rom name="Cruis'n USA (USA) (Wii Virtual Console).z64" size="8388608" crc="8fc564f9" md5="41ca21bd737e16ba81168982b74276f1" sha1="273f1d6ddd48f92af49f37e88405f318a340c2cd"/>
+		<rom name="Cruis'n USA (USA) (Wii Virtual Console).n64" />
+		<rom name="Cruis'n USA (USA) (Wii Virtual Console).z64" size="8388608" crc="8fc564f9" md5="41ca21bd737e16ba81168982b74276f1" sha1="273f1d6ddd48f92af49f37e88405f318a340c2cd" />
 	</game>
 	<game name="Cruis'n World (Europe) (Rev 1)">
 		<description>Cruis'n World (Europe) (Rev 1)</description>
-		<release name="Cruis'n World (Europe) (Rev 1)" region="EUR"/>
-		<rom name="Cruis'n World (Europe) (Rev 1).z64" size="12582912" crc="ebaed1f9" md5="20db5e4ddb0cd5b04c4bf09cdc95592f" sha1="362078633d549d3270b3b3b6b0e0d0243321d9ae"/>
+		<rom name="Cruis'n World (Europe) (Rev 1).n64" />
+		<release name="Cruis'n World (Europe) (Rev 1)" region="EUR" />
+		<rom name="Cruis'n World (Europe) (Rev 1).z64" size="12582912" crc="ebaed1f9" md5="20db5e4ddb0cd5b04c4bf09cdc95592f" sha1="362078633d549d3270b3b3b6b0e0d0243321d9ae" />
 	</game>
 	<game name="Cruis'n World (Europe)" cloneof="Cruis'n World (Europe) (Rev 1)">
 		<description>Cruis'n World (Europe)</description>
-		<rom name="Cruis'n World (Europe).z64" size="12582912" crc="e46ce079" md5="af950a1b6c460d7fc3e78375d35047ef" sha1="ee508f14c936265d101c9699b5ae1a722b3e7d9e"/>
+		<rom name="Cruis'n World (Europe).n64" />
+		<rom name="Cruis'n World (Europe).z64" size="12582912" crc="e46ce079" md5="af950a1b6c460d7fc3e78375d35047ef" sha1="ee508f14c936265d101c9699b5ae1a722b3e7d9e" />
 	</game>
 	<game name="Cruis'n World (USA)" cloneof="Cruis'n World (Europe) (Rev 1)">
 		<description>Cruis'n World (USA)</description>
-		<release name="Cruis'n World (USA)" region="USA"/>
-		<rom name="Cruis'n World (USA).z64" size="12582912" crc="a123769f" md5="aada4cbd938e58a447b399a1d46f03e6" sha1="6da1a6a2bda687d50e798d80c342948ad1738202"/>
+		<rom name="Cruis'n World (USA).n64" />
+		<release name="Cruis'n World (USA)" region="USA" />
+		<rom name="Cruis'n World (USA).z64" size="12582912" crc="a123769f" md5="aada4cbd938e58a447b399a1d46f03e6" sha1="6da1a6a2bda687d50e798d80c342948ad1738202" />
 	</game>
 	<game name="Custom Robo (Japan)">
 		<description>Custom Robo (Japan)</description>
-		<release name="Custom Robo (Japan)" region="JPN"/>
-		<rom name="Custom Robo (Japan).z64" size="16777216" crc="f2fae693" md5="a06d2e83cf2628915e8847f609474661" sha1="49de08f08400a477485c4798d6cd81d95842c806"/>
+		<rom name="Custom Robo (Japan).n64" />
+		<release name="Custom Robo (Japan)" region="JPN" />
+		<rom name="Custom Robo (Japan).z64" size="16777216" crc="f2fae693" md5="a06d2e83cf2628915e8847f609474661" sha1="49de08f08400a477485c4798d6cd81d95842c806" />
 	</game>
 	<game name="Zuhe Jiqiren (China) (iQue)" cloneof="Custom Robo (Japan)">
 		<description>Zuhe Jiqiren (China) (iQue)</description>
-		<rom name="Zuhe Jiqiren (China) (iQue).z64" size="16793600" crc="76742798" md5="33f2bc6847985f96de8177147dcd3b85" sha1="563755afd3cf8d30ec10e100a2e032addf429246"/>
+		<rom name="Zuhe Jiqiren (China) (iQue).n64" />
+		<rom name="Zuhe Jiqiren (China) (iQue).z64" size="16793600" crc="76742798" md5="33f2bc6847985f96de8177147dcd3b85" sha1="563755afd3cf8d30ec10e100a2e032addf429246" />
 	</game>
 	<game name="Custom Robo V2 (Japan)">
 		<description>Custom Robo V2 (Japan)</description>
-		<release name="Custom Robo V2 (Japan)" region="JPN"/>
-		<rom name="Custom Robo V2 (Japan).z64" size="16777216" crc="c8201454" md5="115118dd5e0f02d82ba1bf070a7b78f1" sha1="f9515c2482af8df791339536f60260509c424f6a" status="verified"/>
+		<rom name="Custom Robo V2 (Japan).n64" />
+		<release name="Custom Robo V2 (Japan)" region="JPN" />
+		<rom name="Custom Robo V2 (Japan).z64" size="16777216" crc="c8201454" md5="115118dd5e0f02d82ba1bf070a7b78f1" sha1="f9515c2482af8df791339536f60260509c424f6a" status="verified" />
 	</game>
 	<game name="CyberTiger (Europe)">
 		<description>CyberTiger (Europe)</description>
-		<release name="CyberTiger (Europe)" region="EUR"/>
-		<rom name="CyberTiger (Europe).z64" size="16777216" crc="7319d9af" md5="8c4a4cd472d610cda5459b3a92f21d30" sha1="ae220ac1cd6d892098937dc639c925f9ef158759"/>
+		<rom name="CyberTiger (Europe).n64" />
+		<release name="CyberTiger (Europe)" region="EUR" />
+		<rom name="CyberTiger (Europe).z64" size="16777216" crc="7319d9af" md5="8c4a4cd472d610cda5459b3a92f21d30" sha1="ae220ac1cd6d892098937dc639c925f9ef158759" />
 	</game>
 	<game name="CyberTiger (USA)" cloneof="CyberTiger (Europe)">
 		<description>CyberTiger (USA)</description>
-		<release name="CyberTiger (USA)" region="USA"/>
-		<rom name="CyberTiger (USA).z64" size="16777216" crc="10cc5f15" md5="88072f30d4f9cf384b2b3a0300649218" sha1="14e0635ccc2a80c77fd0a888a2e7977c55c6e129"/>
+		<rom name="CyberTiger (USA).n64" />
+		<release name="CyberTiger (USA)" region="USA" />
+		<rom name="CyberTiger (USA).z64" size="16777216" crc="10cc5f15" md5="88072f30d4f9cf384b2b3a0300649218" sha1="14e0635ccc2a80c77fd0a888a2e7977c55c6e129" />
 	</game>
 	<game name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="c61f6bb9" md5="1408fcf68b60d845f090107ef355a7e5" sha1="5499b5284c04cee98186e68198d6bfe73fee0cdb"/>
+		<rom name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="c61f6bb9" md5="1408fcf68b60d845f090107ef355a7e5" sha1="5499b5284c04cee98186e68198d6bfe73fee0cdb" />
 	</game>
 	<game name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)" cloneof="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)</description>
-		<release name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)" region="USA"/>
-		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es).z64" size="16777216" crc="3177a905" md5="02192b4b3797983bbe5e452336584208" sha1="2c840e2991d6a2af63c4efe830240fc49d93fc9a"/>
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es).n64" />
+		<release name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es)" region="USA" />
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es).z64" size="16777216" crc="3177a905" md5="02192b4b3797983bbe5e452336584208" sha1="2c840e2991d6a2af63c4efe830240fc49d93fc9a" />
 	</game>
 	<game name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07)" cloneof="Daffy Duck Starring as Duck Dodgers (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07)</description>
-		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07).z64" size="33554432" crc="1e48d155" md5="08ce7620b31851cbb05d386fe22c7109" sha1="145e0cb7f3a0e866945631dcf633d31b26c7e6bc"/>
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07).n64" />
+		<rom name="Duck Dodgers Starring Daffy Duck (USA) (En,Fr,Es) (Beta) (2000-03-07).z64" size="33554432" crc="1e48d155" md5="08ce7620b31851cbb05d386fe22c7109" sha1="145e0cb7f3a0e866945631dcf633d31b26c7e6bc" />
 	</game>
 	<game name="Dance Dance Revolution - Disney Dancing Museum (Japan)">
 		<description>Dance Dance Revolution - Disney Dancing Museum (Japan)</description>
-		<release name="Dance Dance Revolution - Disney Dancing Museum (Japan)" region="JPN"/>
-		<rom name="Dance Dance Revolution - Disney Dancing Museum (Japan).z64" size="33554432" crc="43ee0117" md5="0b86fa9259e2b751111a1701091644b1" sha1="9ada4f62d209fb35c52103f2253ddcc137f90c5d"/>
+		<rom name="Dance Dance Revolution - Disney Dancing Museum (Japan).n64" />
+		<release name="Dance Dance Revolution - Disney Dancing Museum (Japan)" region="JPN" />
+		<rom name="Dance Dance Revolution - Disney Dancing Museum (Japan).z64" size="33554432" crc="43ee0117" md5="0b86fa9259e2b751111a1701091644b1" sha1="9ada4f62d209fb35c52103f2253ddcc137f90c5d" />
 	</game>
 	<game name="Dark Rift (Europe)">
 		<description>Dark Rift (Europe)</description>
-		<release name="Dark Rift (Europe)" region="EUR"/>
-		<rom name="Dark Rift (Europe).z64" size="8388608" crc="d2a19c71" md5="4242fde5b74f22aaf5746459e126121f" sha1="18b02fc18411acd770bf3f25b2707669dac2ec5d" status="verified"/>
+		<rom name="Dark Rift (Europe).n64" />
+		<release name="Dark Rift (Europe)" region="EUR" />
+		<rom name="Dark Rift (Europe).z64" size="8388608" crc="d2a19c71" md5="4242fde5b74f22aaf5746459e126121f" sha1="18b02fc18411acd770bf3f25b2707669dac2ec5d" status="verified" />
 	</game>
 	<game name="Dark Rift (USA)" cloneof="Dark Rift (Europe)">
 		<description>Dark Rift (USA)</description>
-		<release name="Dark Rift (USA)" region="USA"/>
-		<rom name="Dark Rift (USA).z64" size="8388608" crc="83fd222f" md5="ecb170ebbfda0e932c07524040bcc36c" sha1="3254442626ca2f2ac74400dc1c6a306f5d1b6ceb"/>
+		<rom name="Dark Rift (USA).n64" />
+		<release name="Dark Rift (USA)" region="USA" />
+		<rom name="Dark Rift (USA).z64" size="8388608" crc="83fd222f" md5="ecb170ebbfda0e932c07524040bcc36c" sha1="3254442626ca2f2ac74400dc1c6a306f5d1b6ceb" />
 	</game>
 	<game name="Space Dynamites (Japan)" cloneof="Dark Rift (Europe)">
 		<description>Space Dynamites (Japan)</description>
-		<release name="Space Dynamites (Japan)" region="JPN"/>
-		<rom name="Space Dynamites (Japan).z64" size="8388608" crc="8cb4b948" md5="7f9cdbbb1aaaaf0983c64988ef9c58be" sha1="def172a1b2d17a6ebbbc0551172de4ae46b88e48"/>
+		<rom name="Space Dynamites (Japan).n64" />
+		<release name="Space Dynamites (Japan)" region="JPN" />
+		<rom name="Space Dynamites (Japan).z64" size="8388608" crc="8cb4b948" md5="7f9cdbbb1aaaaf0983c64988ef9c58be" sha1="def172a1b2d17a6ebbbc0551172de4ae46b88e48" />
 	</game>
 	<game name="Densha de Go! 64 (Japan)">
 		<description>Densha de Go! 64 (Japan)</description>
-		<release name="Densha de Go! 64 (Japan)" region="JPN"/>
-		<rom name="Densha de Go! 64 (Japan).z64" size="33554432" crc="7bfc71e0" md5="772fa166e5db51effc77fb8d832ac4d2" sha1="5b99d3af55dfd04a5acc11b9d25a3330c1e45708"/>
+		<rom name="Densha de Go! 64 (Japan).n64" />
+		<release name="Densha de Go! 64 (Japan)" region="JPN" />
+		<rom name="Densha de Go! 64 (Japan).z64" size="33554432" crc="7bfc71e0" md5="772fa166e5db51effc77fb8d832ac4d2" sha1="5b99d3af55dfd04a5acc11b9d25a3330c1e45708" />
 	</game>
 	<game name="Derby Stallion 64 (Japan)">
 		<description>Derby Stallion 64 (Japan)</description>
-		<release name="Derby Stallion 64 (Japan)" region="JPN"/>
-		<rom name="Derby Stallion 64 (Japan).z64" size="33554432" crc="a9417994" md5="7f57463856540104b21a5289312b626f" sha1="9a2b7dfa38fbf9cd07ff676c0e484d7b97db606b"/>
+		<rom name="Derby Stallion 64 (Japan).n64" />
+		<release name="Derby Stallion 64 (Japan)" region="JPN" />
+		<rom name="Derby Stallion 64 (Japan).z64" size="33554432" crc="a9417994" md5="7f57463856540104b21a5289312b626f" sha1="9a2b7dfa38fbf9cd07ff676c0e484d7b97db606b" />
 	</game>
 	<game name="Derby Stallion 64 (Japan) (Beta)" cloneof="Derby Stallion 64 (Japan)">
 		<description>Derby Stallion 64 (Japan) (Beta)</description>
-		<rom name="Derby Stallion 64 (Japan) (Beta).z64" size="33554432" crc="8ec950a9" md5="1051e1402ee110f3c5e372c9e1c5b338" sha1="bd03f18c456d5db90475dcf1aae2237c82d7446a"/>
+		<rom name="Derby Stallion 64 (Japan) (Beta).n64" />
+		<rom name="Derby Stallion 64 (Japan) (Beta).z64" size="33554432" crc="8ec950a9" md5="1051e1402ee110f3c5e372c9e1c5b338" sha1="bd03f18c456d5db90475dcf1aae2237c82d7446a" />
 	</game>
 	<game name="Destruction Derby 64 (Europe) (En,Fr,De)">
 		<description>Destruction Derby 64 (Europe) (En,Fr,De)</description>
-		<release name="Destruction Derby 64 (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Destruction Derby 64 (Europe) (En,Fr,De).z64" size="16777216" crc="7ad9e429" md5="bda717ecc8434f12f313342485828b58" sha1="eed379520c7fc7d08ebe5a076683bd56f3a0a04f"/>
+		<rom name="Destruction Derby 64 (Europe) (En,Fr,De).n64" />
+		<release name="Destruction Derby 64 (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Destruction Derby 64 (Europe) (En,Fr,De).z64" size="16777216" crc="7ad9e429" md5="bda717ecc8434f12f313342485828b58" sha1="eed379520c7fc7d08ebe5a076683bd56f3a0a04f" />
 	</game>
 	<game name="Destruction Derby 64 (USA)" cloneof="Destruction Derby 64 (Europe) (En,Fr,De)">
 		<description>Destruction Derby 64 (USA)</description>
-		<release name="Destruction Derby 64 (USA)" region="USA"/>
-		<rom name="Destruction Derby 64 (USA).z64" size="16777216" crc="38f1b5d9" md5="7fccb47498eec06e96ae9372247d1e90" sha1="a2c0799e13566d1b723299592cfcac9387f25fa7"/>
+		<rom name="Destruction Derby 64 (USA).n64" />
+		<release name="Destruction Derby 64 (USA)" region="USA" />
+		<rom name="Destruction Derby 64 (USA).z64" size="16777216" crc="38f1b5d9" md5="7fccb47498eec06e96ae9372247d1e90" sha1="a2c0799e13566d1b723299592cfcac9387f25fa7" />
 	</game>
 	<game name="Dezaemon 3D (Japan)">
 		<description>Dezaemon 3D (Japan)</description>
-		<release name="Dezaemon 3D (Japan)" region="JPN"/>
-		<rom name="Dezaemon 3D (Japan).z64" size="16777216" crc="9e978488" md5="54be265e7b2c28ab92bf1a4130acb5a2" sha1="1c10a85a2b6a782e6302b19c2387e2d58983a8d4"/>
+		<rom name="Dezaemon 3D (Japan).n64" />
+		<release name="Dezaemon 3D (Japan)" region="JPN" />
+		<rom name="Dezaemon 3D (Japan).z64" size="16777216" crc="9e978488" md5="54be265e7b2c28ab92bf1a4130acb5a2" sha1="1c10a85a2b6a782e6302b19c2387e2d58983a8d4" />
 	</game>
 	<game name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
 		<description>Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)</description>
-		<release name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)" region="EUR"/>
-		<rom name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1).z64" size="12582912" crc="b1e87639" md5="6b2bafe540e0af052a78e85b992be999" sha1="b7f628073237b3d211d40406aa0884ff8fdd70d5"/>
+		<rom name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1).n64" />
+		<release name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)" region="EUR" />
+		<rom name="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1).z64" size="12582912" crc="b1e87639" md5="6b2bafe540e0af052a78e85b992be999" sha1="b7f628073237b3d211d40406aa0884ff8fdd70d5" />
 	</game>
 	<game name="Diddy Kong Racing (Europe) (En,Fr,De)" cloneof="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
 		<description>Diddy Kong Racing (Europe) (En,Fr,De)</description>
-		<rom name="Diddy Kong Racing (Europe) (En,Fr,De).z64" size="12582912" crc="4a13323c" md5="0f0b7b78b345fbf2581d834cb4a81245" sha1="dd5d64dd140cb7aa28404fa35abdcaba33c29260"/>
+		<rom name="Diddy Kong Racing (Europe) (En,Fr,De).n64" />
+		<rom name="Diddy Kong Racing (Europe) (En,Fr,De).z64" size="12582912" crc="4a13323c" md5="0f0b7b78b345fbf2581d834cb4a81245" sha1="dd5d64dd140cb7aa28404fa35abdcaba33c29260" />
 	</game>
 	<game name="Diddy Kong Racing (Japan)" cloneof="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
 		<description>Diddy Kong Racing (Japan)</description>
-		<release name="Diddy Kong Racing (Japan)" region="JPN"/>
-		<rom name="Diddy Kong Racing (Japan).z64" size="12582912" crc="b566fb94" md5="10747662a55241b9234cd114c940504f" sha1="23ba3d302025153d111416e751027cef11213a19" status="verified"/>
+		<rom name="Diddy Kong Racing (Japan).n64" />
+		<release name="Diddy Kong Racing (Japan)" region="JPN" />
+		<rom name="Diddy Kong Racing (Japan).z64" size="12582912" crc="b566fb94" md5="10747662a55241b9234cd114c940504f" sha1="23ba3d302025153d111416e751027cef11213a19" status="verified" />
 	</game>
 	<game name="Diddy Kong Racing (USA) (En,Fr)" cloneof="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
 		<description>Diddy Kong Racing (USA) (En,Fr)</description>
-		<rom name="Diddy Kong Racing (USA) (En,Fr).z64" size="12582912" crc="eb759206" md5="4f0e07f0eeac7e5d7ce3a75461888d03" sha1="0cb115d8716dbbc2922fda38e533b9fe63bb9670" status="verified"/>
+		<rom name="Diddy Kong Racing (USA) (En,Fr).n64" />
+		<rom name="Diddy Kong Racing (USA) (En,Fr).z64" size="12582912" crc="eb759206" md5="4f0e07f0eeac7e5d7ce3a75461888d03" sha1="0cb115d8716dbbc2922fda38e533b9fe63bb9670" status="verified" />
 	</game>
 	<game name="Diddy Kong Racing (USA) (En,Fr) (Rev 1)" cloneof="Diddy Kong Racing (Europe) (En,Fr,De) (Rev 1)">
 		<description>Diddy Kong Racing (USA) (En,Fr) (Rev 1)</description>
-		<release name="Diddy Kong Racing (USA) (En,Fr) (Rev 1)" region="USA"/>
-		<rom name="Diddy Kong Racing (USA) (En,Fr) (Rev 1).z64" size="12582912" crc="5acca298" md5="b31f8cca50f31acc9b999ed5b779d6ed" sha1="6d96743d46f8c0cd0edb0ec5600b003c89b93755"/>
+		<rom name="Diddy Kong Racing (USA) (En,Fr) (Rev 1).n64" />
+		<release name="Diddy Kong Racing (USA) (En,Fr) (Rev 1)" region="USA" />
+		<rom name="Diddy Kong Racing (USA) (En,Fr) (Rev 1).z64" size="12582912" crc="5acca298" md5="b31f8cca50f31acc9b999ed5b779d6ed" sha1="6d96743d46f8c0cd0edb0ec5600b003c89b93755" />
 	</game>
 	<game name="Die Hard 64 (USA) (Proto) (Level 1)">
 		<description>Die Hard 64 (USA) (Proto) (Level 1)</description>
-		<release name="Die Hard 64 (USA) (Proto) (Level 1)" region="USA"/>
-		<rom name="Die Hard 64 (USA) (Proto) (Level 1).z64" size="33554432" crc="5e826037" md5="820929ebbe6fd332ac1720f94b745a8b" sha1="bc384f588c47e7a4c69ca5afd21189919050ae46"/>
+		<rom name="Die Hard 64 (USA) (Proto) (Level 1).n64" />
+		<release name="Die Hard 64 (USA) (Proto) (Level 1)" region="USA" />
+		<rom name="Die Hard 64 (USA) (Proto) (Level 1).z64" size="33554432" crc="5e826037" md5="820929ebbe6fd332ac1720f94b745a8b" sha1="bc384f588c47e7a4c69ca5afd21189919050ae46" />
 	</game>
 	<game name="Die Hard 64 (USA) (Proto) (Level 2)" cloneof="Die Hard 64 (USA) (Proto) (Level 1)">
 		<description>Die Hard 64 (USA) (Proto) (Level 2)</description>
-		<rom name="Die Hard 64 (USA) (Proto) (Level 2).z64" size="33554432" crc="d1d593cf" md5="3d1e03b097f2124f8f713013d8219291" sha1="25282d4cb5c41affa4149e8bbb215f48e65bad8e"/>
+		<rom name="Die Hard 64 (USA) (Proto) (Level 2).n64" />
+		<rom name="Die Hard 64 (USA) (Proto) (Level 2).z64" size="33554432" crc="d1d593cf" md5="3d1e03b097f2124f8f713013d8219291" sha1="25282d4cb5c41affa4149e8bbb215f48e65bad8e" />
 	</game>
 	<game name="Die Hard 64 (USA) (Proto) (Level 3)" cloneof="Die Hard 64 (USA) (Proto) (Level 1)">
 		<description>Die Hard 64 (USA) (Proto) (Level 3)</description>
-		<rom name="Die Hard 64 (USA) (Proto) (Level 3).z64" size="33554432" crc="70943925" md5="1b28c4ca21648d318bc6dd3ef27bb1fa" sha1="0971545144930f221a4350e98866c8cd1ee22af5"/>
+		<rom name="Die Hard 64 (USA) (Proto) (Level 3).n64" />
+		<rom name="Die Hard 64 (USA) (Proto) (Level 3).z64" size="33554432" crc="70943925" md5="1b28c4ca21648d318bc6dd3ef27bb1fa" sha1="0971545144930f221a4350e98866c8cd1ee22af5" />
 	</game>
 	<game name="Dinosaur Planet (USA) (Proto) (2000-12-01)">
 		<description>Dinosaur Planet (USA) (Proto) (2000-12-01)</description>
-		<rom name="Dinosaur Planet (USA) (Proto) (2000-12-01).z64" size="67108864" crc="a7daf9fa" md5="49f7bb346ade39d1915c22e090ffd748" sha1="cb9760b49198f7b754593a01c8ed642211caacde"/>
+		<rom name="Dinosaur Planet (USA) (Proto) (2000-12-01).n64" />
+		<rom name="Dinosaur Planet (USA) (Proto) (2000-12-01).z64" size="67108864" crc="a7daf9fa" md5="49f7bb346ade39d1915c22e090ffd748" sha1="cb9760b49198f7b754593a01c8ed642211caacde" />
 	</game>
 	<game name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)">
 		<description>Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).z64" size="20971520" crc="c4b0d9ea" md5="e8b403a0f0e212fa5c1220af10d9c379" sha1="c42fafb06be6eb7de08370d07f19571b7661074b"/>
+		<rom name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It).z64" size="20971520" crc="c4b0d9ea" md5="e8b403a0f0e212fa5c1220af10d9c379" sha1="c42fafb06be6eb7de08370d07f19571b7661074b" />
 	</game>
 	<game name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)" cloneof="Donald Duck - Quack Attack (Europe) (En,Fr,De,Es,It)">
 		<description>Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)</description>
-		<release name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)" region="USA"/>
-		<rom name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).z64" size="20971520" crc="7fdec270" md5="0e0e920ab13ef13508f5a98cc4cd2ff8" sha1="e31a7567d408c890065029ba537f830765b17d94"/>
+		<rom name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).n64" />
+		<release name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It)" region="USA" />
+		<rom name="Donald Duck - Goin' Quackers (USA) (En,Fr,De,Es,It).z64" size="20971520" crc="7fdec270" md5="0e0e920ab13ef13508f5a98cc4cd2ff8" sha1="e31a7567d408c890065029ba537f830765b17d94" />
 	</game>
 	<game name="Donkey Kong 64 (Europe) (En,Fr,De,Es)">
 		<description>Donkey Kong 64 (Europe) (En,Fr,De,Es)</description>
-		<release name="Donkey Kong 64 (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Donkey Kong 64 (Europe) (En,Fr,De,Es).z64" size="33554432" crc="a28c71c6" md5="118e9ce360b97a6f8dab2c9f30660bf5" sha1="f96af883845308106600d84e0618c1a066dc6676" status="verified"/>
+		<rom name="Donkey Kong 64 (Europe) (En,Fr,De,Es).n64" />
+		<release name="Donkey Kong 64 (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Donkey Kong 64 (Europe) (En,Fr,De,Es).z64" size="33554432" crc="a28c71c6" md5="118e9ce360b97a6f8dab2c9f30660bf5" sha1="f96af883845308106600d84e0618c1a066dc6676" status="verified" />
 	</game>
 	<game name="Donkey Kong 64 (Japan)" cloneof="Donkey Kong 64 (Europe) (En,Fr,De,Es)">
 		<description>Donkey Kong 64 (Japan)</description>
-		<release name="Donkey Kong 64 (Japan)" region="JPN"/>
-		<rom name="Donkey Kong 64 (Japan).z64" size="33554432" crc="919f7e74" md5="5b677f4bf93d6578252fcad2c8ceb637" sha1="f0ad2b2bbf04d574ed7afbb1bb6a4f0511dcd87d" status="verified"/>
+		<rom name="Donkey Kong 64 (Japan).n64" />
+		<release name="Donkey Kong 64 (Japan)" region="JPN" />
+		<rom name="Donkey Kong 64 (Japan).z64" size="33554432" crc="919f7e74" md5="5b677f4bf93d6578252fcad2c8ceb637" sha1="f0ad2b2bbf04d574ed7afbb1bb6a4f0511dcd87d" status="verified" />
 	</game>
 	<game name="Donkey Kong 64 (USA)" cloneof="Donkey Kong 64 (Europe) (En,Fr,De,Es)">
 		<description>Donkey Kong 64 (USA)</description>
-		<release name="Donkey Kong 64 (USA)" region="USA"/>
-		<rom name="Donkey Kong 64 (USA).z64" size="33554432" crc="d44b4fc6" md5="9ec41abf2519fc386cadd0731f6e868c" sha1="cf806ff2603640a748fca5026ded28802f1f4a50" status="verified"/>
+		<rom name="Donkey Kong 64 (USA).n64" />
+		<release name="Donkey Kong 64 (USA)" region="USA" />
+		<rom name="Donkey Kong 64 (USA).z64" size="33554432" crc="d44b4fc6" md5="9ec41abf2519fc386cadd0731f6e868c" sha1="cf806ff2603640a748fca5026ded28802f1f4a50" status="verified" />
 	</game>
 	<game name="Donkey Kong 64 (USA) (Demo) (Kiosk)" cloneof="Donkey Kong 64 (Europe) (En,Fr,De,Es)">
 		<description>Donkey Kong 64 (USA) (Demo) (Kiosk)</description>
-		<rom name="Donkey Kong 64 (USA) (Demo) (Kiosk).z64" size="33554432" crc="c83dfa15" md5="98a5836e3a5da7bd0b5819e7498acea2" sha1="b4717e602f07ca9be0d4822813c658cd8b99f993"/>
+		<rom name="Donkey Kong 64 (USA) (Demo) (Kiosk).n64" />
+		<rom name="Donkey Kong 64 (USA) (Demo) (Kiosk).z64" size="33554432" crc="c83dfa15" md5="98a5836e3a5da7bd0b5819e7498acea2" sha1="b4717e602f07ca9be0d4822813c658cd8b99f993" />
 	</game>
 	<game name="Doom 64 (Europe)">
 		<description>Doom 64 (Europe)</description>
-		<release name="Doom 64 (Europe)" region="EUR"/>
-		<rom name="Doom 64 (Europe).z64" size="8388608" crc="d985c356" md5="190ccca6526dc4a1f611e3b40f5131c0" sha1="b63060f69bb4e1547da1d762e740d19393977055"/>
+		<rom name="Doom 64 (Europe).n64" />
+		<release name="Doom 64 (Europe)" region="EUR" />
+		<rom name="Doom 64 (Europe).z64" size="8388608" crc="d985c356" md5="190ccca6526dc4a1f611e3b40f5131c0" sha1="b63060f69bb4e1547da1d762e740d19393977055" />
 	</game>
 	<game name="Doom 64 (Japan)" cloneof="Doom 64 (Europe)">
 		<description>Doom 64 (Japan)</description>
-		<release name="Doom 64 (Japan)" region="JPN"/>
-		<rom name="Doom 64 (Japan).z64" size="8388608" crc="c8f3af5b" md5="06f15ef2228c1b1147c41dccaa07d9de" sha1="6b0d65e62626a92aa59ee4bff3f02715f6247692"/>
+		<rom name="Doom 64 (Japan).n64" />
+		<release name="Doom 64 (Japan)" region="JPN" />
+		<rom name="Doom 64 (Japan).z64" size="8388608" crc="c8f3af5b" md5="06f15ef2228c1b1147c41dccaa07d9de" sha1="6b0d65e62626a92aa59ee4bff3f02715f6247692" />
 	</game>
 	<game name="Doom 64 (USA)" cloneof="Doom 64 (Europe)">
 		<description>Doom 64 (USA)</description>
-		<rom name="Doom 64 (USA).z64" size="8388608" crc="5cc1ade6" md5="b67748b64a2cc7efd2f3ad4504561e0e" sha1="799a588d73da3fcce8031026a8187da92b91c817"/>
+		<rom name="Doom 64 (USA).n64" />
+		<rom name="Doom 64 (USA).z64" size="8388608" crc="5cc1ade6" md5="b67748b64a2cc7efd2f3ad4504561e0e" sha1="799a588d73da3fcce8031026a8187da92b91c817" />
 	</game>
 	<game name="Doom 64 (USA) (Rev 1)" cloneof="Doom 64 (Europe)">
 		<description>Doom 64 (USA) (Rev 1)</description>
-		<release name="Doom 64 (USA) (Rev 1)" region="USA"/>
-		<rom name="Doom 64 (USA) (Rev 1).z64" size="8388608" crc="1d3a17b5" md5="1b1378bb9ee819f740550f566745af73" sha1="6fb0ce9c75bbe54b6e1ede337652b0221e5f2aad"/>
+		<rom name="Doom 64 (USA) (Rev 1).n64" />
+		<release name="Doom 64 (USA) (Rev 1)" region="USA" />
+		<rom name="Doom 64 (USA) (Rev 1).z64" size="8388608" crc="1d3a17b5" md5="1b1378bb9ee819f740550f566745af73" sha1="6fb0ce9c75bbe54b6e1ede337652b0221e5f2aad" />
 	</game>
 	<game name="Doraemon - Nobita to 3tsu no Seireiseki (Japan)">
 		<description>Doraemon - Nobita to 3tsu no Seireiseki (Japan)</description>
-		<release name="Doraemon - Nobita to 3tsu no Seireiseki (Japan)" region="JPN"/>
-		<rom name="Doraemon - Nobita to 3tsu no Seireiseki (Japan).z64" size="8388608" crc="154e8b33" md5="c2166455e94e89e9e3ab612b4377c443" sha1="bbeb7b7a92a68b17ca72dcb9d7fb16f7b771c4f6"/>
+		<rom name="Doraemon - Nobita to 3tsu no Seireiseki (Japan).n64" />
+		<release name="Doraemon - Nobita to 3tsu no Seireiseki (Japan)" region="JPN" />
+		<rom name="Doraemon - Nobita to 3tsu no Seireiseki (Japan).z64" size="8388608" crc="154e8b33" md5="c2166455e94e89e9e3ab612b4377c443" sha1="bbeb7b7a92a68b17ca72dcb9d7fb16f7b771c4f6" />
 	</game>
 	<game name="Doraemon 2 - Nobita to Hikari no Shinden (Japan)">
 		<description>Doraemon 2 - Nobita to Hikari no Shinden (Japan)</description>
-		<release name="Doraemon 2 - Nobita to Hikari no Shinden (Japan)" region="JPN"/>
-		<rom name="Doraemon 2 - Nobita to Hikari no Shinden (Japan).z64" size="12582912" crc="0c1a0c38" md5="0580d96a71671c9e6972fdcf5897cc26" sha1="4b187360e1999556662c28b65dd179432ec61f9a"/>
+		<rom name="Doraemon 2 - Nobita to Hikari no Shinden (Japan).n64" />
+		<release name="Doraemon 2 - Nobita to Hikari no Shinden (Japan)" region="JPN" />
+		<rom name="Doraemon 2 - Nobita to Hikari no Shinden (Japan).z64" size="12582912" crc="0c1a0c38" md5="0580d96a71671c9e6972fdcf5897cc26" sha1="4b187360e1999556662c28b65dd179432ec61f9a" />
 	</game>
 	<game name="Doraemon 3 - Nobita no Machi SOS! (Japan)">
 		<description>Doraemon 3 - Nobita no Machi SOS! (Japan)</description>
-		<release name="Doraemon 3 - Nobita no Machi SOS! (Japan)" region="JPN"/>
-		<rom name="Doraemon 3 - Nobita no Machi SOS! (Japan).z64" size="16777216" crc="d3b68be4" md5="a4a1d490ba67831775fc381b846e2168" sha1="dd9ba0f6cfc10c3b78401cc55d06ad534f39d5b1"/>
+		<rom name="Doraemon 3 - Nobita no Machi SOS! (Japan).n64" />
+		<release name="Doraemon 3 - Nobita no Machi SOS! (Japan)" region="JPN" />
+		<rom name="Doraemon 3 - Nobita no Machi SOS! (Japan).z64" size="16777216" crc="d3b68be4" md5="a4a1d490ba67831775fc381b846e2168" sha1="dd9ba0f6cfc10c3b78401cc55d06ad534f39d5b1" />
 	</game>
 	<game name="Doubutsu no Mori (Japan)">
 		<description>Doubutsu no Mori (Japan)</description>
-		<release name="Doubutsu no Mori (Japan)" region="JPN"/>
-		<rom name="Doubutsu no Mori (Japan).z64" size="16777216" crc="9503e3f1" md5="a4f7c57c180297b2e7ba5a5feb44fe0b" sha1="e106dff7146f72415337c96deb14f630e1580efb"/>
+		<rom name="Doubutsu no Mori (Japan).n64" />
+		<release name="Doubutsu no Mori (Japan)" region="JPN" />
+		<rom name="Doubutsu no Mori (Japan).z64" size="16777216" crc="9503e3f1" md5="a4f7c57c180297b2e7ba5a5feb44fe0b" sha1="e106dff7146f72415337c96deb14f630e1580efb" />
 	</game>
 	<game name="Dongwu Senlin (China) (iQue)" cloneof="Doubutsu no Mori (Japan)">
 		<description>Dongwu Senlin (China) (iQue)</description>
-		<rom name="Dongwu Senlin (China) (iQue).z64" size="16138240" crc="4703c2dd" md5="af83e0cf36298e62e9eb2eb8c89aa710" sha1="b0f25508ccc99551190b86f88da6772942308f85"/>
+		<rom name="Dongwu Senlin (China) (iQue).n64" />
+		<rom name="Dongwu Senlin (China) (iQue).z64" size="16138240" crc="4703c2dd" md5="af83e0cf36298e62e9eb2eb8c89aa710" sha1="b0f25508ccc99551190b86f88da6772942308f85" />
 	</game>
 	<game name="Dr. Mario 64 (USA)">
 		<description>Dr. Mario 64 (USA)</description>
-		<release name="Dr. Mario 64 (USA)" region="USA"/>
-		<rom name="Dr. Mario 64 (USA).z64" size="4194304" crc="a4701927" md5="1a7936367413e5d6874abda6d623ad32" sha1="a130d3622ce40e0158db2da4247101f6e92206fc"/>
+		<rom name="Dr. Mario 64 (USA).n64" />
+		<release name="Dr. Mario 64 (USA)" region="USA" />
+		<rom name="Dr. Mario 64 (USA).z64" size="4194304" crc="a4701927" md5="1a7936367413e5d6874abda6d623ad32" sha1="a130d3622ce40e0158db2da4247101f6e92206fc" />
 	</game>
 	<game name="Mario Yisheng (China) (iQue)" cloneof="Dr. Mario 64 (USA)">
 		<description>Mario Yisheng (China) (iQue)</description>
-		<rom name="Mario Yisheng (China) (iQue).z64" size="3358720" crc="61848015" md5="dd291b9c65420fd892107f6c665b7a45" sha1="e396df7729acc70c0e7ab988fca2b75ea167632d"/>
+		<rom name="Mario Yisheng (China) (iQue).n64" />
+		<rom name="Mario Yisheng (China) (iQue).z64" size="3358720" crc="61848015" md5="dd291b9c65420fd892107f6c665b7a45" sha1="e396df7729acc70c0e7ab988fca2b75ea167632d" />
 	</game>
 	<game name="Dragon Sword 64 (USA) (Proto) (1999-08-25)">
 		<description>Dragon Sword 64 (USA) (Proto) (1999-08-25)</description>
-		<release name="Dragon Sword 64 (USA) (Proto) (1999-08-25)" region="USA"/>
-		<rom name="Dragon Sword 64 (USA) (Proto) (1999-08-25).z64" size="33554432" crc="2296b50d" md5="942fc6737765ac718799a7f66202216c" sha1="4478a6405f61014478bbc35cee3a00ee1515d8ce"/>
+		<rom name="Dragon Sword 64 (USA) (Proto) (1999-08-25).n64" />
+		<release name="Dragon Sword 64 (USA) (Proto) (1999-08-25)" region="USA" />
+		<rom name="Dragon Sword 64 (USA) (Proto) (1999-08-25).z64" size="33554432" crc="2296b50d" md5="942fc6737765ac718799a7f66202216c" sha1="4478a6405f61014478bbc35cee3a00ee1515d8ce" />
 	</game>
 	<game name="Dragon Sword 64 (Europe) (Proto)" cloneof="Dragon Sword 64 (USA) (Proto) (1999-08-25)">
 		<description>Dragon Sword 64 (Europe) (Proto)</description>
-		<release name="Dragon Sword 64 (Europe) (Proto)" region="EUR"/>
-		<rom name="Dragon Sword 64 (Europe) (Proto).z64" size="33554432" crc="55ded416" md5="4d901e4e15f931fd09e803343017ebfe" sha1="e7827a1d0f3e7d222ecab414c260d185f9ef9749"/>
+		<rom name="Dragon Sword 64 (Europe) (Proto).n64" />
+		<release name="Dragon Sword 64 (Europe) (Proto)" region="EUR" />
+		<rom name="Dragon Sword 64 (Europe) (Proto).z64" size="33554432" crc="55ded416" md5="4d901e4e15f931fd09e803343017ebfe" sha1="e7827a1d0f3e7d222ecab414c260d185f9ef9749" />
 	</game>
 	<game name="Dual Heroes (Europe)">
 		<description>Dual Heroes (Europe)</description>
-		<release name="Dual Heroes (Europe)" region="EUR"/>
-		<rom name="Dual Heroes (Europe).z64" size="12582912" crc="5a7e226b" md5="f120fadb52b414eb4fb7d13092ac3cdb" sha1="061b7956c3aadddc6fdc11aab885f95a71b7f463"/>
+		<rom name="Dual Heroes (Europe).n64" />
+		<release name="Dual Heroes (Europe)" region="EUR" />
+		<rom name="Dual Heroes (Europe).z64" size="12582912" crc="5a7e226b" md5="f120fadb52b414eb4fb7d13092ac3cdb" sha1="061b7956c3aadddc6fdc11aab885f95a71b7f463" />
 	</game>
 	<game name="Dual Heroes (Japan)" cloneof="Dual Heroes (Europe)">
 		<description>Dual Heroes (Japan)</description>
-		<release name="Dual Heroes (Japan)" region="JPN"/>
-		<rom name="Dual Heroes (Japan).z64" size="12582912" crc="20f23dde" md5="e7652ed5ceceb5b1bc14495c58546d1c" sha1="cfd5992bcc3e0d90966d8a6fc6e0813e75473b14"/>
+		<rom name="Dual Heroes (Japan).n64" />
+		<release name="Dual Heroes (Japan)" region="JPN" />
+		<rom name="Dual Heroes (Japan).z64" size="12582912" crc="20f23dde" md5="e7652ed5ceceb5b1bc14495c58546d1c" sha1="cfd5992bcc3e0d90966d8a6fc6e0813e75473b14" />
 	</game>
 	<game name="Dual Heroes (USA)" cloneof="Dual Heroes (Europe)">
 		<description>Dual Heroes (USA)</description>
-		<release name="Dual Heroes (USA)" region="USA"/>
-		<rom name="Dual Heroes (USA).z64" size="12582912" crc="d09f4da8" md5="923d65e69f51858c697e0e5759cd038b" sha1="8fd879ce53e211d33a689015a78cff3fdd39db09"/>
+		<rom name="Dual Heroes (USA).n64" />
+		<release name="Dual Heroes (USA)" region="USA" />
+		<rom name="Dual Heroes (USA).z64" size="12582912" crc="d09f4da8" md5="923d65e69f51858c697e0e5759cd038b" sha1="8fd879ce53e211d33a689015a78cff3fdd39db09" />
 	</game>
 	<game name="Duke Nukem - Zero Hour (Europe)">
 		<description>Duke Nukem - Zero Hour (Europe)</description>
-		<release name="Duke Nukem - Zero Hour (Europe)" region="EUR"/>
-		<rom name="Duke Nukem - Zero Hour (Europe).z64" size="33554432" crc="ea82f037" md5="86e98aaca0d90bf744da090539ba4ad8" sha1="c18ad90fb889f95773fef48c204ce06cff9e6be3"/>
+		<rom name="Duke Nukem - Zero Hour (Europe).n64" />
+		<release name="Duke Nukem - Zero Hour (Europe)" region="EUR" />
+		<rom name="Duke Nukem - Zero Hour (Europe).z64" size="33554432" crc="ea82f037" md5="86e98aaca0d90bf744da090539ba4ad8" sha1="c18ad90fb889f95773fef48c204ce06cff9e6be3" />
 	</game>
 	<game name="Duke Nukem - Zero Hour (France)" cloneof="Duke Nukem - Zero Hour (Europe)">
 		<description>Duke Nukem - Zero Hour (France)</description>
-		<release name="Duke Nukem - Zero Hour (France)" region="FRA"/>
-		<rom name="Duke Nukem - Zero Hour (France).z64" size="33554432" crc="7ecdfb28" md5="e2b73feb0843874ea831a2e0076fcb72" sha1="e69a4dda8cca88d4c149f2b00640da0ff04fa9c8"/>
+		<rom name="Duke Nukem - Zero Hour (France).n64" />
+		<release name="Duke Nukem - Zero Hour (France)" region="FRA" />
+		<rom name="Duke Nukem - Zero Hour (France).z64" size="33554432" crc="7ecdfb28" md5="e2b73feb0843874ea831a2e0076fcb72" sha1="e69a4dda8cca88d4c149f2b00640da0ff04fa9c8" />
 	</game>
 	<game name="Duke Nukem - Zero Hour (USA)" cloneof="Duke Nukem - Zero Hour (Europe)">
 		<description>Duke Nukem - Zero Hour (USA)</description>
-		<release name="Duke Nukem - Zero Hour (USA)" region="USA"/>
-		<rom name="Duke Nukem - Zero Hour (USA).z64" size="33554432" crc="9a3258d7" md5="026789d47db5fe202a76f89797b33ac7" sha1="de4db292cc6cf5dd1dd1d3c9700cf8e5c3078410"/>
+		<rom name="Duke Nukem - Zero Hour (USA).n64" />
+		<release name="Duke Nukem - Zero Hour (USA)" region="USA" />
+		<rom name="Duke Nukem - Zero Hour (USA).z64" size="33554432" crc="9a3258d7" md5="026789d47db5fe202a76f89797b33ac7" sha1="de4db292cc6cf5dd1dd1d3c9700cf8e5c3078410" />
 	</game>
 	<game name="Duke Nukem 64 (Europe)">
 		<description>Duke Nukem 64 (Europe)</description>
-		<release name="Duke Nukem 64 (Europe)" region="EUR"/>
-		<rom name="Duke Nukem 64 (Europe).z64" size="8388608" crc="3275adb0" md5="8657cba95c409b74c1f5632cbc36643f" sha1="6cc06f6097f90228bd7d7784fa7d20ba17e82eef" status="verified"/>
+		<rom name="Duke Nukem 64 (Europe).n64" />
+		<release name="Duke Nukem 64 (Europe)" region="EUR" />
+		<rom name="Duke Nukem 64 (Europe).z64" size="8388608" crc="3275adb0" md5="8657cba95c409b74c1f5632cbc36643f" sha1="6cc06f6097f90228bd7d7784fa7d20ba17e82eef" status="verified" />
 	</game>
 	<game name="Duke Nukem 64 (France)" cloneof="Duke Nukem 64 (Europe)">
 		<description>Duke Nukem 64 (France)</description>
-		<release name="Duke Nukem 64 (France)" region="FRA"/>
-		<rom name="Duke Nukem 64 (France).z64" size="8388608" crc="b9c9f07a" md5="e2e79c7167bdb26e176d220904739c91" sha1="2c48706c4280a51e52691331543606e4170a19a9"/>
+		<rom name="Duke Nukem 64 (France).n64" />
+		<release name="Duke Nukem 64 (France)" region="FRA" />
+		<rom name="Duke Nukem 64 (France).z64" size="8388608" crc="b9c9f07a" md5="e2e79c7167bdb26e176d220904739c91" sha1="2c48706c4280a51e52691331543606e4170a19a9" />
 	</game>
 	<game name="Duke Nukem 64 (USA)" cloneof="Duke Nukem 64 (Europe)">
 		<description>Duke Nukem 64 (USA)</description>
-		<release name="Duke Nukem 64 (USA)" region="USA"/>
-		<rom name="Duke Nukem 64 (USA).z64" size="8388608" crc="dbfd5a53" md5="c7f1a43764a26da2e43f2a36a5f76e4c" sha1="98d6778004becc672eba0a5e887f6e3f3d1b5c15" status="verified"/>
+		<rom name="Duke Nukem 64 (USA).n64" />
+		<release name="Duke Nukem 64 (USA)" region="USA" />
+		<rom name="Duke Nukem 64 (USA).z64" size="8388608" crc="dbfd5a53" md5="c7f1a43764a26da2e43f2a36a5f76e4c" sha1="98d6778004becc672eba0a5e887f6e3f3d1b5c15" status="verified" />
 	</game>
 	<game name="Duke Nukem 64 (Europe) (Beta)" cloneof="Duke Nukem 64 (Europe)">
 		<description>Duke Nukem 64 (Europe) (Beta)</description>
-		<rom name="Duke Nukem 64 (Europe) (Beta).z64" size="8388608" crc="4a82d036" md5="bb2472b3f8a41fbf3aec3ccef7ea8c78" sha1="bd6ed4a342290eab3d99be392986e085e91315ac"/>
+		<rom name="Duke Nukem 64 (Europe) (Beta).n64" />
+		<rom name="Duke Nukem 64 (Europe) (Beta).z64" size="8388608" crc="4a82d036" md5="bb2472b3f8a41fbf3aec3ccef7ea8c78" sha1="bd6ed4a342290eab3d99be392986e085e91315ac" />
 	</game>
 	<game name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)">
 		<description>Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="61a56330" md5="bf2df4b86faa2181a7acfe2643fa2293" sha1="f02c1afd18c1cbe309472cbe5b3b3f04b22db7ee"/>
+		<rom name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="61a56330" md5="bf2df4b86faa2181a7acfe2643fa2293" sha1="f02c1afd18c1cbe309472cbe5b3b3f04b22db7ee" />
 	</game>
 	<game name="Earthworm Jim 3D (USA)" cloneof="Earthworm Jim 3D (Europe) (En,Fr,De,Es,It)">
 		<description>Earthworm Jim 3D (USA)</description>
-		<release name="Earthworm Jim 3D (USA)" region="USA"/>
-		<rom name="Earthworm Jim 3D (USA).z64" size="16777216" crc="9e6579c5" md5="980dfb38ad9a883119de135f45b7db36" sha1="eab14f23640cd6148d4888902cdcc00dd6111bf9"/>
+		<rom name="Earthworm Jim 3D (USA).n64" />
+		<release name="Earthworm Jim 3D (USA)" region="USA" />
+		<rom name="Earthworm Jim 3D (USA).z64" size="16777216" crc="9e6579c5" md5="980dfb38ad9a883119de135f45b7db36" sha1="eab14f23640cd6148d4888902cdcc00dd6111bf9" />
 	</game>
 	<game name="ECW Hardcore Revolution (Europe)">
 		<description>ECW Hardcore Revolution (Europe)</description>
-		<release name="ECW Hardcore Revolution (Europe)" region="EUR"/>
-		<rom name="ECW Hardcore Revolution (Europe).z64" size="33554432" crc="be8feead" md5="1830ede2557e8685e6f76d05cc65076a" sha1="226cad0c48e9e0d1dc928298518ca8b2d6eae5ed" status="verified"/>
+		<rom name="ECW Hardcore Revolution (Europe).n64" />
+		<release name="ECW Hardcore Revolution (Europe)" region="EUR" />
+		<rom name="ECW Hardcore Revolution (Europe).z64" size="33554432" crc="be8feead" md5="1830ede2557e8685e6f76d05cc65076a" sha1="226cad0c48e9e0d1dc928298518ca8b2d6eae5ed" status="verified" />
 	</game>
 	<game name="ECW Hardcore Revolution (USA)" cloneof="ECW Hardcore Revolution (Europe)">
 		<description>ECW Hardcore Revolution (USA)</description>
-		<release name="ECW Hardcore Revolution (USA)" region="USA"/>
-		<rom name="ECW Hardcore Revolution (USA).z64" size="33554432" crc="36d368ef" md5="8eebb16b7a4d39ae8bc8cccbc41f0a01" sha1="d460dc1eb24ef3e1e27c6b125c8c8d8324a64125"/>
+		<rom name="ECW Hardcore Revolution (USA).n64" />
+		<release name="ECW Hardcore Revolution (USA)" region="USA" />
+		<rom name="ECW Hardcore Revolution (USA).z64" size="33554432" crc="36d368ef" md5="8eebb16b7a4d39ae8bc8cccbc41f0a01" sha1="d460dc1eb24ef3e1e27c6b125c8c8d8324a64125" />
 	</game>
 	<game name="ECW Hardcore Revolution (Germany)" cloneof="ECW Hardcore Revolution (Europe)">
 		<description>ECW Hardcore Revolution (Germany)</description>
-		<release name="ECW Hardcore Revolution (Germany)" region="GER"/>
-		<rom name="ECW Hardcore Revolution (Germany).z64" size="33554432" crc="e9cf3d9f" md5="5d1e41aa28169e71b4919fa08f1acd9b" sha1="cdabb42be0755d186ad6cae6427fb7c0a12b2e7b"/>
+		<rom name="ECW Hardcore Revolution (Germany).n64" />
+		<release name="ECW Hardcore Revolution (Germany)" region="GER" />
+		<rom name="ECW Hardcore Revolution (Germany).z64" size="33554432" crc="e9cf3d9f" md5="5d1e41aa28169e71b4919fa08f1acd9b" sha1="cdabb42be0755d186ad6cae6427fb7c0a12b2e7b" />
 	</game>
 	<game name="Eikou no Saint Andrews (Japan)">
 		<description>Eikou no Saint Andrews (Japan)</description>
-		<release name="Eikou no Saint Andrews (Japan)" region="JPN"/>
-		<rom name="Eikou no Saint Andrews (Japan).z64" size="8388608" crc="1699d2d6" md5="935dd85ad198bbde92161cdce47cbfb3" sha1="5686b49ac9a60ebfc1d1abf6214f7bc06849abf4"/>
+		<rom name="Eikou no Saint Andrews (Japan).n64" />
+		<release name="Eikou no Saint Andrews (Japan)" region="JPN" />
+		<rom name="Eikou no Saint Andrews (Japan).z64" size="8388608" crc="1699d2d6" md5="935dd85ad198bbde92161cdce47cbfb3" sha1="5686b49ac9a60ebfc1d1abf6214f7bc06849abf4" />
 	</game>
 	<game name="Excitebike 64 (Europe)">
 		<description>Excitebike 64 (Europe)</description>
-		<release name="Excitebike 64 (Europe)" region="EUR"/>
-		<rom name="Excitebike 64 (Europe).z64" size="16777216" crc="0b881e60" md5="8fa253fd69b73df9a831ef2f731491f2" sha1="5abfb6024f935ef5fe0067f39fd594c50697c749"/>
+		<rom name="Excitebike 64 (Europe).n64" />
+		<release name="Excitebike 64 (Europe)" region="EUR" />
+		<rom name="Excitebike 64 (Europe).z64" size="16777216" crc="0b881e60" md5="8fa253fd69b73df9a831ef2f731491f2" sha1="5abfb6024f935ef5fe0067f39fd594c50697c749" />
 	</game>
 	<game name="Excitebike 64 (Japan)" cloneof="Excitebike 64 (Europe)">
 		<description>Excitebike 64 (Japan)</description>
-		<release name="Excitebike 64 (Japan)" region="JPN"/>
-		<rom name="Excitebike 64 (Japan).z64" size="16777216" crc="03bfd065" md5="bf15a61aff71c93bf5e05243f57bca1d" sha1="e2c8d01fc66c0a575e79cb338678f1fd065226d6"/>
+		<rom name="Excitebike 64 (Japan).n64" />
+		<release name="Excitebike 64 (Japan)" region="JPN" />
+		<rom name="Excitebike 64 (Japan).z64" size="16777216" crc="03bfd065" md5="bf15a61aff71c93bf5e05243f57bca1d" sha1="e2c8d01fc66c0a575e79cb338678f1fd065226d6" />
 	</game>
 	<game name="Excitebike 64 (USA)" cloneof="Excitebike 64 (Europe)">
 		<description>Excitebike 64 (USA)</description>
-		<rom name="Excitebike 64 (USA).z64" size="16777216" crc="fc459192" md5="7200d1c1cf489fafff767729f215e6e6" sha1="a847dd011e98204ad198cadeb6c80dda10d9a40e"/>
+		<rom name="Excitebike 64 (USA).n64" />
+		<rom name="Excitebike 64 (USA).z64" size="16777216" crc="fc459192" md5="7200d1c1cf489fafff767729f215e6e6" sha1="a847dd011e98204ad198cadeb6c80dda10d9a40e" />
 	</game>
 	<game name="Excitebike 64 (USA) (Demo) (Kiosk)" cloneof="Excitebike 64 (Europe)">
 		<description>Excitebike 64 (USA) (Demo) (Kiosk)</description>
-		<rom name="Excitebike 64 (USA) (Demo) (Kiosk).z64" size="16777216" crc="be6298b0" md5="e0018c33346714b63a55c0e040f23dea" sha1="daaf564815e9eef3fc163b9546b5880ee256274b"/>
+		<rom name="Excitebike 64 (USA) (Demo) (Kiosk).n64" />
+		<rom name="Excitebike 64 (USA) (Demo) (Kiosk).z64" size="16777216" crc="be6298b0" md5="e0018c33346714b63a55c0e040f23dea" sha1="daaf564815e9eef3fc163b9546b5880ee256274b" />
 	</game>
 	<game name="Excitebike 64 (USA) (Rev 1)" cloneof="Excitebike 64 (Europe)">
 		<description>Excitebike 64 (USA) (Rev 1)</description>
-		<release name="Excitebike 64 (USA) (Rev 1)" region="USA"/>
-		<rom name="Excitebike 64 (USA) (Rev 1).z64" size="16777216" crc="143926ce" md5="21954e4e404d9e87dbdb87dd309f3e94" sha1="c2fac422af135409c1b38569b309f9d452c81c35"/>
+		<rom name="Excitebike 64 (USA) (Rev 1).n64" />
+		<release name="Excitebike 64 (USA) (Rev 1)" region="USA" />
+		<rom name="Excitebike 64 (USA) (Rev 1).z64" size="16777216" crc="143926ce" md5="21954e4e404d9e87dbdb87dd309f3e94" sha1="c2fac422af135409c1b38569b309f9d452c81c35" />
 	</game>
 	<game name="Yueye Motuo (China) (iQue)" cloneof="Excitebike 64 (Europe)">
 		<description>Yueye Motuo (China) (iQue)</description>
-		<rom name="Yueye Motuo (China) (iQue).z64" size="16072704" crc="d7ad44fd" md5="f4b41863440137c6a3ba22942f3e0da2" sha1="e20d95e7c53c3d7ed7857bb89f0c79c94578bb4f"/>
+		<rom name="Yueye Motuo (China) (iQue).n64" />
+		<rom name="Yueye Motuo (China) (iQue).z64" size="16072704" crc="d7ad44fd" md5="f4b41863440137c6a3ba22942f3e0da2" sha1="e20d95e7c53c3d7ed7857bb89f0c79c94578bb4f" />
 	</game>
 	<game name="Extreme-G (Europe) (En,Fr,De,Es,It)">
 		<description>Extreme-G (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Extreme-G (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Extreme-G (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="0b71b1ea" md5="3b2ca0da0810c95b31df8c1fb8811be2" sha1="e7120856ecc9a7f29c21f45130eca0eca8a7bfec" status="verified"/>
+		<rom name="Extreme-G (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Extreme-G (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Extreme-G (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="0b71b1ea" md5="3b2ca0da0810c95b31df8c1fb8811be2" sha1="e7120856ecc9a7f29c21f45130eca0eca8a7bfec" status="verified" />
 	</game>
 	<game name="Extreme-G (Japan)" cloneof="Extreme-G (Europe) (En,Fr,De,Es,It)">
 		<description>Extreme-G (Japan)</description>
-		<release name="Extreme-G (Japan)" region="JPN"/>
-		<rom name="Extreme-G (Japan).z64" size="8388608" crc="750dc9a7" md5="a7cd65e5a4a8838d1cd452ba66e74df6" sha1="d9d6f7cc456b530fd3233ef2d8d6b9f845cee043"/>
+		<rom name="Extreme-G (Japan).n64" />
+		<release name="Extreme-G (Japan)" region="JPN" />
+		<rom name="Extreme-G (Japan).z64" size="8388608" crc="750dc9a7" md5="a7cd65e5a4a8838d1cd452ba66e74df6" sha1="d9d6f7cc456b530fd3233ef2d8d6b9f845cee043" />
 	</game>
 	<game name="Extreme-G (USA)" cloneof="Extreme-G (Europe) (En,Fr,De,Es,It)">
 		<description>Extreme-G (USA)</description>
-		<release name="Extreme-G (USA)" region="USA"/>
-		<rom name="Extreme-G (USA).z64" size="8388608" crc="04cb74ec" md5="3e660d3f991c0529e90bfec0244db31a" sha1="eb9b273431970a6124319a8fd125f0b2cacd8966"/>
+		<rom name="Extreme-G (USA).n64" />
+		<release name="Extreme-G (USA)" region="USA" />
+		<rom name="Extreme-G (USA).z64" size="8388608" crc="04cb74ec" md5="3e660d3f991c0529e90bfec0244db31a" sha1="eb9b273431970a6124319a8fd125f0b2cacd8966" />
 	</game>
 	<game name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)">
 		<description>Extreme-G XG2 (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="1a57f416" md5="bb7f98e657fb4b5fcc7dc04bd72e2d2b" sha1="ca6db450d29a6cc0d4a6fbb3468a1ed725cef51e"/>
+		<rom name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Extreme-G XG2 (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="1a57f416" md5="bb7f98e657fb4b5fcc7dc04bd72e2d2b" sha1="ca6db450d29a6cc0d4a6fbb3468a1ed725cef51e" />
 	</game>
 	<game name="Extreme-G XG2 (Japan)" cloneof="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)">
 		<description>Extreme-G XG2 (Japan)</description>
-		<release name="Extreme-G XG2 (Japan)" region="JPN"/>
-		<rom name="Extreme-G XG2 (Japan).z64" size="12582912" crc="7c8a36da" md5="f17884a2c16fb6fd11a74d65b1388b4a" sha1="94efb5d7247a075a9cc782d39b5e8af56d5f434f"/>
+		<rom name="Extreme-G XG2 (Japan).n64" />
+		<release name="Extreme-G XG2 (Japan)" region="JPN" />
+		<rom name="Extreme-G XG2 (Japan).z64" size="12582912" crc="7c8a36da" md5="f17884a2c16fb6fd11a74d65b1388b4a" sha1="94efb5d7247a075a9cc782d39b5e8af56d5f434f" />
 	</game>
 	<game name="Extreme-G XG2 (USA)" cloneof="Extreme-G XG2 (Europe) (En,Fr,De,Es,It)">
 		<description>Extreme-G XG2 (USA)</description>
-		<release name="Extreme-G XG2 (USA)" region="USA"/>
-		<rom name="Extreme-G XG2 (USA).z64" size="12582912" crc="81a4c28b" md5="44fe06ba3686c02a7988f27600a533da" sha1="ed0a50086ef9a89f5b445c20ab6f365165959630"/>
+		<rom name="Extreme-G XG2 (USA).n64" />
+		<release name="Extreme-G XG2 (USA)" region="USA" />
+		<rom name="Extreme-G XG2 (USA).z64" size="12582912" crc="81a4c28b" md5="44fe06ba3686c02a7988f27600a533da" sha1="ed0a50086ef9a89f5b445c20ab6f365165959630" />
 	</game>
 	<game name="F-1 World Grand Prix (Europe)">
 		<description>F-1 World Grand Prix (Europe)</description>
-		<release name="F-1 World Grand Prix (Europe)" region="EUR"/>
-		<rom name="F-1 World Grand Prix (Europe).z64" size="12582912" crc="1f4e651a" md5="fac450eaff8fa46a1414db02e6eeab9f" sha1="d812098662c4f8f73deb06d140e46a7754ce3b42"/>
+		<rom name="F-1 World Grand Prix (Europe).n64" />
+		<release name="F-1 World Grand Prix (Europe)" region="EUR" />
+		<rom name="F-1 World Grand Prix (Europe).z64" size="12582912" crc="1f4e651a" md5="fac450eaff8fa46a1414db02e6eeab9f" sha1="d812098662c4f8f73deb06d140e46a7754ce3b42" />
 	</game>
 	<game name="F-1 World Grand Prix (France)" cloneof="F-1 World Grand Prix (Europe)">
 		<description>F-1 World Grand Prix (France)</description>
-		<release name="F-1 World Grand Prix (France)" region="FRA"/>
-		<rom name="F-1 World Grand Prix (France).z64" size="12582912" crc="57cd299d" md5="35f6c42d5a9284688284c24250f4d6be" sha1="dd68b3624f2f8a0f821a391b690ecc5bb4fef2fd"/>
+		<rom name="F-1 World Grand Prix (France).n64" />
+		<release name="F-1 World Grand Prix (France)" region="FRA" />
+		<rom name="F-1 World Grand Prix (France).z64" size="12582912" crc="57cd299d" md5="35f6c42d5a9284688284c24250f4d6be" sha1="dd68b3624f2f8a0f821a391b690ecc5bb4fef2fd" />
 	</game>
 	<game name="F-1 World Grand Prix (Germany)" cloneof="F-1 World Grand Prix (Europe)">
 		<description>F-1 World Grand Prix (Germany)</description>
-		<release name="F-1 World Grand Prix (Germany)" region="GER"/>
-		<rom name="F-1 World Grand Prix (Germany).z64" size="12582912" crc="0f1984dc" md5="a8c78454c70bd73375aaf69c4078d5da" sha1="2ae85db9d6e9f3b85e4478577d5eb049ec4040c9"/>
+		<rom name="F-1 World Grand Prix (Germany).n64" />
+		<release name="F-1 World Grand Prix (Germany)" region="GER" />
+		<rom name="F-1 World Grand Prix (Germany).z64" size="12582912" crc="0f1984dc" md5="a8c78454c70bd73375aaf69c4078d5da" sha1="2ae85db9d6e9f3b85e4478577d5eb049ec4040c9" />
 	</game>
 	<game name="F-1 World Grand Prix (Japan)" cloneof="F-1 World Grand Prix (Europe)">
 		<description>F-1 World Grand Prix (Japan)</description>
-		<release name="F-1 World Grand Prix (Japan)" region="JPN"/>
-		<rom name="F-1 World Grand Prix (Japan).z64" size="12582912" crc="f7bacbc3" md5="f248f0aae609111ba9dff9fd7afbc485" sha1="595bfa62ec34f7884ff46137c92771cde4d8d6fe"/>
+		<rom name="F-1 World Grand Prix (Japan).n64" />
+		<release name="F-1 World Grand Prix (Japan)" region="JPN" />
+		<rom name="F-1 World Grand Prix (Japan).z64" size="12582912" crc="f7bacbc3" md5="f248f0aae609111ba9dff9fd7afbc485" sha1="595bfa62ec34f7884ff46137c92771cde4d8d6fe" />
 	</game>
 	<game name="F-1 World Grand Prix (USA)" cloneof="F-1 World Grand Prix (Europe)">
 		<description>F-1 World Grand Prix (USA)</description>
-		<release name="F-1 World Grand Prix (USA)" region="USA"/>
-		<rom name="F-1 World Grand Prix (USA).z64" size="12582912" crc="7dc9ef2c" md5="a81b1de864df3f4bb0903760be673f21" sha1="dd17545adc8fe2af2a713ab48c5f71801222edaf"/>
+		<rom name="F-1 World Grand Prix (USA).n64" />
+		<release name="F-1 World Grand Prix (USA)" region="USA" />
+		<rom name="F-1 World Grand Prix (USA).z64" size="12582912" crc="7dc9ef2c" md5="a81b1de864df3f4bb0903760be673f21" sha1="dd17545adc8fe2af2a713ab48c5f71801222edaf" />
 	</game>
 	<game name="F-1 World Grand Prix (Europe) (Beta)" cloneof="F-1 World Grand Prix (Europe)">
 		<description>F-1 World Grand Prix (Europe) (Beta)</description>
-		<rom name="F-1 World Grand Prix (Europe) (Beta).z64" size="12582912" crc="bebbc6c8" md5="9fbe3363da6c146ef2e29605bca834ff" sha1="63bd69c382eca5e569eddf7456f6435a7dce484f"/>
+		<rom name="F-1 World Grand Prix (Europe) (Beta).n64" />
+		<rom name="F-1 World Grand Prix (Europe) (Beta).z64" size="12582912" crc="bebbc6c8" md5="9fbe3363da6c146ef2e29605bca834ff" sha1="63bd69c382eca5e569eddf7456f6435a7dce484f" />
 	</game>
 	<game name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es)">
 		<description>F-1 World Grand Prix II (Europe) (En,Fr,De,Es)</description>
-		<release name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es).z64" size="12582912" crc="803d33df" md5="bc0fd2468ac7769a37c3c58cd5699585" sha1="53ed343a757b8a14814732393d02b3d780bccab5"/>
+		<rom name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es).n64" />
+		<release name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="F-1 World Grand Prix II (Europe) (En,Fr,De,Es).z64" size="12582912" crc="803d33df" md5="bc0fd2468ac7769a37c3c58cd5699585" sha1="53ed343a757b8a14814732393d02b3d780bccab5" />
 	</game>
 	<game name="F-Zero X (Europe)">
 		<description>F-Zero X (Europe)</description>
-		<release name="F-Zero X (Europe)" region="EUR"/>
-		<rom name="F-Zero X (Europe).z64" size="16777216" crc="2d6f7e8b" md5="ee79a8fe287b5dcaea584439363342fc" sha1="af9038bcb543a2b4faaab876dbdab4663859e092" status="verified"/>
+		<rom name="F-Zero X (Europe).n64" />
+		<release name="F-Zero X (Europe)" region="EUR" />
+		<rom name="F-Zero X (Europe).z64" size="16777216" crc="2d6f7e8b" md5="ee79a8fe287b5dcaea584439363342fc" sha1="af9038bcb543a2b4faaab876dbdab4663859e092" status="verified" />
 	</game>
 	<game name="F-Zero X (Japan)" cloneof="F-Zero X (Europe)">
 		<description>F-Zero X (Japan)</description>
-		<release name="F-Zero X (Japan)" region="JPN"/>
-		<rom name="F-Zero X (Japan).z64" size="16777216" crc="6b1cef83" md5="58d200d43620007314304f4e6c9e6528" sha1="a418b0151521b76691fa03f8658c8b567c69498b" status="verified"/>
+		<rom name="F-Zero X (Japan).n64" />
+		<release name="F-Zero X (Japan)" region="JPN" />
+		<rom name="F-Zero X (Japan).z64" size="16777216" crc="6b1cef83" md5="58d200d43620007314304f4e6c9e6528" sha1="a418b0151521b76691fa03f8658c8b567c69498b" status="verified" />
 	</game>
 	<game name="F-Zero X (USA)" cloneof="F-Zero X (Europe)">
 		<description>F-Zero X (USA)</description>
-		<release name="F-Zero X (USA)" region="USA"/>
-		<rom name="F-Zero X (USA).z64" size="16777216" crc="0b561fba" md5="753437d0d8ada1d12f3f9cf0f0a5171f" sha1="5f658e88ffa9de23cba6986a8fd3d3a90d7b4340" status="verified"/>
+		<rom name="F-Zero X (USA).n64" />
+		<release name="F-Zero X (USA)" region="USA" />
+		<rom name="F-Zero X (USA).z64" size="16777216" crc="0b561fba" md5="753437d0d8ada1d12f3f9cf0f0a5171f" sha1="5f658e88ffa9de23cba6986a8fd3d3a90d7b4340" status="verified" />
 	</game>
 	<game name="F-Zero X - Weilai Saiche (China) (iQue)" cloneof="F-Zero X (Europe)">
 		<description>F-Zero X - Weilai Saiche (China) (iQue)</description>
-		<rom name="F-Zero X - Weilai Saiche (China) (iQue).z64" size="16334848" crc="3d30385a" md5="4024477aaed7dd5ff5ea60bf568123b7" sha1="3c7fa54be9c0124c502f1c8df53765f82d401508"/>
+		<rom name="F-Zero X - Weilai Saiche (China) (iQue).n64" />
+		<rom name="F-Zero X - Weilai Saiche (China) (iQue).z64" size="16334848" crc="3d30385a" md5="4024477aaed7dd5ff5ea60bf568123b7" sha1="3c7fa54be9c0124c502f1c8df53765f82d401508" />
 	</game>
 	<game name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)">
 		<description>F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)</description>
-		<release name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)" region="CHN"/>
-		<rom name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual).z64" size="294912" crc="8ebc6ed5" md5="9729fc397e8d178ea974869e07df0502" sha1="26b4f91a0e2ea2e6994bcdc42b54d8c7e2279d98"/>
+		<rom name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual).n64" />
+		<release name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)" region="CHN" />
+		<rom name="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual).z64" size="294912" crc="8ebc6ed5" md5="9729fc397e8d178ea974869e07df0502" sha1="26b4f91a0e2ea2e6994bcdc42b54d8c7e2279d98" />
 	</game>
 	<game name="F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual)" cloneof="F-Zero X - Weilai Saiche (China) (v4) (iQue) (Manual)">
 		<description>F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual)</description>
-		<rom name="F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual).z64" size="180224" crc="88331ad2" md5="8400c0875e16f599c1b7fc433e339d58" sha1="8199c5b4dec4174bd2ff1c901bb47f356cf16503"/>
+		<rom name="F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual).n64" />
+		<rom name="F-Zero X - Weilai Saiche (China) (v2) (iQue) (Manual).z64" size="180224" crc="88331ad2" md5="8400c0875e16f599c1b7fc433e339d58" sha1="8199c5b4dec4174bd2ff1c901bb47f356cf16503" />
 	</game>
 	<game name="F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta)">
 		<description>F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta)</description>
-		<rom name="F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta).z64" size="33554432" crc="68fe1cec" md5="95bf2153aaad6faff3fb42fecd2f0200" sha1="6aa870ec53602650638b50d7c89cac026be481f0"/>
+		<rom name="F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta).n64" />
+		<rom name="F-Zero X + The Legend of Zelda Ocarina of Time (USA) (Beta).z64" size="33554432" crc="68fe1cec" md5="95bf2153aaad6faff3fb42fecd2f0200" sha1="6aa870ec53602650638b50d7c89cac026be481f0" />
 	</game>
 	<game name="F1 Pole Position 64 (Europe) (En,Fr,De)">
 		<description>F1 Pole Position 64 (Europe) (En,Fr,De)</description>
-		<release name="F1 Pole Position 64 (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="F1 Pole Position 64 (Europe) (En,Fr,De).z64" size="8388608" crc="ed750623" md5="a6bd93ea576cdf8569f68171452f7e8a" sha1="685feb2e8615d5d50944093eb0552858d3e12583"/>
+		<rom name="F1 Pole Position 64 (Europe) (En,Fr,De).n64" />
+		<release name="F1 Pole Position 64 (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="F1 Pole Position 64 (Europe) (En,Fr,De).z64" size="8388608" crc="ed750623" md5="a6bd93ea576cdf8569f68171452f7e8a" sha1="685feb2e8615d5d50944093eb0552858d3e12583" />
 	</game>
 	<game name="F1 Pole Position 64 (USA) (En,Fr,De)" cloneof="F1 Pole Position 64 (Europe) (En,Fr,De)">
 		<description>F1 Pole Position 64 (USA) (En,Fr,De)</description>
-		<release name="F1 Pole Position 64 (USA) (En,Fr,De)" region="USA"/>
-		<rom name="F1 Pole Position 64 (USA) (En,Fr,De).z64" size="8388608" crc="30a24d89" md5="049db657f4223d949f56e9dc5b6a9180" sha1="6e6bdaefc9980f066cd2abc5fa7f29f2353ca8b1"/>
+		<rom name="F1 Pole Position 64 (USA) (En,Fr,De).n64" />
+		<release name="F1 Pole Position 64 (USA) (En,Fr,De)" region="USA" />
+		<rom name="F1 Pole Position 64 (USA) (En,Fr,De).z64" size="8388608" crc="30a24d89" md5="049db657f4223d949f56e9dc5b6a9180" sha1="6e6bdaefc9980f066cd2abc5fa7f29f2353ca8b1" />
 	</game>
 	<game name="Human Grand Prix - The New Generation (Japan)" cloneof="F1 Pole Position 64 (Europe) (En,Fr,De)">
 		<description>Human Grand Prix - The New Generation (Japan)</description>
-		<release name="Human Grand Prix - The New Generation (Japan)" region="JPN"/>
-		<rom name="Human Grand Prix - The New Generation (Japan).z64" size="8388608" crc="31e102e3" md5="97e706ed9cc6f30708ffdc187c85d59f" sha1="b8dfe78c7abf1e33edad0b5ecec1c9f1f3c8b576"/>
+		<rom name="Human Grand Prix - The New Generation (Japan).n64" />
+		<release name="Human Grand Prix - The New Generation (Japan)" region="JPN" />
+		<rom name="Human Grand Prix - The New Generation (Japan).z64" size="8388608" crc="31e102e3" md5="97e706ed9cc6f30708ffdc187c85d59f" sha1="b8dfe78c7abf1e33edad0b5ecec1c9f1f3c8b576" />
 	</game>
 	<game name="F1 Racing Championship (Europe) (En,Fr,De,Es,It)">
 		<description>F1 Racing Championship (Europe) (En,Fr,De,Es,It)</description>
-		<release name="F1 Racing Championship (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="F1 Racing Championship (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="2da744f5" md5="9581fc6ceac86dc8a2aee4053043e422" sha1="3bce20f58ef9f377299858b7f2dabd0a02d2e9b9"/>
+		<rom name="F1 Racing Championship (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="F1 Racing Championship (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="F1 Racing Championship (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="2da744f5" md5="9581fc6ceac86dc8a2aee4053043e422" sha1="3bce20f58ef9f377299858b7f2dabd0a02d2e9b9" />
 	</game>
 	<game name="F1 Racing Championship (Brazil) (En,Fr)" cloneof="F1 Racing Championship (Europe) (En,Fr,De,Es,It)">
 		<description>F1 Racing Championship (Brazil) (En,Fr)</description>
-		<release name="F1 Racing Championship (Brazil) (En,Fr)" region="BRA"/>
-		<rom name="F1 Racing Championship (Brazil) (En,Fr).z64" size="16777216" crc="c05b9184" md5="44d5f87127053a21db120bd108b7ac0c" sha1="4c95cee963c9f8b477c41c03afccb3362a14e7ce"/>
+		<rom name="F1 Racing Championship (Brazil) (En,Fr).n64" />
+		<release name="F1 Racing Championship (Brazil) (En,Fr)" region="BRA" />
+		<rom name="F1 Racing Championship (Brazil) (En,Fr).z64" size="16777216" crc="c05b9184" md5="44d5f87127053a21db120bd108b7ac0c" sha1="4c95cee963c9f8b477c41c03afccb3362a14e7ce" />
 	</game>
 	<game name="Famista 64 (Japan)">
 		<description>Famista 64 (Japan)</description>
-		<release name="Famista 64 (Japan)" region="JPN"/>
-		<rom name="Famista 64 (Japan).z64" size="12582912" crc="9fb0e6c9" md5="d99b1a3f6d72defd76f3620959b94944" sha1="f4acb365c8a0dffdf2e93a726fd5e805ab857c56"/>
+		<rom name="Famista 64 (Japan).n64" />
+		<release name="Famista 64 (Japan)" region="JPN" />
+		<rom name="Famista 64 (Japan).z64" size="12582912" crc="9fb0e6c9" md5="d99b1a3f6d72defd76f3620959b94944" sha1="f4acb365c8a0dffdf2e93a726fd5e805ab857c56" />
 	</game>
 	<game name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)">
 		<description>FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)</description>
-		<release name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)" region="EUR"/>
-		<rom name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).z64" size="12582912" crc="137cb3cc" md5="26b18d35984528ae2f90adbb2f2642f7" sha1="676b4d14ad74ccc92ee4b19aa9130ddce42e0e9c" status="verified"/>
+		<rom name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).n64" />
+		<release name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)" region="EUR" />
+		<rom name="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv).z64" size="12582912" crc="137cb3cc" md5="26b18d35984528ae2f90adbb2f2642f7" sha1="676b4d14ad74ccc92ee4b19aa9130ddce42e0e9c" status="verified" />
 	</game>
 	<game name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)" cloneof="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)">
 		<description>FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)</description>
-		<release name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)" region="USA"/>
-		<rom name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).z64" size="12582912" crc="28b1221c" md5="2c6d146a8473511cfcfbbe8518f49d71" sha1="148d6424d2135afefecde74092701c491027c23e"/>
+		<rom name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).n64" />
+		<release name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv)" region="USA" />
+		<rom name="FIFA - Road to World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv).z64" size="12582912" crc="28b1221c" md5="2c6d146a8473511cfcfbbe8518f49d71" sha1="148d6424d2135afefecde74092701c491027c23e" />
 	</game>
 	<game name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)" cloneof="FIFA - Road to World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv)">
 		<description>FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)</description>
-		<release name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)" region="JPN"/>
-		<rom name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).z64" size="12582912" crc="ae346df6" md5="3611779f29997267622cbc80e2d087cc" sha1="d8a0c9ef8ff258d061a639e7572d0d9e3038a895"/>
+		<rom name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).n64" />
+		<release name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan)" region="JPN" />
+		<rom name="FIFA - Road to World Cup 98 - World Cup e no Michi (Japan).z64" size="12582912" crc="ae346df6" md5="3611779f29997267622cbc80e2d087cc" sha1="d8a0c9ef8ff258d061a639e7572d0d9e3038a895" />
 	</game>
 	<game name="FIFA 64 (Europe) (En,Fr,De)">
 		<description>FIFA 64 (Europe) (En,Fr,De)</description>
-		<release name="FIFA 64 (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="FIFA 64 (Europe) (En,Fr,De).z64" size="8388608" crc="ae2583fb" md5="9a7006212947ee7648ee1d13162e55e0" sha1="eacdf23e27ec1e0639042bf03804222851e4f151"/>
+		<rom name="FIFA 64 (Europe) (En,Fr,De).n64" />
+		<release name="FIFA 64 (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="FIFA 64 (Europe) (En,Fr,De).z64" size="8388608" crc="ae2583fb" md5="9a7006212947ee7648ee1d13162e55e0" sha1="eacdf23e27ec1e0639042bf03804222851e4f151" />
 	</game>
 	<game name="FIFA Soccer 64 (USA) (En,Fr,De)" cloneof="FIFA 64 (Europe) (En,Fr,De)">
 		<description>FIFA Soccer 64 (USA) (En,Fr,De)</description>
-		<release name="FIFA Soccer 64 (USA) (En,Fr,De)" region="USA"/>
-		<rom name="FIFA Soccer 64 (USA) (En,Fr,De).z64" size="8388608" crc="57de7cab" md5="cc7c58a032aaba19e72ccbfa6b3eeff6" sha1="603c5bf64497dca86c4eb802f97f1c32e75a68a8"/>
+		<rom name="FIFA Soccer 64 (USA) (En,Fr,De).n64" />
+		<release name="FIFA Soccer 64 (USA) (En,Fr,De)" region="USA" />
+		<rom name="FIFA Soccer 64 (USA) (En,Fr,De).z64" size="8388608" crc="57de7cab" md5="cc7c58a032aaba19e72ccbfa6b3eeff6" sha1="603c5bf64497dca86c4eb802f97f1c32e75a68a8" />
 	</game>
 	<game name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)">
 		<description>FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)</description>
-		<release name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)" region="EUR"/>
-		<rom name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).z64" size="16777216" crc="6eae1e6e" md5="6432c622c05ea9cd3217e280ac2ce37c" sha1="07400c53aef501887f73ef6a45ce04fe2f170fb0"/>
+		<rom name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" />
+		<release name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)" region="EUR" />
+		<rom name="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv).z64" size="16777216" crc="6eae1e6e" md5="6432c622c05ea9cd3217e280ac2ce37c" sha1="07400c53aef501887f73ef6a45ce04fe2f170fb0" />
 	</game>
 	<game name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)" cloneof="FIFA 99 (Europe) (En,Fr,De,Es,It,Nl,Pt,Sv)">
 		<description>FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)</description>
-		<release name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)" region="USA"/>
-		<rom name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).z64" size="16777216" crc="6b2473a9" md5="148de3073727b9fd156f10afadd46864" sha1="735062e593715f128d3aad435de0e7a899aed127"/>
+		<rom name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).n64" />
+		<release name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv)" region="USA" />
+		<rom name="FIFA 99 (USA) (En,Fr,De,Es,It,Nl,Pt,Sv).z64" size="16777216" crc="6b2473a9" md5="148de3073727b9fd156f10afadd46864" sha1="735062e593715f128d3aad435de0e7a899aed127" />
 	</game>
 	<game name="Fighter Destiny 2 (USA)">
 		<description>Fighter Destiny 2 (USA)</description>
-		<release name="Fighter Destiny 2 (USA)" region="USA"/>
-		<rom name="Fighter Destiny 2 (USA).z64" size="16777216" crc="bb2563c6" md5="04dd2a319f4f5c22569b612cfdf9f00c" sha1="1dc12cfd908f56debcad6cf582bfdfc23a3ad725"/>
+		<rom name="Fighter Destiny 2 (USA).n64" />
+		<release name="Fighter Destiny 2 (USA)" region="USA" />
+		<rom name="Fighter Destiny 2 (USA).z64" size="16777216" crc="bb2563c6" md5="04dd2a319f4f5c22569b612cfdf9f00c" sha1="1dc12cfd908f56debcad6cf582bfdfc23a3ad725" />
 	</game>
 	<game name="Kakutou Denshou - F-Cup Maniax (Japan)" cloneof="Fighter Destiny 2 (USA)">
 		<description>Kakutou Denshou - F-Cup Maniax (Japan)</description>
-		<release name="Kakutou Denshou - F-Cup Maniax (Japan)" region="JPN"/>
-		<rom name="Kakutou Denshou - F-Cup Maniax (Japan).z64" size="16777216" crc="db40a155" md5="dff0efe2b35fcde506d21b0c0bd373a5" sha1="f88f541d5913c99a9eac5ca4162e65b8a3828725"/>
+		<rom name="Kakutou Denshou - F-Cup Maniax (Japan).n64" />
+		<release name="Kakutou Denshou - F-Cup Maniax (Japan)" region="JPN" />
+		<rom name="Kakutou Denshou - F-Cup Maniax (Japan).z64" size="16777216" crc="db40a155" md5="dff0efe2b35fcde506d21b0c0bd373a5" sha1="f88f541d5913c99a9eac5ca4162e65b8a3828725" />
 	</game>
 	<game name="Fighters Destiny (Europe)">
 		<description>Fighters Destiny (Europe)</description>
-		<release name="Fighters Destiny (Europe)" region="EUR"/>
-		<rom name="Fighters Destiny (Europe).z64" size="12582912" crc="c9225511" md5="ef5cb24ce3fe4e0f850901205437b574" sha1="2763731085a9d86d357d8fef775c2d21d3c9f2b4"/>
+		<rom name="Fighters Destiny (Europe).n64" />
+		<release name="Fighters Destiny (Europe)" region="EUR" />
+		<rom name="Fighters Destiny (Europe).z64" size="12582912" crc="c9225511" md5="ef5cb24ce3fe4e0f850901205437b574" sha1="2763731085a9d86d357d8fef775c2d21d3c9f2b4" />
 	</game>
 	<game name="Fighters Destiny (France)" cloneof="Fighters Destiny (Europe)">
 		<description>Fighters Destiny (France)</description>
-		<release name="Fighters Destiny (France)" region="FRA"/>
-		<rom name="Fighters Destiny (France).z64" size="12582912" crc="0cc22034" md5="44b0be1c4b48f6119d3ac9424903d0eb" sha1="28c6486f4036295284a022b6d70d3bc2f64b20e8"/>
+		<rom name="Fighters Destiny (France).n64" />
+		<release name="Fighters Destiny (France)" region="FRA" />
+		<rom name="Fighters Destiny (France).z64" size="12582912" crc="0cc22034" md5="44b0be1c4b48f6119d3ac9424903d0eb" sha1="28c6486f4036295284a022b6d70d3bc2f64b20e8" />
 	</game>
 	<game name="Fighters Destiny (Germany)" cloneof="Fighters Destiny (Europe)">
 		<description>Fighters Destiny (Germany)</description>
-		<release name="Fighters Destiny (Germany)" region="GER"/>
-		<rom name="Fighters Destiny (Germany).z64" size="12582912" crc="5052168c" md5="1cf379aca2397222af9f3dc5d8e3c444" sha1="aef7792324c262c956e91ee01f57bed0c36bd825"/>
+		<rom name="Fighters Destiny (Germany).n64" />
+		<release name="Fighters Destiny (Germany)" region="GER" />
+		<rom name="Fighters Destiny (Germany).z64" size="12582912" crc="5052168c" md5="1cf379aca2397222af9f3dc5d8e3c444" sha1="aef7792324c262c956e91ee01f57bed0c36bd825" />
 	</game>
 	<game name="Fighters Destiny (USA)" cloneof="Fighters Destiny (Europe)">
 		<description>Fighters Destiny (USA)</description>
-		<release name="Fighters Destiny (USA)" region="USA"/>
-		<rom name="Fighters Destiny (USA).z64" size="12582912" crc="f45ea789" md5="d61d97a7658c419a25a9bac96b0a3df8" sha1="f87e1677602e38bac962424042e289ec58ec37b2"/>
+		<rom name="Fighters Destiny (USA).n64" />
+		<release name="Fighters Destiny (USA)" region="USA" />
+		<rom name="Fighters Destiny (USA).z64" size="12582912" crc="f45ea789" md5="d61d97a7658c419a25a9bac96b0a3df8" sha1="f87e1677602e38bac962424042e289ec58ec37b2" />
 	</game>
 	<game name="Fighting Cup (Japan)" cloneof="Fighters Destiny (Europe)">
 		<description>Fighting Cup (Japan)</description>
-		<release name="Fighting Cup (Japan)" region="JPN"/>
-		<rom name="Fighting Cup (Japan).z64" size="12582912" crc="8a1c261e" md5="722c3a74a90305d6079a37994cebf5b2" sha1="011bdbaa1bc6d6a5540a749cf1a90bf6a35fd94b"/>
+		<rom name="Fighting Cup (Japan).n64" />
+		<release name="Fighting Cup (Japan)" region="JPN" />
+		<rom name="Fighting Cup (Japan).z64" size="12582912" crc="8a1c261e" md5="722c3a74a90305d6079a37994cebf5b2" sha1="011bdbaa1bc6d6a5540a749cf1a90bf6a35fd94b" />
 	</game>
 	<game name="Fighting Force 64 (Europe)">
 		<description>Fighting Force 64 (Europe)</description>
-		<release name="Fighting Force 64 (Europe)" region="EUR"/>
-		<rom name="Fighting Force 64 (Europe).z64" size="16777216" crc="4052c176" md5="0035e8205336982e362402aaea37d147" sha1="705d2b553fab526c908e46c048be3a3338ae2a86"/>
+		<rom name="Fighting Force 64 (Europe).n64" />
+		<release name="Fighting Force 64 (Europe)" region="EUR" />
+		<rom name="Fighting Force 64 (Europe).z64" size="16777216" crc="4052c176" md5="0035e8205336982e362402aaea37d147" sha1="705d2b553fab526c908e46c048be3a3338ae2a86" />
 	</game>
 	<game name="Fighting Force 64 (USA)" cloneof="Fighting Force 64 (Europe)">
 		<description>Fighting Force 64 (USA)</description>
-		<release name="Fighting Force 64 (USA)" region="USA"/>
-		<rom name="Fighting Force 64 (USA).z64" size="16777216" crc="8456841e" md5="e7008d17fd71d9c2bda1362c885388b2" sha1="6b4e78201ad5c5d0bd932652f233d9732316cdc2"/>
+		<rom name="Fighting Force 64 (USA).n64" />
+		<release name="Fighting Force 64 (USA)" region="USA" />
+		<rom name="Fighting Force 64 (USA).z64" size="16777216" crc="8456841e" md5="e7008d17fd71d9c2bda1362c885388b2" sha1="6b4e78201ad5c5d0bd932652f233d9732316cdc2" />
 	</game>
 	<game name="Flying Dragon (Europe)">
 		<description>Flying Dragon (Europe)</description>
-		<release name="Flying Dragon (Europe)" region="EUR"/>
-		<rom name="Flying Dragon (Europe).z64" size="12582912" crc="c3066e59" md5="add115aad0ab7d33bfd243936d809178" sha1="3f4462d85d5b5ddc6edaeef45b682eeff7f4b144"/>
+		<rom name="Flying Dragon (Europe).n64" />
+		<release name="Flying Dragon (Europe)" region="EUR" />
+		<rom name="Flying Dragon (Europe).z64" size="12582912" crc="c3066e59" md5="add115aad0ab7d33bfd243936d809178" sha1="3f4462d85d5b5ddc6edaeef45b682eeff7f4b144" />
 	</game>
 	<game name="Flying Dragon (USA)" cloneof="Flying Dragon (Europe)">
 		<description>Flying Dragon (USA)</description>
-		<release name="Flying Dragon (USA)" region="USA"/>
-		<rom name="Flying Dragon (USA).z64" size="12582912" crc="91bc9aeb" md5="272b359d8f8ac48acbf053c262f422e4" sha1="5472fe1dcaaacaecba8d1bed8eab4a2146e58665"/>
+		<rom name="Flying Dragon (USA).n64" />
+		<release name="Flying Dragon (USA)" region="USA" />
+		<rom name="Flying Dragon (USA).z64" size="12582912" crc="91bc9aeb" md5="272b359d8f8ac48acbf053c262f422e4" sha1="5472fe1dcaaacaecba8d1bed8eab4a2146e58665" />
 	</game>
 	<game name="Hiryuu no Ken Twin (Japan)" cloneof="Flying Dragon (Europe)">
 		<description>Hiryuu no Ken Twin (Japan)</description>
-		<release name="Hiryuu no Ken Twin (Japan)" region="JPN"/>
-		<rom name="Hiryuu no Ken Twin (Japan).z64" size="12582912" crc="ba6a687e" md5="73084495f3209c54900525436bbbc531" sha1="c7a76b061c383600378e52a39dada8d2be58325b" status="verified"/>
+		<rom name="Hiryuu no Ken Twin (Japan).n64" />
+		<release name="Hiryuu no Ken Twin (Japan)" region="JPN" />
+		<rom name="Hiryuu no Ken Twin (Japan).z64" size="12582912" crc="ba6a687e" md5="73084495f3209c54900525436bbbc531" sha1="c7a76b061c383600378e52a39dada8d2be58325b" status="verified" />
 	</game>
 	<game name="Forsaken (Europe) (En,Fr,Es,It)">
 		<description>Forsaken (Europe) (En,Fr,Es,It)</description>
-		<release name="Forsaken (Europe) (En,Fr,Es,It)" region="EUR"/>
-		<rom name="Forsaken (Europe) (En,Fr,Es,It).z64" size="8388608" crc="5ed736d9" md5="8286ded701dfa22436d311bd5b93bd29" sha1="ac24c6e48fcd03c32aef484188ba842b619ff613" status="verified"/>
+		<rom name="Forsaken (Europe) (En,Fr,Es,It).n64" />
+		<release name="Forsaken (Europe) (En,Fr,Es,It)" region="EUR" />
+		<rom name="Forsaken (Europe) (En,Fr,Es,It).z64" size="8388608" crc="5ed736d9" md5="8286ded701dfa22436d311bd5b93bd29" sha1="ac24c6e48fcd03c32aef484188ba842b619ff613" status="verified" />
 	</game>
 	<game name="Forsaken (Germany)" cloneof="Forsaken (Europe) (En,Fr,Es,It)">
 		<description>Forsaken (Germany)</description>
-		<release name="Forsaken (Germany)" region="GER"/>
-		<rom name="Forsaken (Germany).z64" size="8388608" crc="9793abc2" md5="74650f7154e0b2dd7c364f511b0d6a77" sha1="f1be08780d117c44fc10a0dba792d6c5be7d4093"/>
+		<rom name="Forsaken (Germany).n64" />
+		<release name="Forsaken (Germany)" region="GER" />
+		<rom name="Forsaken (Germany).z64" size="8388608" crc="9793abc2" md5="74650f7154e0b2dd7c364f511b0d6a77" sha1="f1be08780d117c44fc10a0dba792d6c5be7d4093" />
 	</game>
 	<game name="Forsaken 64 (USA)" cloneof="Forsaken (Europe) (En,Fr,Es,It)">
 		<description>Forsaken 64 (USA)</description>
-		<release name="Forsaken 64 (USA)" region="USA"/>
-		<rom name="Forsaken 64 (USA).z64" size="8388608" crc="76c4333d" md5="5cdee5503a57d14533c66b35a5848899" sha1="7c670b224acfa960df902c866febb679806cb3fb"/>
+		<rom name="Forsaken 64 (USA).n64" />
+		<release name="Forsaken 64 (USA)" region="USA" />
+		<rom name="Forsaken 64 (USA).z64" size="8388608" crc="76c4333d" md5="5cdee5503a57d14533c66b35a5848899" sha1="7c670b224acfa960df902c866febb679806cb3fb" />
 	</game>
 	<game name="Fox Sports College Hoops '99 (USA)">
 		<description>Fox Sports College Hoops '99 (USA)</description>
-		<release name="Fox Sports College Hoops '99 (USA)" region="USA"/>
-		<rom name="Fox Sports College Hoops '99 (USA).z64" size="12582912" crc="67eaf0f3" md5="360dc6be6d06dca12e53c077ac0d2571" sha1="a8ce01a7d6d01be19ffb87cb54cc069494efb596"/>
+		<rom name="Fox Sports College Hoops '99 (USA).n64" />
+		<release name="Fox Sports College Hoops '99 (USA)" region="USA" />
+		<rom name="Fox Sports College Hoops '99 (USA).z64" size="12582912" crc="67eaf0f3" md5="360dc6be6d06dca12e53c077ac0d2571" sha1="a8ce01a7d6d01be19ffb87cb54cc069494efb596" />
 	</game>
 	<game name="Freak Boy (Unknown) (Proto)">
 		<description>Freak Boy (Unknown) (Proto)</description>
-		<rom name="Freak Boy (Unknown) (Proto).z64" size="16777216" crc="40632bec" md5="19d8cc329244f73f9a0e0750e3688d58" sha1="9326914cd8271e220d6289837f8780f63f98ef30"/>
+		<rom name="Freak Boy (Unknown) (Proto).n64" />
+		<rom name="Freak Boy (Unknown) (Proto).z64" size="16777216" crc="40632bec" md5="19d8cc329244f73f9a0e0750e3688d58" sha1="9326914cd8271e220d6289837f8780f63f98ef30" />
 	</game>
 	<game name="Frogger 2 (USA) (Proto 2)">
 		<description>Frogger 2 (USA) (Proto 2)</description>
-		<release name="Frogger 2 (USA) (Proto 2)" region="USA"/>
-		<rom name="Frogger 2 (USA) (Proto 2).z64" size="33554432" crc="a8f81f39" md5="27f61a55e27ea7f1ede4ca11966acc7c" sha1="412d60ec37b71621368fe1885272f74385a7c5a3"/>
+		<rom name="Frogger 2 (USA) (Proto 2).n64" />
+		<release name="Frogger 2 (USA) (Proto 2)" region="USA" />
+		<rom name="Frogger 2 (USA) (Proto 2).z64" size="33554432" crc="a8f81f39" md5="27f61a55e27ea7f1ede4ca11966acc7c" sha1="412d60ec37b71621368fe1885272f74385a7c5a3" />
 	</game>
 	<game name="Frogger 2 (USA) (Proto 1)" cloneof="Frogger 2 (USA) (Proto 2)">
 		<description>Frogger 2 (USA) (Proto 1)</description>
-		<rom name="Frogger 2 (USA) (Proto 1).z64" size="33554432" crc="8d62268e" md5="097189b4c9bf6775e4685951b6e66f24" sha1="637cafe4abdc3fc0ef0703e3a47ea6a633b16fa3"/>
+		<rom name="Frogger 2 (USA) (Proto 1).n64" />
+		<rom name="Frogger 2 (USA) (Proto 1).z64" size="33554432" crc="8d62268e" md5="097189b4c9bf6775e4685951b6e66f24" sha1="637cafe4abdc3fc0ef0703e3a47ea6a633b16fa3" />
 	</game>
 	<game name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)">
 		<description>Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)</description>
-		<release name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)" region="JPN"/>
-		<rom name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).z64" size="33554432" crc="2aa6d2a1" md5="bbcde4966bee5602a80d9b8c1011dfa6" sha1="f97b070a1fa6ab3d190b36d6b68a2ef182d35233"/>
+		<rom name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).n64" />
+		<release name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan)" region="JPN" />
+		<rom name="Fushigi no Dungeon - Fuurai no Shiren 2 - Oni Shuurai! Shiren Jou! (Japan).z64" size="33554432" crc="2aa6d2a1" md5="bbcde4966bee5602a80d9b8c1011dfa6" sha1="f97b070a1fa6ab3d190b36d6b68a2ef182d35233" />
 	</game>
 	<game name="G.A.S.P!! Fighters' NEXTream (Europe)">
 		<description>G.A.S.P!! Fighters' NEXTream (Europe)</description>
-		<release name="G.A.S.P!! Fighters' NEXTream (Europe)" region="EUR"/>
-		<rom name="G.A.S.P!! Fighters' NEXTream (Europe).z64" size="12582912" crc="5aa63b04" md5="316c59dae45c20250a0419a937e7d65b" sha1="b069f2c0b6ab4fbd486861c4d3aaf8a149ab4529"/>
+		<rom name="G.A.S.P!! Fighters' NEXTream (Europe).n64" />
+		<release name="G.A.S.P!! Fighters' NEXTream (Europe)" region="EUR" />
+		<rom name="G.A.S.P!! Fighters' NEXTream (Europe).z64" size="12582912" crc="5aa63b04" md5="316c59dae45c20250a0419a937e7d65b" sha1="b069f2c0b6ab4fbd486861c4d3aaf8a149ab4529" />
 	</game>
 	<game name="Deadly Arts (USA)" cloneof="G.A.S.P!! Fighters' NEXTream (Europe)">
 		<description>Deadly Arts (USA)</description>
-		<release name="Deadly Arts (USA)" region="USA"/>
-		<rom name="Deadly Arts (USA).z64" size="12582912" crc="3db8130e" md5="a2a4a0318dab366a595336b6f80ff3ab" sha1="aa8566669575e3fea05daf5688d4fe05df735cd9"/>
+		<rom name="Deadly Arts (USA).n64" />
+		<release name="Deadly Arts (USA)" region="USA" />
+		<rom name="Deadly Arts (USA).z64" size="12582912" crc="3db8130e" md5="a2a4a0318dab366a595336b6f80ff3ab" sha1="aa8566669575e3fea05daf5688d4fe05df735cd9" />
 	</game>
 	<game name="G.A.S.P!! Fighters' NEXTream (Japan)" cloneof="G.A.S.P!! Fighters' NEXTream (Europe)">
 		<description>G.A.S.P!! Fighters' NEXTream (Japan)</description>
-		<release name="G.A.S.P!! Fighters' NEXTream (Japan)" region="JPN"/>
-		<rom name="G.A.S.P!! Fighters' NEXTream (Japan).z64" size="12582912" crc="6ead2d89" md5="6c73558de5a1eee6597d7264f9a11b0c" sha1="86693e6c1623708438ebf23ab0e78dd6ea8c8fa7"/>
+		<rom name="G.A.S.P!! Fighters' NEXTream (Japan).n64" />
+		<release name="G.A.S.P!! Fighters' NEXTream (Japan)" region="JPN" />
+		<rom name="G.A.S.P!! Fighters' NEXTream (Japan).z64" size="12582912" crc="6ead2d89" md5="6c73558de5a1eee6597d7264f9a11b0c" sha1="86693e6c1623708438ebf23ab0e78dd6ea8c8fa7" />
 	</game>
 	<game name="GameBooster 64 (Europe) (v1.1) (Unl)">
 		<description>GameBooster 64 (Europe) (v1.1) (Unl)</description>
-		<release name="GameBooster 64 (Europe) (v1.1) (Unl)" region="EUR"/>
-		<rom name="GameBooster 64 (Europe) (v1.1) (Unl).bin" size="262144" crc="35b99bd9" md5="1a56fe2b2fe339c7dd4ff8d37ec8654b" sha1="d79ee0482443c046b9e865a78f3d4507b7478af4"/>
+		<rom name="GameBooster 64 (Europe) (v1.1) (Unl).z64" />
+		<rom name="GameBooster 64 (Europe) (v1.1) (Unl).n64" />
+		<release name="GameBooster 64 (Europe) (v1.1) (Unl)" region="EUR" />
+		<rom name="GameBooster 64 (Europe) (v1.1) (Unl).bin" size="262144" crc="35b99bd9" md5="1a56fe2b2fe339c7dd4ff8d37ec8654b" sha1="d79ee0482443c046b9e865a78f3d4507b7478af4" />
 	</game>
 	<game name="GameBooster 64 (USA) (v1.1) (Unl)" cloneof="GameBooster 64 (Europe) (v1.1) (Unl)">
 		<description>GameBooster 64 (USA) (v1.1) (Unl)</description>
-		<release name="GameBooster 64 (USA) (v1.1) (Unl)" region="USA"/>
-		<rom name="GameBooster 64 (USA) (v1.1) (Unl).bin" size="262144" crc="e0b8edae" md5="60d0264b38e22ef0d6b9549e4c81c29f" sha1="5d0f244584d6cc0b0ced714409412f61de181e57"/>
+		<rom name="GameBooster 64 (USA) (v1.1) (Unl).z64" />
+		<rom name="GameBooster 64 (USA) (v1.1) (Unl).n64" />
+		<release name="GameBooster 64 (USA) (v1.1) (Unl)" region="USA" />
+		<rom name="GameBooster 64 (USA) (v1.1) (Unl).bin" size="262144" crc="e0b8edae" md5="60d0264b38e22ef0d6b9549e4c81c29f" sha1="5d0f244584d6cc0b0ced714409412f61de181e57" />
 	</game>
 	<game name="Gauntlet Legends (Europe)">
 		<description>Gauntlet Legends (Europe)</description>
-		<release name="Gauntlet Legends (Europe)" region="EUR"/>
-		<rom name="Gauntlet Legends (Europe).z64" size="16777216" crc="b7b3a489" md5="28c2108a375f7731e719333a09439d2f" sha1="29f19e0405dca66c7383fb94104a22758a9d06dd"/>
+		<rom name="Gauntlet Legends (Europe).n64" />
+		<release name="Gauntlet Legends (Europe)" region="EUR" />
+		<rom name="Gauntlet Legends (Europe).z64" size="16777216" crc="b7b3a489" md5="28c2108a375f7731e719333a09439d2f" sha1="29f19e0405dca66c7383fb94104a22758a9d06dd" />
 	</game>
 	<game name="Gauntlet Legends (Japan)" cloneof="Gauntlet Legends (Europe)">
 		<description>Gauntlet Legends (Japan)</description>
-		<release name="Gauntlet Legends (Japan)" region="JPN"/>
-		<rom name="Gauntlet Legends (Japan).z64" size="16777216" crc="8d133db0" md5="3b2615d754a61e45b1034d555d830a78" sha1="8389b01e5872053f1f39bc586db9fa012d46c5fa"/>
+		<rom name="Gauntlet Legends (Japan).n64" />
+		<release name="Gauntlet Legends (Japan)" region="JPN" />
+		<rom name="Gauntlet Legends (Japan).z64" size="16777216" crc="8d133db0" md5="3b2615d754a61e45b1034d555d830a78" sha1="8389b01e5872053f1f39bc586db9fa012d46c5fa" />
 	</game>
 	<game name="Gauntlet Legends (USA)" cloneof="Gauntlet Legends (Europe)">
 		<description>Gauntlet Legends (USA)</description>
-		<release name="Gauntlet Legends (USA)" region="USA"/>
-		<rom name="Gauntlet Legends (USA).z64" size="16777216" crc="64765e82" md5="9cb963e8b71f18568f78ec1af120362e" sha1="0489dcce749c6a5102681d288ed0616a4b94e99d"/>
+		<rom name="Gauntlet Legends (USA).n64" />
+		<release name="Gauntlet Legends (USA)" region="USA" />
+		<rom name="Gauntlet Legends (USA).z64" size="16777216" crc="64765e82" md5="9cb963e8b71f18568f78ec1af120362e" sha1="0489dcce749c6a5102681d288ed0616a4b94e99d" />
 	</game>
 	<game name="Getter Love!! - Cho Renai Party Game Tanjou (Japan)">
 		<description>Getter Love!! - Cho Renai Party Game Tanjou (Japan)</description>
-		<release name="Getter Love!! - Cho Renai Party Game Tanjou (Japan)" region="JPN"/>
-		<rom name="Getter Love!! - Cho Renai Party Game Tanjou (Japan).z64" size="12582912" crc="724ecae7" md5="5270d98f9e67dc7ef354ece109c2a18f" sha1="942d161abf00b612486388eee98a2c51fc990147"/>
+		<rom name="Getter Love!! - Cho Renai Party Game Tanjou (Japan).n64" />
+		<release name="Getter Love!! - Cho Renai Party Game Tanjou (Japan)" region="JPN" />
+		<rom name="Getter Love!! - Cho Renai Party Game Tanjou (Japan).z64" size="12582912" crc="724ecae7" md5="5270d98f9e67dc7ef354ece109c2a18f" sha1="942d161abf00b612486388eee98a2c51fc990147" />
 	</game>
 	<game name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)">
 		<description>Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)</description>
-		<release name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)" region="EUR"/>
-		<rom name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).z64" size="33554432" crc="6bc4a056" md5="9f0492a34d7a2d7c4e9f29dc1848a04a" sha1="54653ba26a12521ccd886212fffdf2f6427c2fea"/>
+		<rom name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).n64" />
+		<release name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)" region="EUR" />
+		<rom name="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It).z64" size="33554432" crc="6bc4a056" md5="9f0492a34d7a2d7c4e9f29dc1848a04a" sha1="54653ba26a12521ccd886212fffdf2f6427c2fea" />
 	</game>
 	<game name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" cloneof="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)">
 		<description>Gex 3 - Deep Cover Gecko (Europe) (Fr,De)</description>
-		<release name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" region="FRA"/>
-		<release name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" region="GER"/>
-		<rom name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De).z64" size="33554432" crc="a43cb8e4" md5="43b9a7a5ccb6ea3f4860f9f80d73669d" sha1="4bcd958526d9145acf4e3ee7ee484e62dc1bb4ba"/>
+		<rom name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De).n64" />
+		<release name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" region="FRA" />
+		<release name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De)" region="GER" />
+		<rom name="Gex 3 - Deep Cover Gecko (Europe) (Fr,De).z64" size="33554432" crc="a43cb8e4" md5="43b9a7a5ccb6ea3f4860f9f80d73669d" sha1="4bcd958526d9145acf4e3ee7ee484e62dc1bb4ba" />
 	</game>
 	<game name="Gex 3 - Deep Cover Gecko (USA)" cloneof="Gex 3 - Deep Cover Gecko (Europe) (En,Es,It)">
 		<description>Gex 3 - Deep Cover Gecko (USA)</description>
-		<release name="Gex 3 - Deep Cover Gecko (USA)" region="USA"/>
-		<rom name="Gex 3 - Deep Cover Gecko (USA).z64" size="33554432" crc="87a7d099" md5="6770ddec84eb21a5e0d0f55dfd52a01a" sha1="467bc88942e02d542e1a4705dcab98ab7281819f"/>
+		<rom name="Gex 3 - Deep Cover Gecko (USA).n64" />
+		<release name="Gex 3 - Deep Cover Gecko (USA)" region="USA" />
+		<rom name="Gex 3 - Deep Cover Gecko (USA).z64" size="33554432" crc="87a7d099" md5="6770ddec84eb21a5e0d0f55dfd52a01a" sha1="467bc88942e02d542e1a4705dcab98ab7281819f" />
 	</game>
 	<game name="Gex 64 - Enter the Gecko (Europe)">
 		<description>Gex 64 - Enter the Gecko (Europe)</description>
-		<release name="Gex 64 - Enter the Gecko (Europe)" region="EUR"/>
-		<rom name="Gex 64 - Enter the Gecko (Europe).z64" size="16777216" crc="a7c92bea" md5="5bba457e286d250101ce274e0e58080d" sha1="c5318e2660fed61782bb170e780b89305aa8c3dc"/>
+		<rom name="Gex 64 - Enter the Gecko (Europe).n64" />
+		<release name="Gex 64 - Enter the Gecko (Europe)" region="EUR" />
+		<rom name="Gex 64 - Enter the Gecko (Europe).z64" size="16777216" crc="a7c92bea" md5="5bba457e286d250101ce274e0e58080d" sha1="c5318e2660fed61782bb170e780b89305aa8c3dc" />
 	</game>
 	<game name="Gex 64 - Enter the Gecko (USA)" cloneof="Gex 64 - Enter the Gecko (Europe)">
 		<description>Gex 64 - Enter the Gecko (USA)</description>
-		<release name="Gex 64 - Enter the Gecko (USA)" region="USA"/>
-		<rom name="Gex 64 - Enter the Gecko (USA).z64" size="16777216" crc="c545ce80" md5="47f9d900c97ece154bb40a9c6dccd3fd" sha1="16042cd0dfa5439ca436f1bf05ebfb7e9f730cda"/>
+		<rom name="Gex 64 - Enter the Gecko (USA).n64" />
+		<release name="Gex 64 - Enter the Gecko (USA)" region="USA" />
+		<rom name="Gex 64 - Enter the Gecko (USA).z64" size="16777216" crc="c545ce80" md5="47f9d900c97ece154bb40a9c6dccd3fd" sha1="16042cd0dfa5439ca436f1bf05ebfb7e9f730cda" />
 	</game>
 	<game name="Glover (Europe) (En,Fr,De)">
 		<description>Glover (Europe) (En,Fr,De)</description>
-		<release name="Glover (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Glover (Europe) (En,Fr,De).z64" size="8388608" crc="90eceb4a" md5="2f2163c53db135792331df00398b3f87" sha1="a5209925761c4ef08e5d446a55bc957505308a31" status="verified"/>
+		<rom name="Glover (Europe) (En,Fr,De).n64" />
+		<release name="Glover (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Glover (Europe) (En,Fr,De).z64" size="8388608" crc="90eceb4a" md5="2f2163c53db135792331df00398b3f87" sha1="a5209925761c4ef08e5d446a55bc957505308a31" status="verified" />
 	</game>
 	<game name="Glover (USA)" cloneof="Glover (Europe) (En,Fr,De)">
 		<description>Glover (USA)</description>
-		<release name="Glover (USA)" region="USA"/>
-		<rom name="Glover (USA).z64" size="8388608" crc="f874571c" md5="87aa5740dff79291ee97832da1f86205" sha1="270be17b3c8da9b88a7b99c2a545b0bce16837f4"/>
+		<rom name="Glover (USA).n64" />
+		<release name="Glover (USA)" region="USA" />
+		<rom name="Glover (USA).z64" size="8388608" crc="f874571c" md5="87aa5740dff79291ee97832da1f86205" sha1="270be17b3c8da9b88a7b99c2a545b0bce16837f4" />
 	</game>
 	<game name="Glover (USA) (Beta) (1998-07-16)" cloneof="Glover (Europe) (En,Fr,De)">
 		<description>Glover (USA) (Beta) (1998-07-16)</description>
-		<rom name="Glover (USA) (Beta) (1998-07-16).z64" size="67108864" crc="7a866221" md5="43c3375bbd6496b6c51d08ec193bc8ed" sha1="a60bb3856218b554beee25d30dcf05e6d0308f52"/>
+		<rom name="Glover (USA) (Beta) (1998-07-16).n64" />
+		<rom name="Glover (USA) (Beta) (1998-07-16).z64" size="67108864" crc="7a866221" md5="43c3375bbd6496b6c51d08ec193bc8ed" sha1="a60bb3856218b554beee25d30dcf05e6d0308f52" />
 	</game>
 	<game name="Glover (USA) (Rev 1) (Proto)" cloneof="Glover (Europe) (En,Fr,De)">
 		<description>Glover (USA) (Rev 1) (Proto)</description>
-		<rom name="Glover (USA) (Rev 1) (Proto).z64" size="25165824" crc="5e091e8f" md5="9cc14c73eb1202c3d19633ee05ad5fc4" sha1="3da3074fe998dbc6c47791a5b6dcbb5143b0fad8"/>
+		<rom name="Glover (USA) (Rev 1) (Proto).n64" />
+		<rom name="Glover (USA) (Rev 1) (Proto).z64" size="25165824" crc="5e091e8f" md5="9cc14c73eb1202c3d19633ee05ad5fc4" sha1="3da3074fe998dbc6c47791a5b6dcbb5143b0fad8" />
 	</game>
 	<game name="Whack 'n' Roll (Unknown) (Beta) (1998-02-05)" cloneof="Glover (Europe) (En,Fr,De)">
 		<description>Whack 'n' Roll (Unknown) (Beta) (1998-02-05)</description>
-		<rom name="Whack 'n' Roll (Unknown) (Beta) (1998-02-05).n64" size="3823288" crc="74df67bb" md5="aab9c595a91b9f26e12cae2ff2649881" sha1="1d8f3b0cc37dc357cddc8075fc749bc7d66b5331"/>
+		<rom name="Whack 'n' Roll (Unknown) (Beta) (1998-02-05).z64" />
+		<rom name="Whack 'n' Roll (Unknown) (Beta) (1998-02-05).n64" size="3823288" crc="74df67bb" md5="aab9c595a91b9f26e12cae2ff2649881" sha1="1d8f3b0cc37dc357cddc8075fc749bc7d66b5331" />
 	</game>
 	<game name="Glover 2 (USA) (Proto 2)">
 		<description>Glover 2 (USA) (Proto 2)</description>
-		<release name="Glover 2 (USA) (Proto 2)" region="USA"/>
-		<rom name="Glover 2 (USA) (Proto 2).z64" size="33554432" crc="400aecc7" md5="a8567ddabd3672fff18bc5df933cf8c7" sha1="9e2d87385cf0b3b250222bc5e5ffc2750e13393b"/>
+		<rom name="Glover 2 (USA) (Proto 2).n64" />
+		<release name="Glover 2 (USA) (Proto 2)" region="USA" />
+		<rom name="Glover 2 (USA) (Proto 2).z64" size="33554432" crc="400aecc7" md5="a8567ddabd3672fff18bc5df933cf8c7" sha1="9e2d87385cf0b3b250222bc5e5ffc2750e13393b" />
 	</game>
 	<game name="Glover 2 (USA) (Proto 1)" cloneof="Glover 2 (USA) (Proto 2)">
 		<description>Glover 2 (USA) (Proto 1)</description>
-		<rom name="Glover 2 (USA) (Proto 1).z64" size="33554432" crc="d0809afb" md5="4e15d92cca23e1a01bb65246431b5c5a" sha1="58750c5fb47e35badd41eaf748cc9cdb3b24f64a"/>
+		<rom name="Glover 2 (USA) (Proto 1).n64" />
+		<rom name="Glover 2 (USA) (Proto 1).z64" size="33554432" crc="d0809afb" md5="4e15d92cca23e1a01bb65246431b5c5a" sha1="58750c5fb47e35badd41eaf748cc9cdb3b24f64a" />
 	</game>
 	<game name="Goemon - Mononoke Sugoroku (Japan)">
 		<description>Goemon - Mononoke Sugoroku (Japan)</description>
-		<release name="Goemon - Mononoke Sugoroku (Japan)" region="JPN"/>
-		<rom name="Goemon - Mononoke Sugoroku (Japan).z64" size="16777216" crc="965c4575" md5="2bde49f2855030de342976c9a95b81b3" sha1="accc27a72e9bd8bcac011009a08df7f7aae3b2fe"/>
+		<rom name="Goemon - Mononoke Sugoroku (Japan).n64" />
+		<release name="Goemon - Mononoke Sugoroku (Japan)" region="JPN" />
+		<rom name="Goemon - Mononoke Sugoroku (Japan).z64" size="16777216" crc="965c4575" md5="2bde49f2855030de342976c9a95b81b3" sha1="accc27a72e9bd8bcac011009a08df7f7aae3b2fe" />
 	</game>
 	<game name="Golden Nugget 64 (USA)">
 		<description>Golden Nugget 64 (USA)</description>
-		<release name="Golden Nugget 64 (USA)" region="USA"/>
-		<rom name="Golden Nugget 64 (USA).z64" size="8388608" crc="70594d3c" md5="231bac1afb3de138072c2d697783059b" sha1="1c0b0e11804585a17fe1f8776cf5744963d5e2d7"/>
+		<rom name="Golden Nugget 64 (USA).n64" />
+		<release name="Golden Nugget 64 (USA)" region="USA" />
+		<rom name="Golden Nugget 64 (USA).z64" size="8388608" crc="70594d3c" md5="231bac1afb3de138072c2d697783059b" sha1="1c0b0e11804585a17fe1f8776cf5744963d5e2d7" />
 	</game>
 	<game name="GoldenEye 007 (Europe)">
 		<description>GoldenEye 007 (Europe)</description>
-		<release name="GoldenEye 007 (Europe)" region="EUR"/>
-		<rom name="GoldenEye 007 (Europe).z64" size="12582912" crc="9ec14aeb" md5="cff69b70a8ad674a0efe5558765855c9" sha1="167c3c433dec1f1eb921736f7d53fac8cb45ee31" status="verified"/>
+		<rom name="GoldenEye 007 (Europe).n64" />
+		<release name="GoldenEye 007 (Europe)" region="EUR" />
+		<rom name="GoldenEye 007 (Europe).z64" size="12582912" crc="9ec14aeb" md5="cff69b70a8ad674a0efe5558765855c9" sha1="167c3c433dec1f1eb921736f7d53fac8cb45ee31" status="verified" />
 	</game>
 	<game name="GoldenEye 007 (Japan)" cloneof="GoldenEye 007 (Europe)">
 		<description>GoldenEye 007 (Japan)</description>
-		<release name="GoldenEye 007 (Japan)" region="JPN"/>
-		<rom name="GoldenEye 007 (Japan).z64" size="12582912" crc="a6be19dd" md5="1880da358f875c0740d4a6731e110109" sha1="2a5dade32f7fad6c73c659d2026994632c1b3174"/>
+		<rom name="GoldenEye 007 (Japan).n64" />
+		<release name="GoldenEye 007 (Japan)" region="JPN" />
+		<rom name="GoldenEye 007 (Japan).z64" size="12582912" crc="a6be19dd" md5="1880da358f875c0740d4a6731e110109" sha1="2a5dade32f7fad6c73c659d2026994632c1b3174" />
 	</game>
 	<game name="GoldenEye 007 (USA)" cloneof="GoldenEye 007 (Europe)">
 		<description>GoldenEye 007 (USA)</description>
-		<release name="GoldenEye 007 (USA)" region="USA"/>
-		<rom name="GoldenEye 007 (USA).z64" size="12582912" crc="b6330846" md5="70c525880240c1e838b8b1be35666c3b" sha1="abe01e4aeb033b6c0836819f549c791b26cfde83" status="verified"/>
+		<rom name="GoldenEye 007 (USA).n64" />
+		<release name="GoldenEye 007 (USA)" region="USA" />
+		<rom name="GoldenEye 007 (USA).z64" size="12582912" crc="b6330846" md5="70c525880240c1e838b8b1be35666c3b" sha1="abe01e4aeb033b6c0836819f549c791b26cfde83" status="verified" />
 	</game>
 	<game name="GT 64 - Championship Edition (Europe) (En,Fr,De)">
 		<description>GT 64 - Championship Edition (Europe) (En,Fr,De)</description>
-		<release name="GT 64 - Championship Edition (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="GT 64 - Championship Edition (Europe) (En,Fr,De).z64" size="12582912" crc="6dfb4747" md5="628aa3cd492559b705488f634797e045" sha1="a4d0d694f521cef69f64acaee3eb420a64f28e4d" status="verified"/>
+		<rom name="GT 64 - Championship Edition (Europe) (En,Fr,De).n64" />
+		<release name="GT 64 - Championship Edition (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="GT 64 - Championship Edition (Europe) (En,Fr,De).z64" size="12582912" crc="6dfb4747" md5="628aa3cd492559b705488f634797e045" sha1="a4d0d694f521cef69f64acaee3eb420a64f28e4d" status="verified" />
 	</game>
 	<game name="City-Tour GP - Zen-Nihon GT Senshuken (Japan)" cloneof="GT 64 - Championship Edition (Europe) (En,Fr,De)">
 		<description>City-Tour GP - Zen-Nihon GT Senshuken (Japan)</description>
-		<release name="City-Tour GP - Zen-Nihon GT Senshuken (Japan)" region="JPN"/>
-		<rom name="City-Tour GP - Zen-Nihon GT Senshuken (Japan).z64" size="16777216" crc="e272bdf6" md5="2a0bf5a9a136d57af01d199b16899634" sha1="2b543707f5bdba52a49d71755615d6cf38e23e76"/>
+		<rom name="City-Tour GP - Zen-Nihon GT Senshuken (Japan).n64" />
+		<release name="City-Tour GP - Zen-Nihon GT Senshuken (Japan)" region="JPN" />
+		<rom name="City-Tour GP - Zen-Nihon GT Senshuken (Japan).z64" size="16777216" crc="e272bdf6" md5="2a0bf5a9a136d57af01d199b16899634" sha1="2b543707f5bdba52a49d71755615d6cf38e23e76" />
 	</game>
 	<game name="GT 64 - Championship Edition (USA)" cloneof="GT 64 - Championship Edition (Europe) (En,Fr,De)">
 		<description>GT 64 - Championship Edition (USA)</description>
-		<release name="GT 64 - Championship Edition (USA)" region="USA"/>
-		<rom name="GT 64 - Championship Edition (USA).z64" size="12582912" crc="bc627da7" md5="fe81aa381719fada693d803bae7d5eb9" sha1="b941246af78748f4e081f496dac0a9e2056d3d8d"/>
+		<rom name="GT 64 - Championship Edition (USA).n64" />
+		<release name="GT 64 - Championship Edition (USA)" region="USA" />
+		<rom name="GT 64 - Championship Edition (USA).z64" size="12582912" crc="bc627da7" md5="fe81aa381719fada693d803bae7d5eb9" sha1="b941246af78748f4e081f496dac0a9e2056d3d8d" />
 	</game>
 	<game name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25)" cloneof="GT 64 - Championship Edition (Europe) (En,Fr,De)">
 		<description>GT 64 - Championship Edition (USA) (Beta) (1998-05-25)</description>
-		<rom name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25).z64" size="16777216" crc="191bf504" md5="4690cab33d0bc10b62d62cecdcaa50a1" sha1="6b58306825ef85a3a128dd5bc0bc0c21f517b3a2"/>
+		<rom name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25).n64" />
+		<rom name="GT 64 - Championship Edition (USA) (Beta) (1998-05-25).z64" size="16777216" crc="191bf504" md5="4690cab33d0bc10b62d62cecdcaa50a1" sha1="6b58306825ef85a3a128dd5bc0bc0c21f517b3a2" />
 	</game>
 	<game name="Hamster Monogatari 64 (Japan)">
 		<description>Hamster Monogatari 64 (Japan)</description>
-		<release name="Hamster Monogatari 64 (Japan)" region="JPN"/>
-		<rom name="Hamster Monogatari 64 (Japan).z64" size="12582912" crc="c1d98b78" md5="3d4c7b11076bafa4620bcc154c0eeef3" sha1="436627174830fb9941bd4f25efa6fa1024498a97"/>
+		<rom name="Hamster Monogatari 64 (Japan).n64" />
+		<release name="Hamster Monogatari 64 (Japan)" region="JPN" />
+		<rom name="Hamster Monogatari 64 (Japan).z64" size="12582912" crc="c1d98b78" md5="3d4c7b11076bafa4620bcc154c0eeef3" sha1="436627174830fb9941bd4f25efa6fa1024498a97" />
 	</game>
 	<game name="Harukanaru Augusta - Masters '98 (Japan)">
 		<description>Harukanaru Augusta - Masters '98 (Japan)</description>
-		<release name="Harukanaru Augusta - Masters '98 (Japan)" region="JPN"/>
-		<rom name="Harukanaru Augusta - Masters '98 (Japan).z64" size="16777216" crc="51228f0c" md5="a02a4fb4b93e9847348440652cef8d4d" sha1="08af498bca98c79e3fa18c9c860091d5eb952e6e"/>
+		<rom name="Harukanaru Augusta - Masters '98 (Japan).n64" />
+		<release name="Harukanaru Augusta - Masters '98 (Japan)" region="JPN" />
+		<rom name="Harukanaru Augusta - Masters '98 (Japan).z64" size="16777216" crc="51228f0c" md5="a02a4fb4b93e9847348440652cef8d4d" sha1="08af498bca98c79e3fa18c9c860091d5eb952e6e" />
 	</game>
 	<game name="Harvest Moon 64 (USA)">
 		<description>Harvest Moon 64 (USA)</description>
-		<release name="Harvest Moon 64 (USA)" region="USA"/>
-		<rom name="Harvest Moon 64 (USA).z64" size="16777216" crc="decdc0ad" md5="6da848a70d83ece130d274124760928e" sha1="90631460f1876a14849df0541d534012b410a34c"/>
+		<rom name="Harvest Moon 64 (USA).n64" />
+		<release name="Harvest Moon 64 (USA)" region="USA" />
+		<rom name="Harvest Moon 64 (USA).z64" size="16777216" crc="decdc0ad" md5="6da848a70d83ece130d274124760928e" sha1="90631460f1876a14849df0541d534012b410a34c" />
 	</game>
 	<game name="Bokujou Monogatari 2 (Japan)" cloneof="Harvest Moon 64 (USA)">
 		<description>Bokujou Monogatari 2 (Japan)</description>
-		<rom name="Bokujou Monogatari 2 (Japan).z64" size="16777216" crc="f97237c7" md5="1cf31e7f6e0deb2c18c39ddd4eed9e51" sha1="e41d15c394b5fefd4016add3883a794c48e7e232"/>
+		<rom name="Bokujou Monogatari 2 (Japan).n64" />
+		<rom name="Bokujou Monogatari 2 (Japan).z64" size="16777216" crc="f97237c7" md5="1cf31e7f6e0deb2c18c39ddd4eed9e51" sha1="e41d15c394b5fefd4016add3883a794c48e7e232" />
 	</game>
 	<game name="Bokujou Monogatari 2 (Japan) (Rev 1)" cloneof="Harvest Moon 64 (USA)">
 		<description>Bokujou Monogatari 2 (Japan) (Rev 1)</description>
-		<rom name="Bokujou Monogatari 2 (Japan) (Rev 1).z64" size="16777216" crc="20fd2939" md5="e627b898a7692c08b595a8d2178e34a0" sha1="211313fe7ca7a4e0bf376afcf7c83c51e5c7f1a0"/>
+		<rom name="Bokujou Monogatari 2 (Japan) (Rev 1).n64" />
+		<rom name="Bokujou Monogatari 2 (Japan) (Rev 1).z64" size="16777216" crc="20fd2939" md5="e627b898a7692c08b595a8d2178e34a0" sha1="211313fe7ca7a4e0bf376afcf7c83c51e5c7f1a0" />
 	</game>
 	<game name="Bokujou Monogatari 2 (Japan) (Rev 2)" cloneof="Harvest Moon 64 (USA)">
 		<description>Bokujou Monogatari 2 (Japan) (Rev 2)</description>
-		<release name="Bokujou Monogatari 2 (Japan) (Rev 2)" region="JPN"/>
-		<rom name="Bokujou Monogatari 2 (Japan) (Rev 2).z64" size="16777216" crc="9181c1b7" md5="24e3ee6a54278db65c463804f2bb6223" sha1="74c5fd9647b702e889a5f2094d4bc4001bd6f68b"/>
+		<rom name="Bokujou Monogatari 2 (Japan) (Rev 2).n64" />
+		<release name="Bokujou Monogatari 2 (Japan) (Rev 2)" region="JPN" />
+		<rom name="Bokujou Monogatari 2 (Japan) (Rev 2).z64" size="16777216" crc="9181c1b7" md5="24e3ee6a54278db65c463804f2bb6223" sha1="74c5fd9647b702e889a5f2094d4bc4001bd6f68b" />
 	</game>
 	<game name="Heiwa Pachinko World 64 (Japan)">
 		<description>Heiwa Pachinko World 64 (Japan)</description>
-		<release name="Heiwa Pachinko World 64 (Japan)" region="JPN"/>
-		<rom name="Heiwa Pachinko World 64 (Japan).z64" size="8388608" crc="99a427fa" md5="5e8539e037eea88c5a2746f60e431c8d" sha1="d48a484febaac3bd146130434921861890503b29"/>
+		<rom name="Heiwa Pachinko World 64 (Japan).n64" />
+		<release name="Heiwa Pachinko World 64 (Japan)" region="JPN" />
+		<rom name="Heiwa Pachinko World 64 (Japan).z64" size="8388608" crc="99a427fa" md5="5e8539e037eea88c5a2746f60e431c8d" sha1="d48a484febaac3bd146130434921861890503b29" />
 	</game>
 	<game name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="b1954b08" md5="1546877fd85c00a83515005727e5fda5" sha1="d2e26f4aecf488f87e1ab36395280385b060d229"/>
+		<rom name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl).z64" size="16777216" crc="b1954b08" md5="1546877fd85c00a83515005727e5fda5" sha1="d2e26f4aecf488f87e1ab36395280385b060d229" />
 	</game>
 	<game name="Hercules - The Legendary Journeys (USA)" cloneof="Hercules - The Legendary Journeys (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Hercules - The Legendary Journeys (USA)</description>
-		<release name="Hercules - The Legendary Journeys (USA)" region="USA"/>
-		<rom name="Hercules - The Legendary Journeys (USA).z64" size="16777216" crc="4948892b" md5="6bbd8c42f6ef8f5b9541d6f4db657dd7" sha1="5c3c4345be505763fc51a9e3713f5787e4044646"/>
+		<rom name="Hercules - The Legendary Journeys (USA).n64" />
+		<release name="Hercules - The Legendary Journeys (USA)" region="USA" />
+		<rom name="Hercules - The Legendary Journeys (USA).z64" size="16777216" crc="4948892b" md5="6bbd8c42f6ef8f5b9541d6f4db657dd7" sha1="5c3c4345be505763fc51a9e3713f5787e4044646" />
 	</game>
 	<game name="Hexen (Europe)">
 		<description>Hexen (Europe)</description>
-		<release name="Hexen (Europe)" region="EUR"/>
-		<rom name="Hexen (Europe).z64" size="8388608" crc="5369efb4" md5="2080262a251d270f9ce819887f2104a7" sha1="1a929ae2a7930cf4b762fa28a9d20338c5fed847"/>
+		<rom name="Hexen (Europe).n64" />
+		<release name="Hexen (Europe)" region="EUR" />
+		<rom name="Hexen (Europe).z64" size="8388608" crc="5369efb4" md5="2080262a251d270f9ce819887f2104a7" sha1="1a929ae2a7930cf4b762fa28a9d20338c5fed847" />
 	</game>
 	<game name="Hexen (France)" cloneof="Hexen (Europe)">
 		<description>Hexen (France)</description>
-		<release name="Hexen (France)" region="FRA"/>
-		<rom name="Hexen (France).z64" size="8388608" crc="e373fa31" md5="a5921c00111200257284ce0aba0904ca" sha1="476d3b340ba2a1b1acc1d0cc97ac6e25a5136ca2"/>
+		<rom name="Hexen (France).n64" />
+		<release name="Hexen (France)" region="FRA" />
+		<rom name="Hexen (France).z64" size="8388608" crc="e373fa31" md5="a5921c00111200257284ce0aba0904ca" sha1="476d3b340ba2a1b1acc1d0cc97ac6e25a5136ca2" />
 	</game>
 	<game name="Hexen (Germany)" cloneof="Hexen (Europe)">
 		<description>Hexen (Germany)</description>
-		<release name="Hexen (Germany)" region="GER"/>
-		<rom name="Hexen (Germany).z64" size="8388608" crc="e4821c4b" md5="08cbb141dec604e4dad2787f237d57a2" sha1="8d10ca2860d72c3c1adb409485936c4ba3f18396"/>
+		<rom name="Hexen (Germany).n64" />
+		<release name="Hexen (Germany)" region="GER" />
+		<rom name="Hexen (Germany).z64" size="8388608" crc="e4821c4b" md5="08cbb141dec604e4dad2787f237d57a2" sha1="8d10ca2860d72c3c1adb409485936c4ba3f18396" />
 	</game>
 	<game name="Hexen (Japan)" cloneof="Hexen (Europe)">
 		<description>Hexen (Japan)</description>
-		<release name="Hexen (Japan)" region="JPN"/>
-		<rom name="Hexen (Japan).z64" size="8388608" crc="571da09a" md5="672152cf4dcb5d0a19662c11eff71452" sha1="3e3e2b012bbb873338b0573f6e11426e38f8b5cd"/>
+		<rom name="Hexen (Japan).n64" />
+		<release name="Hexen (Japan)" region="JPN" />
+		<rom name="Hexen (Japan).z64" size="8388608" crc="571da09a" md5="672152cf4dcb5d0a19662c11eff71452" sha1="3e3e2b012bbb873338b0573f6e11426e38f8b5cd" />
 	</game>
 	<game name="Hexen (USA)" cloneof="Hexen (Europe)">
 		<description>Hexen (USA)</description>
-		<release name="Hexen (USA)" region="USA"/>
-		<rom name="Hexen (USA).z64" size="8388608" crc="1d35e110" md5="eb98f1b8c6898af7417f6882946da9b3" sha1="a602839132f6cca71f175fb72039897705ba4661"/>
+		<rom name="Hexen (USA).n64" />
+		<release name="Hexen (USA)" region="USA" />
+		<rom name="Hexen (USA).z64" size="8388608" crc="1d35e110" md5="eb98f1b8c6898af7417f6882946da9b3" sha1="a602839132f6cca71f175fb72039897705ba4661" />
 	</game>
 	<game name="Hey You, Pikachu! (USA)">
 		<description>Hey You, Pikachu! (USA)</description>
-		<release name="Hey You, Pikachu! (USA)" region="USA"/>
-		<rom name="Hey You, Pikachu! (USA).z64" size="16777216" crc="b18b2734" md5="1280c78f286fc1c437a4905ee42c47f1" sha1="da1a1e47a86720f9d54fb2d2d247480041bda824"/>
+		<rom name="Hey You, Pikachu! (USA).n64" />
+		<release name="Hey You, Pikachu! (USA)" region="USA" />
+		<rom name="Hey You, Pikachu! (USA).z64" size="16777216" crc="b18b2734" md5="1280c78f286fc1c437a4905ee42c47f1" sha1="da1a1e47a86720f9d54fb2d2d247480041bda824" />
 	</game>
 	<game name="Pikachuu Genki de Chuu (Japan)" cloneof="Hey You, Pikachu! (USA)">
 		<description>Pikachuu Genki de Chuu (Japan)</description>
-		<release name="Pikachuu Genki de Chuu (Japan)" region="JPN"/>
-		<rom name="Pikachuu Genki de Chuu (Japan).z64" size="16777216" crc="3f6245ae" md5="e0bcb2758edf0ac6ab7db36d98e1e57c" sha1="a28c689e58f58b4a2a672d3d010436661d247476" status="verified"/>
+		<rom name="Pikachuu Genki de Chuu (Japan).n64" />
+		<release name="Pikachuu Genki de Chuu (Japan)" region="JPN" />
+		<rom name="Pikachuu Genki de Chuu (Japan).z64" size="16777216" crc="3f6245ae" md5="e0bcb2758edf0ac6ab7db36d98e1e57c" sha1="a28c689e58f58b4a2a672d3d010436661d247476" status="verified" />
 	</game>
 	<game name="Holy Magic Century (Europe)">
 		<description>Holy Magic Century (Europe)</description>
-		<release name="Holy Magic Century (Europe)" region="EUR"/>
-		<rom name="Holy Magic Century (Europe).z64" size="16777216" crc="84ff9890" md5="80cc112f62e9a8581a1bb6a1d1e1488b" sha1="139607eba03326fbe9d899663c56e64042d51e84"/>
+		<rom name="Holy Magic Century (Europe).n64" />
+		<release name="Holy Magic Century (Europe)" region="EUR" />
+		<rom name="Holy Magic Century (Europe).z64" size="16777216" crc="84ff9890" md5="80cc112f62e9a8581a1bb6a1d1e1488b" sha1="139607eba03326fbe9d899663c56e64042d51e84" />
 	</game>
 	<game name="Eltale Monsters (Japan)" cloneof="Holy Magic Century (Europe)">
 		<description>Eltale Monsters (Japan)</description>
-		<release name="Eltale Monsters (Japan)" region="JPN"/>
-		<rom name="Eltale Monsters (Japan).z64" size="16777216" crc="24d937bf" md5="9b456acb96291fc8b55232a08ae03346" sha1="4161b5c100ec82b0241b20ca8f81366e23564ccb"/>
+		<rom name="Eltale Monsters (Japan).n64" />
+		<release name="Eltale Monsters (Japan)" region="JPN" />
+		<rom name="Eltale Monsters (Japan).z64" size="16777216" crc="24d937bf" md5="9b456acb96291fc8b55232a08ae03346" sha1="4161b5c100ec82b0241b20ca8f81366e23564ccb" />
 	</game>
 	<game name="Holy Magic Century (France)" cloneof="Holy Magic Century (Europe)">
 		<description>Holy Magic Century (France)</description>
-		<release name="Holy Magic Century (France)" region="FRA"/>
-		<rom name="Holy Magic Century (France).z64" size="16777216" crc="284170ed" md5="988f5abd96259196343659e913666820" sha1="610bf1f4a5cbeb2d6dc3ae1dafc5b3b818f69c26"/>
+		<rom name="Holy Magic Century (France).n64" />
+		<release name="Holy Magic Century (France)" region="FRA" />
+		<rom name="Holy Magic Century (France).z64" size="16777216" crc="284170ed" md5="988f5abd96259196343659e913666820" sha1="610bf1f4a5cbeb2d6dc3ae1dafc5b3b818f69c26" />
 	</game>
 	<game name="Holy Magic Century (Germany)" cloneof="Holy Magic Century (Europe)">
 		<description>Holy Magic Century (Germany)</description>
-		<release name="Holy Magic Century (Germany)" region="GER"/>
-		<rom name="Holy Magic Century (Germany).z64" size="16777216" crc="d1934cf6" md5="ab676c3e9d26a77450ddb4aacd1a3861" sha1="ac5457fff3fcc8d6acffb60fa9a99846d36facf8"/>
+		<rom name="Holy Magic Century (Germany).n64" />
+		<release name="Holy Magic Century (Germany)" region="GER" />
+		<rom name="Holy Magic Century (Germany).z64" size="16777216" crc="d1934cf6" md5="ab676c3e9d26a77450ddb4aacd1a3861" sha1="ac5457fff3fcc8d6acffb60fa9a99846d36facf8" />
 	</game>
 	<game name="Quest 64 (USA)" cloneof="Holy Magic Century (Europe)">
 		<description>Quest 64 (USA)</description>
-		<release name="Quest 64 (USA)" region="USA"/>
-		<rom name="Quest 64 (USA).z64" size="16777216" crc="d75b45c6" md5="ea552e33973468233a0712c251abdb6b" sha1="91b96e938c6d91699057fad91d726ee5a23ce33a"/>
+		<rom name="Quest 64 (USA).n64" />
+		<release name="Quest 64 (USA)" region="USA" />
+		<rom name="Quest 64 (USA).z64" size="16777216" crc="d75b45c6" md5="ea552e33973468233a0712c251abdb6b" sha1="91b96e938c6d91699057fad91d726ee5a23ce33a" />
 	</game>
 	<game name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De)">
 		<description>Hot Wheels - Turbo Racing (Europe) (En,Fr,De)</description>
-		<release name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De).z64" size="16777216" crc="850633a7" md5="ef34da35ef8a0734843cb182c19feb26" sha1="fbcfd6d466931e5cb71fe880c52ea692c3f84d75"/>
+		<rom name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De).n64" />
+		<release name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Hot Wheels - Turbo Racing (Europe) (En,Fr,De).z64" size="16777216" crc="850633a7" md5="ef34da35ef8a0734843cb182c19feb26" sha1="fbcfd6d466931e5cb71fe880c52ea692c3f84d75" />
 	</game>
 	<game name="Hot Wheels - Turbo Racing (USA)" cloneof="Hot Wheels - Turbo Racing (Europe) (En,Fr,De)">
 		<description>Hot Wheels - Turbo Racing (USA)</description>
-		<release name="Hot Wheels - Turbo Racing (USA)" region="USA"/>
-		<rom name="Hot Wheels - Turbo Racing (USA).z64" size="12582912" crc="a5c92148" md5="4311a1aef1898678331f7e3486055307" sha1="94913a07e49005ffd43dfdfa16ff5862bdb93748"/>
+		<rom name="Hot Wheels - Turbo Racing (USA).n64" />
+		<release name="Hot Wheels - Turbo Racing (USA)" region="USA" />
+		<rom name="Hot Wheels - Turbo Racing (USA).z64" size="12582912" crc="a5c92148" md5="4311a1aef1898678331f7e3486055307" sha1="94913a07e49005ffd43dfdfa16ff5862bdb93748" />
 	</game>
 	<game name="Hybrid Heaven (Europe) (En,Fr,De)">
 		<description>Hybrid Heaven (Europe) (En,Fr,De)</description>
-		<release name="Hybrid Heaven (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Hybrid Heaven (Europe) (En,Fr,De).z64" size="16777216" crc="e76627ff" md5="da861c4d9202f661575466450a27c412" sha1="d2210d492bad952b055a4269e45fd89631c32d25" status="verified"/>
+		<rom name="Hybrid Heaven (Europe) (En,Fr,De).n64" />
+		<release name="Hybrid Heaven (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Hybrid Heaven (Europe) (En,Fr,De).z64" size="16777216" crc="e76627ff" md5="da861c4d9202f661575466450a27c412" sha1="d2210d492bad952b055a4269e45fd89631c32d25" status="verified" />
 	</game>
 	<game name="Hybrid Heaven (Japan)" cloneof="Hybrid Heaven (Europe) (En,Fr,De)">
 		<description>Hybrid Heaven (Japan)</description>
-		<release name="Hybrid Heaven (Japan)" region="JPN"/>
-		<rom name="Hybrid Heaven (Japan).z64" size="16777216" crc="e769de96" md5="9946eff915fc947a226407ac1f7b35c4" sha1="09f4d3200b0bd4b984a80248af07de3c40b5cc26"/>
+		<rom name="Hybrid Heaven (Japan).n64" />
+		<release name="Hybrid Heaven (Japan)" region="JPN" />
+		<rom name="Hybrid Heaven (Japan).z64" size="16777216" crc="e769de96" md5="9946eff915fc947a226407ac1f7b35c4" sha1="09f4d3200b0bd4b984a80248af07de3c40b5cc26" />
 	</game>
 	<game name="Hybrid Heaven (USA)" cloneof="Hybrid Heaven (Europe) (En,Fr,De)">
 		<description>Hybrid Heaven (USA)</description>
-		<release name="Hybrid Heaven (USA)" region="USA"/>
-		<rom name="Hybrid Heaven (USA).z64" size="16777216" crc="15b57ef8" md5="c47e95bb32ab132c41d67bd243f9e02a" sha1="16dbc21620b52deab5c5abf8a309ac60adfbee85"/>
+		<rom name="Hybrid Heaven (USA).n64" />
+		<release name="Hybrid Heaven (USA)" region="USA" />
+		<rom name="Hybrid Heaven (USA).z64" size="16777216" crc="15b57ef8" md5="c47e95bb32ab132c41d67bd243f9e02a" sha1="16dbc21620b52deab5c5abf8a309ac60adfbee85" />
 	</game>
 	<game name="Hydro Thunder (Europe)">
 		<description>Hydro Thunder (Europe)</description>
-		<release name="Hydro Thunder (Europe)" region="EUR"/>
-		<rom name="Hydro Thunder (Europe).z64" size="33554432" crc="863ab8f3" md5="434bb8de49011573ac38e893224c5623" sha1="0661b1b0e47bc02d9b0d87d1688fd466793c074b"/>
+		<rom name="Hydro Thunder (Europe).n64" />
+		<release name="Hydro Thunder (Europe)" region="EUR" />
+		<rom name="Hydro Thunder (Europe).z64" size="33554432" crc="863ab8f3" md5="434bb8de49011573ac38e893224c5623" sha1="0661b1b0e47bc02d9b0d87d1688fd466793c074b" />
 	</game>
 	<game name="Hydro Thunder (France)" cloneof="Hydro Thunder (Europe)">
 		<description>Hydro Thunder (France)</description>
-		<release name="Hydro Thunder (France)" region="FRA"/>
-		<rom name="Hydro Thunder (France).z64" size="33554432" crc="010f6242" md5="4b4c85d9dd2d460adafabae8db48b4fa" sha1="03fa91aec0819654f1ad0d12bb81ce3f5d7d08ae"/>
+		<rom name="Hydro Thunder (France).n64" />
+		<release name="Hydro Thunder (France)" region="FRA" />
+		<rom name="Hydro Thunder (France).z64" size="33554432" crc="010f6242" md5="4b4c85d9dd2d460adafabae8db48b4fa" sha1="03fa91aec0819654f1ad0d12bb81ce3f5d7d08ae" />
 	</game>
 	<game name="Hydro Thunder (USA)" cloneof="Hydro Thunder (Europe)">
 		<description>Hydro Thunder (USA)</description>
-		<release name="Hydro Thunder (USA)" region="USA"/>
-		<rom name="Hydro Thunder (USA).z64" size="33554432" crc="e744456f" md5="54f43e6b68782e98caabea5e7976b2be" sha1="f5d5054f97da0d68857f9824130147ec38ee7a76"/>
+		<rom name="Hydro Thunder (USA).n64" />
+		<release name="Hydro Thunder (USA)" region="USA" />
+		<rom name="Hydro Thunder (USA).z64" size="33554432" crc="e744456f" md5="54f43e6b68782e98caabea5e7976b2be" sha1="f5d5054f97da0d68857f9824130147ec38ee7a76" />
 	</game>
 	<game name="Ide Yosuke no Mahjong Juku (Japan)">
 		<description>Ide Yosuke no Mahjong Juku (Japan)</description>
-		<release name="Ide Yosuke no Mahjong Juku (Japan)" region="JPN"/>
-		<rom name="Ide Yosuke no Mahjong Juku (Japan).z64" size="12582912" crc="dbd96deb" md5="92a6ffa1c8d537c7a97c5c613cae05c6" sha1="26e3210f45c78d72eae61cb066d08d6e00c0ea87"/>
+		<rom name="Ide Yosuke no Mahjong Juku (Japan).n64" />
+		<release name="Ide Yosuke no Mahjong Juku (Japan)" region="JPN" />
+		<rom name="Ide Yosuke no Mahjong Juku (Japan).z64" size="12582912" crc="dbd96deb" md5="92a6ffa1c8d537c7a97c5c613cae05c6" sha1="26e3210f45c78d72eae61cb066d08d6e00c0ea87" />
 	</game>
 	<game name="Iggy's Reckin' Balls (Europe)">
 		<description>Iggy's Reckin' Balls (Europe)</description>
-		<release name="Iggy's Reckin' Balls (Europe)" region="EUR"/>
-		<rom name="Iggy's Reckin' Balls (Europe).z64" size="4194304" crc="9bf26065" md5="25b297143e9e5ccbb4b80a7fb6af399b" sha1="da3c5ba5849e104383ea4c3df1fbdb8253f184c9"/>
+		<rom name="Iggy's Reckin' Balls (Europe).n64" />
+		<release name="Iggy's Reckin' Balls (Europe)" region="EUR" />
+		<rom name="Iggy's Reckin' Balls (Europe).z64" size="4194304" crc="9bf26065" md5="25b297143e9e5ccbb4b80a7fb6af399b" sha1="da3c5ba5849e104383ea4c3df1fbdb8253f184c9" />
 	</game>
 	<game name="Iggy-kun no Bura Bura Poyon (Japan)" cloneof="Iggy's Reckin' Balls (Europe)">
 		<description>Iggy-kun no Bura Bura Poyon (Japan)</description>
-		<release name="Iggy-kun no Bura Bura Poyon (Japan)" region="JPN"/>
-		<rom name="Iggy-kun no Bura Bura Poyon (Japan).z64" size="4194304" crc="26cc1266" md5="c70b0b680807f2b8c2c3d5dc495fa8c2" sha1="ebb8c0c99d000a366d2dba0d8d184ec18aa82d43"/>
+		<rom name="Iggy-kun no Bura Bura Poyon (Japan).n64" />
+		<release name="Iggy-kun no Bura Bura Poyon (Japan)" region="JPN" />
+		<rom name="Iggy-kun no Bura Bura Poyon (Japan).z64" size="4194304" crc="26cc1266" md5="c70b0b680807f2b8c2c3d5dc495fa8c2" sha1="ebb8c0c99d000a366d2dba0d8d184ec18aa82d43" />
 	</game>
 	<game name="Iggy's Reckin' Balls (USA)" cloneof="Iggy's Reckin' Balls (Europe)">
 		<description>Iggy's Reckin' Balls (USA)</description>
-		<release name="Iggy's Reckin' Balls (USA)" region="USA"/>
-		<rom name="Iggy's Reckin' Balls (USA).z64" size="4194304" crc="6a6fbd5d" md5="464211abb602ee1005974d2d835a3bcf" sha1="1a32230e0ef147b3c8c07ece5aec96458286b4af"/>
+		<rom name="Iggy's Reckin' Balls (USA).n64" />
+		<release name="Iggy's Reckin' Balls (USA)" region="USA" />
+		<rom name="Iggy's Reckin' Balls (USA).z64" size="4194304" crc="6a6fbd5d" md5="464211abb602ee1005974d2d835a3bcf" sha1="1a32230e0ef147b3c8c07ece5aec96458286b4af" />
 	</game>
 	<game name="In-Fisherman - Bass Hunter 64 (Europe)">
 		<description>In-Fisherman - Bass Hunter 64 (Europe)</description>
-		<release name="In-Fisherman - Bass Hunter 64 (Europe)" region="EUR"/>
-		<rom name="In-Fisherman - Bass Hunter 64 (Europe).z64" size="8388608" crc="00da3704" md5="bf3e84cdd01cac05987fd8da5191534b" sha1="d36374be227e972b1c0b6f2cfbb8fdd724aa1074"/>
+		<rom name="In-Fisherman - Bass Hunter 64 (Europe).n64" />
+		<release name="In-Fisherman - Bass Hunter 64 (Europe)" region="EUR" />
+		<rom name="In-Fisherman - Bass Hunter 64 (Europe).z64" size="8388608" crc="00da3704" md5="bf3e84cdd01cac05987fd8da5191534b" sha1="d36374be227e972b1c0b6f2cfbb8fdd724aa1074" />
 	</game>
 	<game name="In-Fisherman - Bass Hunter 64 (USA)" cloneof="In-Fisherman - Bass Hunter 64 (Europe)">
 		<description>In-Fisherman - Bass Hunter 64 (USA)</description>
-		<release name="In-Fisherman - Bass Hunter 64 (USA)" region="USA"/>
-		<rom name="In-Fisherman - Bass Hunter 64 (USA).z64" size="8388608" crc="d8eb5e6e" md5="c605f40bf669e00a5e51baf0d00621ea" sha1="4aa373e23876c89a549c98036f456b564d779217"/>
+		<rom name="In-Fisherman - Bass Hunter 64 (USA).n64" />
+		<release name="In-Fisherman - Bass Hunter 64 (USA)" region="USA" />
+		<rom name="In-Fisherman - Bass Hunter 64 (USA).z64" size="8388608" crc="d8eb5e6e" md5="c605f40bf669e00a5e51baf0d00621ea" sha1="4aa373e23876c89a549c98036f456b564d779217" />
 	</game>
 	<game name="Indiana Jones and the Infernal Machine (USA)">
 		<description>Indiana Jones and the Infernal Machine (USA)</description>
-		<release name="Indiana Jones and the Infernal Machine (USA)" region="USA"/>
-		<rom name="Indiana Jones and the Infernal Machine (USA).z64" size="33554432" crc="4978eb57" md5="70de1eab508596b6bbefd168b5d07194" sha1="93300d63412d6c7432109b5ad2e4a8b9348e9538"/>
+		<rom name="Indiana Jones and the Infernal Machine (USA).n64" />
+		<release name="Indiana Jones and the Infernal Machine (USA)" region="USA" />
+		<rom name="Indiana Jones and the Infernal Machine (USA).z64" size="33554432" crc="4978eb57" md5="70de1eab508596b6bbefd168b5d07194" sha1="93300d63412d6c7432109b5ad2e4a8b9348e9538" />
 	</game>
 	<game name="Indiana Jones and the Infernal Machine (Australia) (Proto)" cloneof="Indiana Jones and the Infernal Machine (USA)">
 		<description>Indiana Jones and the Infernal Machine (Australia) (Proto)</description>
-		<rom name="Indiana Jones and the Infernal Machine (Australia) (Proto).z64" size="33554432" crc="337219be" md5="63d7ab29ba3dfc5d5b12c1d9c5832355" sha1="8465af5538c4b636834a8b2cd5a7decadf0e8841"/>
+		<rom name="Indiana Jones and the Infernal Machine (Australia) (Proto).n64" />
+		<rom name="Indiana Jones and the Infernal Machine (Australia) (Proto).z64" size="33554432" crc="337219be" md5="63d7ab29ba3dfc5d5b12c1d9c5832355" sha1="8465af5538c4b636834a8b2cd5a7decadf0e8841" />
 	</game>
 	<game name="Indy Racing 2000 (USA)">
 		<description>Indy Racing 2000 (USA)</description>
-		<release name="Indy Racing 2000 (USA)" region="USA"/>
-		<rom name="Indy Racing 2000 (USA).z64" size="16777216" crc="a5163f29" md5="a7781d441af55c4ff8afc68ab3a59313" sha1="015bf0e0bc700a80a2606d3578e4a9b7645e99ec"/>
+		<rom name="Indy Racing 2000 (USA).n64" />
+		<release name="Indy Racing 2000 (USA)" region="USA" />
+		<rom name="Indy Racing 2000 (USA).z64" size="16777216" crc="a5163f29" md5="a7781d441af55c4ff8afc68ab3a59313" sha1="015bf0e0bc700a80a2606d3578e4a9b7645e99ec" />
 	</game>
 	<game name="International Superstar Soccer '98 (Europe)">
 		<description>International Superstar Soccer '98 (Europe)</description>
-		<release name="International Superstar Soccer '98 (Europe)" region="EUR"/>
-		<rom name="International Superstar Soccer '98 (Europe).z64" size="12582912" crc="bf23945d" md5="34489365b550f32c97337d86d52d8c84" sha1="ccaffee3a793a0c3a5e7c48fbc4a4759ef29153f" status="verified"/>
+		<rom name="International Superstar Soccer '98 (Europe).n64" />
+		<release name="International Superstar Soccer '98 (Europe)" region="EUR" />
+		<rom name="International Superstar Soccer '98 (Europe).z64" size="12582912" crc="bf23945d" md5="34489365b550f32c97337d86d52d8c84" sha1="ccaffee3a793a0c3a5e7c48fbc4a4759ef29153f" status="verified" />
 	</game>
 	<game name="International Superstar Soccer '98 (USA)" cloneof="International Superstar Soccer '98 (Europe)">
 		<description>International Superstar Soccer '98 (USA)</description>
-		<release name="International Superstar Soccer '98 (USA)" region="USA"/>
-		<rom name="International Superstar Soccer '98 (USA).z64" size="12582912" crc="b85fa721" md5="7dcc05b98e2fa690b478808ebbad5d1a" sha1="053735184d414e0a1bbd888f3c931252ea1b92fd"/>
+		<rom name="International Superstar Soccer '98 (USA).n64" />
+		<release name="International Superstar Soccer '98 (USA)" region="USA" />
+		<rom name="International Superstar Soccer '98 (USA).z64" size="12582912" crc="b85fa721" md5="7dcc05b98e2fa690b478808ebbad5d1a" sha1="053735184d414e0a1bbd888f3c931252ea1b92fd" />
 	</game>
 	<game name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02)" cloneof="International Superstar Soccer '98 (Europe)">
 		<description>International Superstar Soccer '98 (Europe) (Beta) (1998-03-02)</description>
-		<rom name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02).z64" size="16777216" crc="a63dcb66" md5="21ea0b80849b084ac3138fde780e5dbb" sha1="2fb15e4517ebe84f4a354e555716105fe69dd993"/>
+		<rom name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02).n64" />
+		<rom name="International Superstar Soccer '98 (Europe) (Beta) (1998-03-02).z64" size="16777216" crc="a63dcb66" md5="21ea0b80849b084ac3138fde780e5dbb" sha1="2fb15e4517ebe84f4a354e555716105fe69dd993" />
 	</game>
 	<game name="Jikkyou World Soccer - World Cup France '98 (Japan)" cloneof="International Superstar Soccer '98 (Europe)">
 		<description>Jikkyou World Soccer - World Cup France '98 (Japan)</description>
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan).z64" size="16777216" crc="5c721850" md5="a05e7db2409deecca36e48e9d931cacb" sha1="bb1c7a8634ba6078843532264a8676f80d5b79fc"/>
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan).n64" />
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan).z64" size="16777216" crc="5c721850" md5="a05e7db2409deecca36e48e9d931cacb" sha1="bb1c7a8634ba6078843532264a8676f80d5b79fc" />
 	</game>
 	<game name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1)" cloneof="International Superstar Soccer '98 (Europe)">
 		<description>Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1).z64" size="16777216" crc="68dbcc04" md5="538b54c2aaea73faa3a021d42a3225be" sha1="e9ed8a0ed5b7b20b80f0e140cc4b7261a89143bb"/>
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 1).z64" size="16777216" crc="68dbcc04" md5="538b54c2aaea73faa3a021d42a3225be" sha1="e9ed8a0ed5b7b20b80f0e140cc4b7261a89143bb" />
 	</game>
 	<game name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)" cloneof="International Superstar Soccer '98 (Europe)">
 		<description>Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)</description>
-		<release name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)" region="JPN"/>
-		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2).z64" size="16777216" crc="f63f9a5e" md5="2e5fd9303138e8f558bf67bb9e799960" sha1="8ea26072dd7da07c567ebca7c25071739ec563fb"/>
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2).n64" />
+		<release name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2)" region="JPN" />
+		<rom name="Jikkyou World Soccer - World Cup France '98 (Japan) (Rev 2).z64" size="16777216" crc="f63f9a5e" md5="2e5fd9303138e8f558bf67bb9e799960" sha1="8ea26072dd7da07c567ebca7c25071739ec563fb" />
 	</game>
 	<game name="International Superstar Soccer 2000 (Europe) (En,De)">
 		<description>International Superstar Soccer 2000 (Europe) (En,De)</description>
-		<release name="International Superstar Soccer 2000 (Europe) (En,De)" region="EUR"/>
-		<rom name="International Superstar Soccer 2000 (Europe) (En,De).z64" size="16777216" crc="69572558" md5="9f101b6f6bef4f267deb5c6c37a24b97" sha1="e7078e5f1e899382b1cc145df43ee8cfaa924297" status="verified"/>
+		<rom name="International Superstar Soccer 2000 (Europe) (En,De).n64" />
+		<release name="International Superstar Soccer 2000 (Europe) (En,De)" region="EUR" />
+		<rom name="International Superstar Soccer 2000 (Europe) (En,De).z64" size="16777216" crc="69572558" md5="9f101b6f6bef4f267deb5c6c37a24b97" sha1="e7078e5f1e899382b1cc145df43ee8cfaa924297" status="verified" />
 	</game>
 	<game name="International Superstar Soccer 2000 (Europe) (Fr,It)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
 		<description>International Superstar Soccer 2000 (Europe) (Fr,It)</description>
-		<release name="International Superstar Soccer 2000 (Europe) (Fr,It)" region="FRA"/>
-		<release name="International Superstar Soccer 2000 (Europe) (Fr,It)" region="ITA"/>
-		<rom name="International Superstar Soccer 2000 (Europe) (Fr,It).z64" size="16777216" crc="8a16a6a9" md5="cc2be97a16744860fae8a94611479c4c" sha1="b0505e13ba0f029ea735378c50b224fd618be302" status="verified"/>
+		<rom name="International Superstar Soccer 2000 (Europe) (Fr,It).n64" />
+		<release name="International Superstar Soccer 2000 (Europe) (Fr,It)" region="FRA" />
+		<release name="International Superstar Soccer 2000 (Europe) (Fr,It)" region="ITA" />
+		<rom name="International Superstar Soccer 2000 (Europe) (Fr,It).z64" size="16777216" crc="8a16a6a9" md5="cc2be97a16744860fae8a94611479c4c" sha1="b0505e13ba0f029ea735378c50b224fd618be302" status="verified" />
 	</game>
 	<game name="International Superstar Soccer 2000 (USA) (En,Es)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
 		<description>International Superstar Soccer 2000 (USA) (En,Es)</description>
-		<rom name="International Superstar Soccer 2000 (USA) (En,Es).z64" size="16777216" crc="dcd0538f" md5="23a4ed8d79882594206173b1d476f0e9" sha1="e7bd36c410ce881d8b8dc853cb4b7b7961bf6a62"/>
+		<rom name="International Superstar Soccer 2000 (USA) (En,Es).n64" />
+		<rom name="International Superstar Soccer 2000 (USA) (En,Es).z64" size="16777216" crc="dcd0538f" md5="23a4ed8d79882594206173b1d476f0e9" sha1="e7bd36c410ce881d8b8dc853cb4b7b7961bf6a62" />
 	</game>
 	<game name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
 		<description>International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)</description>
-		<release name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)" region="USA"/>
-		<rom name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1).z64" size="16777216" crc="4c433fdd" md5="de9498be76134bd066aa714ce2c71a16" sha1="47a993fe1316dfd9e208603370d3dddae05f1d1b"/>
+		<rom name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1).n64" />
+		<release name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1)" region="USA" />
+		<rom name="International Superstar Soccer 2000 (USA) (En,Es) (Rev 1).z64" size="16777216" crc="4c433fdd" md5="de9498be76134bd066aa714ce2c71a16" sha1="47a993fe1316dfd9e208603370d3dddae05f1d1b" />
 	</game>
 	<game name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
 		<description>Jikkyou J.League 1999 - Perfect Striker 2 (Japan)</description>
-		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan).z64" size="16777216" crc="2ef647d3" md5="1fb40ee386b58feab6cf29ddb33bcccc" sha1="2967b60aa29954fc684fdf28a0e2c335759695fe"/>
+		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan).n64" />
+		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan).z64" size="16777216" crc="2ef647d3" md5="1fb40ee386b58feab6cf29ddb33bcccc" sha1="2967b60aa29954fc684fdf28a0e2c335759695fe" />
 	</game>
 	<game name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)" cloneof="International Superstar Soccer 2000 (Europe) (En,De)">
 		<description>Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)</description>
-		<release name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1).z64" size="16777216" crc="f96c2be1" md5="d9f8b84fd6fd21f0b1d750062ac86efc" sha1="65a69b9e8a0c5c49e1badec27bf65c426ea0cc16"/>
+		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1).n64" />
+		<release name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1)" region="JPN" />
+		<rom name="Jikkyou J.League 1999 - Perfect Striker 2 (Japan) (Rev 1).z64" size="16777216" crc="f96c2be1" md5="d9f8b84fd6fd21f0b1d750062ac86efc" sha1="65a69b9e8a0c5c49e1badec27bf65c426ea0cc16" />
 	</game>
 	<game name="International Superstar Soccer 64 (Europe)">
 		<description>International Superstar Soccer 64 (Europe)</description>
-		<release name="International Superstar Soccer 64 (Europe)" region="EUR"/>
-		<rom name="International Superstar Soccer 64 (Europe).z64" size="8388608" crc="8c839268" md5="376803f28ca8b2133671783419933ca2" sha1="3b53fd76bb37b923b0fe61e50057ae773a25170a" status="verified"/>
+		<rom name="International Superstar Soccer 64 (Europe).n64" />
+		<release name="International Superstar Soccer 64 (Europe)" region="EUR" />
+		<rom name="International Superstar Soccer 64 (Europe).z64" size="8388608" crc="8c839268" md5="376803f28ca8b2133671783419933ca2" sha1="3b53fd76bb37b923b0fe61e50057ae773a25170a" status="verified" />
 	</game>
 	<game name="International Superstar Soccer 64 (USA)" cloneof="International Superstar Soccer 64 (Europe)">
 		<description>International Superstar Soccer 64 (USA)</description>
-		<release name="International Superstar Soccer 64 (USA)" region="USA"/>
-		<rom name="International Superstar Soccer 64 (USA).z64" size="8388608" crc="0ea249b9" md5="6a345402ae1db5ce1041365e36126bce" sha1="d2c258ee3844be77049e4af5208f8f2bb073a86e"/>
+		<rom name="International Superstar Soccer 64 (USA).n64" />
+		<release name="International Superstar Soccer 64 (USA)" region="USA" />
+		<rom name="International Superstar Soccer 64 (USA).z64" size="8388608" crc="0ea249b9" md5="6a345402ae1db5ce1041365e36126bce" sha1="d2c258ee3844be77049e4af5208f8f2bb073a86e" />
 	</game>
 	<game name="Jikkyou World Soccer 3 (Japan)" cloneof="International Superstar Soccer 64 (Europe)">
 		<description>Jikkyou World Soccer 3 (Japan)</description>
-		<release name="Jikkyou World Soccer 3 (Japan)" region="JPN"/>
-		<rom name="Jikkyou World Soccer 3 (Japan).z64" size="8388608" crc="3ba9e644" md5="ef0f425689586850a6f5796124b0c85b" sha1="a06528ce7a1c007f3e8dfae199b6e65b3dbc034d"/>
+		<rom name="Jikkyou World Soccer 3 (Japan).n64" />
+		<release name="Jikkyou World Soccer 3 (Japan)" region="JPN" />
+		<rom name="Jikkyou World Soccer 3 (Japan).z64" size="8388608" crc="3ba9e644" md5="ef0f425689586850a6f5796124b0c85b" sha1="a06528ce7a1c007f3e8dfae199b6e65b3dbc034d" />
 	</game>
 	<game name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate)" cloneof="International Superstar Soccer 64 (Europe)">
 		<description>Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate)</description>
-		<release name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate)" region="BRA"/>
-		<rom name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate).z64" size="8388608" crc="c296eca1" md5="14f1f43a0314c3e36d9d248e1f03ec2e" sha1="93119cee958ad7a7b28f6a945cfaa7829fe340da"/>
+		<rom name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate).n64" />
+		<release name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate)" region="BRA" />
+		<rom name="Ronaldinho's Soccer 64 (Brazil) (Unl) (Pirate).z64" size="8388608" crc="c296eca1" md5="14f1f43a0314c3e36d9d248e1f03ec2e" sha1="93119cee958ad7a7b28f6a945cfaa7829fe340da" />
 	</game>
 	<game name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)">
 		<description>International Track &amp; Field - Summer Games (Europe) (En,Fr,De)</description>
-		<release name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De).z64" size="12582912" crc="b3181ee0" md5="970488fb7d9c5c25bd924e6f898b84a0" sha1="b3d5a2128813bd077dd3e161978e3c1717e278e0"/>
+		<rom name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De).n64" />
+		<release name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="International Track &amp; Field - Summer Games (Europe) (En,Fr,De).z64" size="12582912" crc="b3181ee0" md5="970488fb7d9c5c25bd924e6f898b84a0" sha1="b3d5a2128813bd077dd3e161978e3c1717e278e0" />
 	</game>
 	<game name="Ganbare! Nippon! Olympics 2000 (Japan)" cloneof="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)">
 		<description>Ganbare! Nippon! Olympics 2000 (Japan)</description>
-		<release name="Ganbare! Nippon! Olympics 2000 (Japan)" region="JPN"/>
-		<rom name="Ganbare! Nippon! Olympics 2000 (Japan).z64" size="12582912" crc="73133cd2" md5="8d8f3a8393f3f5489b3b144369565594" sha1="f683446894a704df016b90cc3409ecdb70cba0aa"/>
+		<rom name="Ganbare! Nippon! Olympics 2000 (Japan).n64" />
+		<release name="Ganbare! Nippon! Olympics 2000 (Japan)" region="JPN" />
+		<rom name="Ganbare! Nippon! Olympics 2000 (Japan).z64" size="12582912" crc="73133cd2" md5="8d8f3a8393f3f5489b3b144369565594" sha1="f683446894a704df016b90cc3409ecdb70cba0aa" />
 	</game>
 	<game name="International Track &amp; Field 2000 (USA)" cloneof="International Track &amp; Field - Summer Games (Europe) (En,Fr,De)">
 		<description>International Track &amp; Field 2000 (USA)</description>
-		<release name="International Track &amp; Field 2000 (USA)" region="USA"/>
-		<rom name="International Track &amp; Field 2000 (USA).z64" size="12582912" crc="da443f0b" md5="35662cfd07fd6af4bab90ca23f7c98e6" sha1="61d7958e61b50fd933faf5d3ae70807fa53818fb"/>
+		<rom name="International Track &amp; Field 2000 (USA).n64" />
+		<release name="International Track &amp; Field 2000 (USA)" region="USA" />
+		<rom name="International Track &amp; Field 2000 (USA).z64" size="12582912" crc="da443f0b" md5="35662cfd07fd6af4bab90ca23f7c98e6" sha1="61d7958e61b50fd933faf5d3ae70807fa53818fb" />
 	</game>
 	<game name="iQue Club (China) (v3) (iQue)">
 		<description>iQue Club (China) (v3) (iQue)</description>
-		<release name="iQue Club (China) (v3) (iQue)" region="CHN"/>
-		<rom name="iQue Club (China) (v3) (iQue).z64" size="573440" crc="6a2c6dcb" md5="f9190dbaf547d6d3f5f3569accf26061" sha1="da6511a6f75e9770381b6225fc2057ac39e884fc"/>
+		<rom name="iQue Club (China) (v3) (iQue).n64" />
+		<release name="iQue Club (China) (v3) (iQue)" region="CHN" />
+		<rom name="iQue Club (China) (v3) (iQue).z64" size="573440" crc="6a2c6dcb" md5="f9190dbaf547d6d3f5f3569accf26061" sha1="da6511a6f75e9770381b6225fc2057ac39e884fc" />
 	</game>
 	<game name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)">
 		<description>Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)</description>
-		<release name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)" region="JPN"/>
-		<rom name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).z64" size="16777216" crc="576915d4" md5="13893db9e919c4e7cf0c0b0064ccb554" sha1="c722ba7fd7c44fee474233db3fd251177a83a9ab"/>
+		<rom name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).n64" />
+		<release name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan)" region="JPN" />
+		<rom name="Itoi Shigesato no Bass Tsuri No. 1 Kettei Ban! (Japan).z64" size="16777216" crc="576915d4" md5="13893db9e919c4e7cf0c0b0064ccb554" sha1="c722ba7fd7c44fee474233db3fd251177a83a9ab" />
 	</game>
 	<game name="J.League Dynamite Soccer 64 (Japan)">
 		<description>J.League Dynamite Soccer 64 (Japan)</description>
-		<release name="J.League Dynamite Soccer 64 (Japan)" region="JPN"/>
-		<rom name="J.League Dynamite Soccer 64 (Japan).z64" size="8388608" crc="dc0b2c8f" md5="1247b093e0fd6ccfd50d15de59301076" sha1="b5618ffde759bcef12a19b336cf940df24f52209"/>
+		<rom name="J.League Dynamite Soccer 64 (Japan).n64" />
+		<release name="J.League Dynamite Soccer 64 (Japan)" region="JPN" />
+		<rom name="J.League Dynamite Soccer 64 (Japan).z64" size="8388608" crc="dc0b2c8f" md5="1247b093e0fd6ccfd50d15de59301076" sha1="b5618ffde759bcef12a19b336cf940df24f52209" />
 	</game>
 	<game name="J.League Eleven Beat 1997 (Japan)">
 		<description>J.League Eleven Beat 1997 (Japan)</description>
-		<release name="J.League Eleven Beat 1997 (Japan)" region="JPN"/>
-		<rom name="J.League Eleven Beat 1997 (Japan).z64" size="8388608" crc="7d0eed6a" md5="30e23d3de446e37e5e7fbef6794a6fc9" sha1="0403902145ced0c42252981bc6c8fef2f76ccc08"/>
+		<rom name="J.League Eleven Beat 1997 (Japan).n64" />
+		<release name="J.League Eleven Beat 1997 (Japan)" region="JPN" />
+		<rom name="J.League Eleven Beat 1997 (Japan).z64" size="8388608" crc="7d0eed6a" md5="30e23d3de446e37e5e7fbef6794a6fc9" sha1="0403902145ced0c42252981bc6c8fef2f76ccc08" />
 	</game>
 	<game name="J.League Live 64 (Japan)">
 		<description>J.League Live 64 (Japan)</description>
-		<release name="J.League Live 64 (Japan)" region="JPN"/>
-		<rom name="J.League Live 64 (Japan).z64" size="8388608" crc="4c536dd7" md5="209db8333eeb526ae9a91209175348ce" sha1="447e573eb019bf4acd48b926c89701e09198ee36"/>
+		<rom name="J.League Live 64 (Japan).n64" />
+		<release name="J.League Live 64 (Japan)" region="JPN" />
+		<rom name="J.League Live 64 (Japan).z64" size="8388608" crc="4c536dd7" md5="209db8333eeb526ae9a91209175348ce" sha1="447e573eb019bf4acd48b926c89701e09198ee36" />
 	</game>
 	<game name="J.League Tactics Soccer (Japan) (Rev 1)">
 		<description>J.League Tactics Soccer (Japan) (Rev 1)</description>
-		<release name="J.League Tactics Soccer (Japan) (Rev 1)" region="JPN"/>
-		<rom name="J.League Tactics Soccer (Japan) (Rev 1).z64" size="12582912" crc="156e705e" md5="793dbf504e20c92f6b73b4e8a25a220c" sha1="9a47293d82c161f1cb146673ac6ad96c1730c624"/>
+		<rom name="J.League Tactics Soccer (Japan) (Rev 1).n64" />
+		<release name="J.League Tactics Soccer (Japan) (Rev 1)" region="JPN" />
+		<rom name="J.League Tactics Soccer (Japan) (Rev 1).z64" size="12582912" crc="156e705e" md5="793dbf504e20c92f6b73b4e8a25a220c" sha1="9a47293d82c161f1cb146673ac6ad96c1730c624" />
 	</game>
 	<game name="J.League Tactics Soccer (Japan)" cloneof="J.League Tactics Soccer (Japan) (Rev 1)">
 		<description>J.League Tactics Soccer (Japan)</description>
-		<rom name="J.League Tactics Soccer (Japan).z64" size="12582912" crc="976a2d12" md5="800acc7d609ecdb3e09e68cbd05f5fa0" sha1="853cecc41c00f1bbc9972dffb94b78bdb0dfa274"/>
+		<rom name="J.League Tactics Soccer (Japan).n64" />
+		<rom name="J.League Tactics Soccer (Japan).z64" size="12582912" crc="976a2d12" md5="800acc7d609ecdb3e09e68cbd05f5fa0" sha1="853cecc41c00f1bbc9972dffb94b78bdb0dfa274" />
 	</game>
 	<game name="Jangou Simulation Mahjong Dou 64 (Japan)">
 		<description>Jangou Simulation Mahjong Dou 64 (Japan)</description>
-		<release name="Jangou Simulation Mahjong Dou 64 (Japan)" region="JPN"/>
-		<rom name="Jangou Simulation Mahjong Dou 64 (Japan).z64" size="8388608" crc="d1c1681e" md5="8ee01de7da2e9ad08d7ed913a5ee8632" sha1="f2f96b00709ac81ba8228bb38a8396824c29ce51"/>
+		<rom name="Jangou Simulation Mahjong Dou 64 (Japan).n64" />
+		<release name="Jangou Simulation Mahjong Dou 64 (Japan)" region="JPN" />
+		<rom name="Jangou Simulation Mahjong Dou 64 (Japan).z64" size="8388608" crc="d1c1681e" md5="8ee01de7da2e9ad08d7ed913a5ee8632" sha1="f2f96b00709ac81ba8228bb38a8396824c29ce51" />
 	</game>
 	<game name="Jeopardy! (USA)">
 		<description>Jeopardy! (USA)</description>
-		<release name="Jeopardy! (USA)" region="USA"/>
-		<rom name="Jeopardy! (USA).z64" size="4194304" crc="e739947c" md5="a45f7200537c0d928a88cbba2dfeb680" sha1="c5bcf3eff6bcdd9e7846ce5fd5db3095db9c58ed"/>
+		<rom name="Jeopardy! (USA).n64" />
+		<release name="Jeopardy! (USA)" region="USA" />
+		<rom name="Jeopardy! (USA).z64" size="4194304" crc="e739947c" md5="a45f7200537c0d928a88cbba2dfeb680" sha1="c5bcf3eff6bcdd9e7846ce5fd5db3095db9c58ed" />
 	</game>
 	<game name="Jeremy McGrath Supercross 2000 (Europe)">
 		<description>Jeremy McGrath Supercross 2000 (Europe)</description>
-		<release name="Jeremy McGrath Supercross 2000 (Europe)" region="EUR"/>
-		<rom name="Jeremy McGrath Supercross 2000 (Europe).z64" size="16777216" crc="5bf42ec4" md5="4c5be1bfc1cccff501eba2a685226962" sha1="7804a688c9f7ed39d9c1a33c0339f4317d3918dc"/>
+		<rom name="Jeremy McGrath Supercross 2000 (Europe).n64" />
+		<release name="Jeremy McGrath Supercross 2000 (Europe)" region="EUR" />
+		<rom name="Jeremy McGrath Supercross 2000 (Europe).z64" size="16777216" crc="5bf42ec4" md5="4c5be1bfc1cccff501eba2a685226962" sha1="7804a688c9f7ed39d9c1a33c0339f4317d3918dc" />
 	</game>
 	<game name="Jeremy McGrath Supercross 2000 (USA)" cloneof="Jeremy McGrath Supercross 2000 (Europe)">
 		<description>Jeremy McGrath Supercross 2000 (USA)</description>
-		<release name="Jeremy McGrath Supercross 2000 (USA)" region="USA"/>
-		<rom name="Jeremy McGrath Supercross 2000 (USA).z64" size="16777216" crc="2a5c9a06" md5="8046a4b8abd4353b2ab9696106ccf8d2" sha1="278ad55333b7b75970812ecb9e691111ca3cfc46"/>
+		<rom name="Jeremy McGrath Supercross 2000 (USA).n64" />
+		<release name="Jeremy McGrath Supercross 2000 (USA)" region="USA" />
+		<rom name="Jeremy McGrath Supercross 2000 (USA).z64" size="16777216" crc="2a5c9a06" md5="8046a4b8abd4353b2ab9696106ccf8d2" sha1="278ad55333b7b75970812ecb9e691111ca3cfc46" />
 	</game>
 	<game name="Jet Force Gemini (Europe) (En,Fr,De,Es)">
 		<description>Jet Force Gemini (Europe) (En,Fr,De,Es)</description>
-		<release name="Jet Force Gemini (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Jet Force Gemini (Europe) (En,Fr,De,Es).z64" size="33554432" crc="cfbed88c" md5="baaf237e71aa7526c9b2f01c08b68a53" sha1="50651c4e0c46332f7f0b45870263f0a8b9a49602"/>
+		<rom name="Jet Force Gemini (Europe) (En,Fr,De,Es).n64" />
+		<release name="Jet Force Gemini (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Jet Force Gemini (Europe) (En,Fr,De,Es).z64" size="33554432" crc="cfbed88c" md5="baaf237e71aa7526c9b2f01c08b68a53" sha1="50651c4e0c46332f7f0b45870263f0a8b9a49602" />
 	</game>
 	<game name="Jet Force Gemini (USA)" cloneof="Jet Force Gemini (Europe) (En,Fr,De,Es)">
 		<description>Jet Force Gemini (USA)</description>
-		<release name="Jet Force Gemini (USA)" region="USA"/>
-		<rom name="Jet Force Gemini (USA).z64" size="33554432" crc="6753d5a3" md5="772cc6eab2620d2d3cdc17bbc26c4f68" sha1="493ced9008dbe932d6e91179b68e8630cf23a023"/>
+		<rom name="Jet Force Gemini (USA).n64" />
+		<release name="Jet Force Gemini (USA)" region="USA" />
+		<rom name="Jet Force Gemini (USA).z64" size="33554432" crc="6753d5a3" md5="772cc6eab2620d2d3cdc17bbc26c4f68" sha1="493ced9008dbe932d6e91179b68e8630cf23a023" />
 	</game>
 	<game name="Jet Force Gemini (USA) (Demo) (Kiosk)" cloneof="Jet Force Gemini (Europe) (En,Fr,De,Es)">
 		<description>Jet Force Gemini (USA) (Demo) (Kiosk)</description>
-		<rom name="Jet Force Gemini (USA) (Demo) (Kiosk).z64" size="33554432" crc="fa061b96" md5="5bbe9ade7171f2e1daaa7c48fad38728" sha1="f00f7c7fb085d0df57dcb649793aced5be4e8562"/>
+		<rom name="Jet Force Gemini (USA) (Demo) (Kiosk).n64" />
+		<rom name="Jet Force Gemini (USA) (Demo) (Kiosk).z64" size="33554432" crc="fa061b96" md5="5bbe9ade7171f2e1daaa7c48fad38728" sha1="f00f7c7fb085d0df57dcb649793aced5be4e8562" />
 	</game>
 	<game name="Star Twins (Japan)" cloneof="Jet Force Gemini (Europe) (En,Fr,De,Es)">
 		<description>Star Twins (Japan)</description>
-		<release name="Star Twins (Japan)" region="JPN"/>
-		<rom name="Star Twins (Japan).z64" size="33554432" crc="964506ce" md5="ca28a3645fc7ad969ebd75c5d6506e7a" sha1="15099233760b36e7afad7da36b9464da1512c4b1"/>
+		<rom name="Star Twins (Japan).n64" />
+		<release name="Star Twins (Japan)" region="JPN" />
+		<rom name="Star Twins (Japan).z64" size="33554432" crc="964506ce" md5="ca28a3645fc7ad969ebd75c5d6506e7a" sha1="15099233760b36e7afad7da36b9464da1512c4b1" />
 	</game>
 	<game name="Jikkyou G1 Stable (Japan) (Rev 1)">
 		<description>Jikkyou G1 Stable (Japan) (Rev 1)</description>
-		<release name="Jikkyou G1 Stable (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Jikkyou G1 Stable (Japan) (Rev 1).z64" size="16777216" crc="6fc0a31b" md5="482bdd39ad2574b943db780b12a9bdfb" sha1="ad0ebbb4b2ea4dffbfd99c77f9be530a479ef7e1"/>
+		<rom name="Jikkyou G1 Stable (Japan) (Rev 1).n64" />
+		<release name="Jikkyou G1 Stable (Japan) (Rev 1)" region="JPN" />
+		<rom name="Jikkyou G1 Stable (Japan) (Rev 1).z64" size="16777216" crc="6fc0a31b" md5="482bdd39ad2574b943db780b12a9bdfb" sha1="ad0ebbb4b2ea4dffbfd99c77f9be530a479ef7e1" />
 	</game>
 	<game name="Jikkyou G1 Stable (Japan)" cloneof="Jikkyou G1 Stable (Japan) (Rev 1)">
 		<description>Jikkyou G1 Stable (Japan)</description>
-		<rom name="Jikkyou G1 Stable (Japan).z64" size="16777216" crc="0a796c3e" md5="878d8a26fd02fdb08200464cb6f566ef" sha1="eb7b24bac29df362cab562662ae9a5de7d5fb0c3"/>
+		<rom name="Jikkyou G1 Stable (Japan).n64" />
+		<rom name="Jikkyou G1 Stable (Japan).z64" size="16777216" crc="0a796c3e" md5="878d8a26fd02fdb08200464cb6f566ef" sha1="eb7b24bac29df362cab562662ae9a5de7d5fb0c3" />
 	</game>
 	<game name="Jikkyou J.League Perfect Striker (Japan)">
 		<description>Jikkyou J.League Perfect Striker (Japan)</description>
-		<release name="Jikkyou J.League Perfect Striker (Japan)" region="JPN"/>
-		<rom name="Jikkyou J.League Perfect Striker (Japan).z64" size="8388608" crc="8ed60dea" md5="58153ac5c4030d1bfd3c15cf57fb02e7" sha1="e1185922648a6b9dec1c820f43a292e480e396cc" status="verified"/>
+		<rom name="Jikkyou J.League Perfect Striker (Japan).n64" />
+		<release name="Jikkyou J.League Perfect Striker (Japan)" region="JPN" />
+		<rom name="Jikkyou J.League Perfect Striker (Japan).z64" size="8388608" crc="8ed60dea" md5="58153ac5c4030d1bfd3c15cf57fb02e7" sha1="e1185922648a6b9dec1c820f43a292e480e396cc" status="verified" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)">
 		<description>Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)</description>
-		<release name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1).z64" size="16777216" crc="bc7ef5c1" md5="f13d0803885b73b4a6b35eddd40b9253" sha1="8fc693bc19c362716cfbaa7d1ef513685bec99e0"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1).n64" />
+		<release name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)" region="JPN" />
+		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1).z64" size="16777216" crc="bc7ef5c1" md5="f13d0803885b73b4a6b35eddd40b9253" sha1="8fc693bc19c362716cfbaa7d1ef513685bec99e0" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan) (Rev 1)">
 		<description>Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan).z64" size="16777216" crc="6a9e24d7" md5="7fc933a64884a382aa07605ea7204ff5" sha1="b24170ed95734dd12084ca3c82b678fabcbd4279"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu - Basic Ban 2001 (Japan).z64" size="16777216" crc="6a9e24d7" md5="7fc933a64884a382aa07605ea7204ff5" sha1="b24170ed95734dd12084ca3c82b678fabcbd4279" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)">
 		<description>Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)</description>
-		<release name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1).z64" size="16777216" crc="753706ef" md5="b653c963ed8d3a749676810f07cfe4e5" sha1="2b9425be9c6f76eb6594d414299c24e19cf12992"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1).n64" />
+		<release name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)" region="JPN" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1).z64" size="16777216" crc="753706ef" md5="b653c963ed8d3a749676810f07cfe4e5" sha1="2b9425be9c6f76eb6594d414299c24e19cf12992" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 2000 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu 2000 (Japan) (Rev 1)">
 		<description>Jikkyou Powerful Pro Yakyuu 2000 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan).z64" size="16777216" crc="351cde48" md5="23409668a6e6c4ece7b5fb0b7d0e8f2c" sha1="365d6efa2665b816a5e0e2233c890ddcd524c05d"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 2000 (Japan).z64" size="16777216" crc="351cde48" md5="23409668a6e6c4ece7b5fb0b7d0e8f2c" sha1="365d6efa2665b816a5e0e2233c890ddcd524c05d" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)">
 		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)</description>
-		<release name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1).z64" size="12582912" crc="40e3ac61" md5="b454490eb44f0978f009fa41de8c478e" sha1="d11b2860925c3784cbd4ad163111414537c5378a"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1).n64" />
+		<release name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)" region="JPN" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1).z64" size="12582912" crc="40e3ac61" md5="b454490eb44f0978f009fa41de8c478e" sha1="d11b2860925c3784cbd4ad163111414537c5378a" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)">
 		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan).z64" size="12582912" crc="480b953e" md5="fda57f65eb159278223eb9d03267c27f" sha1="7e27a27bad4f98500d7a68ec43ab7bffe5de03e1"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan).z64" size="12582912" crc="480b953e" md5="fda57f65eb159278223eb9d03267c27f" sha1="7e27a27bad4f98500d7a68ec43ab7bffe5de03e1" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30)" cloneof="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Rev 1)">
 		<description>Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30).z64" size="16777216" crc="1b8b9a68" md5="ada39573b25804610d8fafaff741b088" sha1="c780866c263f5d9ae8f70bad558b0de6d5795115"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 4 (Japan) (Beta) (1996-11-30).z64" size="16777216" crc="1b8b9a68" md5="ada39573b25804610d8fafaff741b088" sha1="c780866c263f5d9ae8f70bad558b0de6d5795115" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)">
 		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)</description>
-		<release name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)" region="JPN"/>
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2).z64" size="16777216" crc="c02fd9be" md5="68a27fbab060857c267a639931d2c3d6" sha1="a504c2978d8cfffccbb815cc00d96dc0b7bece3b" status="verified"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2).n64" />
+		<release name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)" region="JPN" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2).z64" size="16777216" crc="c02fd9be" md5="68a27fbab060857c267a639931d2c3d6" sha1="a504c2978d8cfffccbb815cc00d96dc0b7bece3b" status="verified" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)">
 		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan).z64" size="16777216" crc="feec34f6" md5="e9f989e09e3f1519aefe619889a4f710" sha1="f1bc8d2a6b03ffab7355c4e7b5fa1c393421e9f9"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan).z64" size="16777216" crc="feec34f6" md5="e9f989e09e3f1519aefe619889a4f710" sha1="f1bc8d2a6b03ffab7355c4e7b5fa1c393421e9f9" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1)" cloneof="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 2)">
 		<description>Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1).z64" size="16777216" crc="7994c2fe" md5="6ef19bf8d8d6196390745f1b858ac16a" sha1="a830e30c8272220c5481f294aa5cb5014df05499"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 5 (Japan) (Rev 1).z64" size="16777216" crc="7994c2fe" md5="6ef19bf8d8d6196390745f1b858ac16a" sha1="a830e30c8272220c5481f294aa5cb5014df05499" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)">
 		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)</description>
-		<release name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)" region="JPN"/>
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2).z64" size="16777216" crc="fcc10356" md5="03bd8e5ca2b1b7d74398db4739979282" sha1="2763b83846165221c8b80bc4430f5b55779622e3"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2).n64" />
+		<release name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)" region="JPN" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2).z64" size="16777216" crc="fcc10356" md5="03bd8e5ca2b1b7d74398db4739979282" sha1="2763b83846165221c8b80bc4430f5b55779622e3" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan)" cloneof="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)">
 		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan).z64" size="16777216" crc="1e53a7ba" md5="060d0313e23b660180441fcc7d24d7db" sha1="02924d963d214102cb723b0e54c901968aa51a1f"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan).z64" size="16777216" crc="1e53a7ba" md5="060d0313e23b660180441fcc7d24d7db" sha1="02924d963d214102cb723b0e54c901968aa51a1f" />
 	</game>
 	<game name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1)" cloneof="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 2)">
 		<description>Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1)</description>
-		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1).z64" size="16777216" crc="7ab7ebf4" md5="23ee24faba0edfb04b5b0407e174496b" sha1="828002c3f34eb357458a9a9c4fa989ba82927fe9"/>
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1).n64" />
+		<rom name="Jikkyou Powerful Pro Yakyuu 6 (Japan) (Rev 1).z64" size="16777216" crc="7ab7ebf4" md5="23ee24faba0edfb04b5b0407e174496b" sha1="828002c3f34eb357458a9a9c4fa989ba82927fe9" />
 	</game>
 	<game name="Jinsei Game 64 (Japan)">
 		<description>Jinsei Game 64 (Japan)</description>
-		<release name="Jinsei Game 64 (Japan)" region="JPN"/>
-		<rom name="Jinsei Game 64 (Japan).z64" size="16777216" crc="67a1a22c" md5="68230d510015ff6817ef898c0b8b636c" sha1="8759a3fc272c3f6259bbe2433eb34411705d8634"/>
+		<rom name="Jinsei Game 64 (Japan).n64" />
+		<release name="Jinsei Game 64 (Japan)" region="JPN" />
+		<rom name="Jinsei Game 64 (Japan).z64" size="16777216" crc="67a1a22c" md5="68230d510015ff6817ef898c0b8b636c" sha1="8759a3fc272c3f6259bbe2433eb34411705d8634" />
 	</game>
 	<game name="John Romero's Daikatana (Europe) (En,Fr,De)">
 		<description>John Romero's Daikatana (Europe) (En,Fr,De)</description>
-		<release name="John Romero's Daikatana (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="John Romero's Daikatana (Europe) (En,Fr,De).z64" size="16777216" crc="f88ac3ce" md5="7ab29c6ad2d8f4007d8213eb3411e0bd" sha1="0278c3f9b2780890c4c2a3ee8a10c550a1eda346"/>
+		<rom name="John Romero's Daikatana (Europe) (En,Fr,De).n64" />
+		<release name="John Romero's Daikatana (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="John Romero's Daikatana (Europe) (En,Fr,De).z64" size="16777216" crc="f88ac3ce" md5="7ab29c6ad2d8f4007d8213eb3411e0bd" sha1="0278c3f9b2780890c4c2a3ee8a10c550a1eda346" />
 	</game>
 	<game name="John Romero's Daikatana (Japan)" cloneof="John Romero's Daikatana (Europe) (En,Fr,De)">
 		<description>John Romero's Daikatana (Japan)</description>
-		<release name="John Romero's Daikatana (Japan)" region="JPN"/>
-		<rom name="John Romero's Daikatana (Japan).z64" size="16777216" crc="44b80fd7" md5="57d31ea7121dd5a05b547225efa5cfd7" sha1="4ed2ec28997865e301c5693639c2ec717c79a5bc"/>
+		<rom name="John Romero's Daikatana (Japan).n64" />
+		<release name="John Romero's Daikatana (Japan)" region="JPN" />
+		<rom name="John Romero's Daikatana (Japan).z64" size="16777216" crc="44b80fd7" md5="57d31ea7121dd5a05b547225efa5cfd7" sha1="4ed2ec28997865e301c5693639c2ec717c79a5bc" />
 	</game>
 	<game name="John Romero's Daikatana (USA)" cloneof="John Romero's Daikatana (Europe) (En,Fr,De)">
 		<description>John Romero's Daikatana (USA)</description>
-		<release name="John Romero's Daikatana (USA)" region="USA"/>
-		<rom name="John Romero's Daikatana (USA).z64" size="16777216" crc="494950c6" md5="5b4c268422469f50b94779e655f2b798" sha1="08709013d512f3a2bed65b98ab451ec8b839d3b4"/>
+		<rom name="John Romero's Daikatana (USA).n64" />
+		<release name="John Romero's Daikatana (USA)" region="USA" />
+		<rom name="John Romero's Daikatana (USA).z64" size="16777216" crc="494950c6" md5="5b4c268422469f50b94779e655f2b798" sha1="08709013d512f3a2bed65b98ab451ec8b839d3b4" />
 	</game>
 	<game name="Ken Griffey Jr.'s Slugfest (USA)">
 		<description>Ken Griffey Jr.'s Slugfest (USA)</description>
-		<release name="Ken Griffey Jr.'s Slugfest (USA)" region="USA"/>
-		<rom name="Ken Griffey Jr.'s Slugfest (USA).z64" size="16777216" crc="12d8f3e9" md5="eec0fab75af59e9c23e6de2132de89ff" sha1="ec33cd4d44bba163f89e435c2aefbf7313d8cece"/>
+		<rom name="Ken Griffey Jr.'s Slugfest (USA).n64" />
+		<release name="Ken Griffey Jr.'s Slugfest (USA)" region="USA" />
+		<rom name="Ken Griffey Jr.'s Slugfest (USA).z64" size="16777216" crc="12d8f3e9" md5="eec0fab75af59e9c23e6de2132de89ff" sha1="ec33cd4d44bba163f89e435c2aefbf7313d8cece" />
 	</game>
 	<game name="Killer Instinct Gold (Europe)">
 		<description>Killer Instinct Gold (Europe)</description>
-		<release name="Killer Instinct Gold (Europe)" region="EUR"/>
-		<rom name="Killer Instinct Gold (Europe).z64" size="12582912" crc="5d0ee5d2" md5="c93d92f10a1a97d2ba87386be7d178fd" sha1="e0ed97c7310b012a5cf81c6f6678a75b8601b47e" status="verified"/>
+		<rom name="Killer Instinct Gold (Europe).n64" />
+		<release name="Killer Instinct Gold (Europe)" region="EUR" />
+		<rom name="Killer Instinct Gold (Europe).z64" size="12582912" crc="5d0ee5d2" md5="c93d92f10a1a97d2ba87386be7d178fd" sha1="e0ed97c7310b012a5cf81c6f6678a75b8601b47e" status="verified" />
 	</game>
 	<game name="Killer Instinct Gold (USA)" cloneof="Killer Instinct Gold (Europe)">
 		<description>Killer Instinct Gold (USA)</description>
-		<rom name="Killer Instinct Gold (USA).z64" size="12582912" crc="31c76be7" md5="8e33ad20c31feb61d7230fad28846c5c" sha1="ba52e91b44450c548467044b26951353dc491e04" status="verified"/>
+		<rom name="Killer Instinct Gold (USA).n64" />
+		<rom name="Killer Instinct Gold (USA).z64" size="12582912" crc="31c76be7" md5="8e33ad20c31feb61d7230fad28846c5c" sha1="ba52e91b44450c548467044b26951353dc491e04" status="verified" />
 	</game>
 	<game name="Killer Instinct Gold (USA) (Rev 1)" cloneof="Killer Instinct Gold (Europe)">
 		<description>Killer Instinct Gold (USA) (Rev 1)</description>
-		<rom name="Killer Instinct Gold (USA) (Rev 1).z64" size="12582912" crc="49ef8f2b" md5="4c9b419dc583c0df4ab908adf83bfc65" sha1="bcc599ed0f0b8b75a8068269958a2230ec7cb34c"/>
+		<rom name="Killer Instinct Gold (USA) (Rev 1).n64" />
+		<rom name="Killer Instinct Gold (USA) (Rev 1).z64" size="12582912" crc="49ef8f2b" md5="4c9b419dc583c0df4ab908adf83bfc65" sha1="bcc599ed0f0b8b75a8068269958a2230ec7cb34c" />
 	</game>
 	<game name="Killer Instinct Gold (USA) (Rev 2)" cloneof="Killer Instinct Gold (Europe)">
 		<description>Killer Instinct Gold (USA) (Rev 2)</description>
-		<release name="Killer Instinct Gold (USA) (Rev 2)" region="USA"/>
-		<rom name="Killer Instinct Gold (USA) (Rev 2).z64" size="12582912" crc="0b5b5df8" md5="dd0a82fcc10397afb37f12bb7f94e67a" sha1="aaeb492b1e538af65a3544a97240675ef438a04f"/>
+		<rom name="Killer Instinct Gold (USA) (Rev 2).n64" />
+		<release name="Killer Instinct Gold (USA) (Rev 2)" region="USA" />
+		<rom name="Killer Instinct Gold (USA) (Rev 2).z64" size="12582912" crc="0b5b5df8" md5="dd0a82fcc10397afb37f12bb7f94e67a" sha1="aaeb492b1e538af65a3544a97240675ef438a04f" />
 	</game>
 	<game name="Kiratto Kaiketsu! 64 Tanteidan (Japan)">
 		<description>Kiratto Kaiketsu! 64 Tanteidan (Japan)</description>
-		<release name="Kiratto Kaiketsu! 64 Tanteidan (Japan)" region="JPN"/>
-		<rom name="Kiratto Kaiketsu! 64 Tanteidan (Japan).z64" size="12582912" crc="7fdc3784" md5="32257bfffd9b2d680f582e148e9b0611" sha1="5340930ee4a26d8897c8734ee812e769c162be0f"/>
+		<rom name="Kiratto Kaiketsu! 64 Tanteidan (Japan).n64" />
+		<release name="Kiratto Kaiketsu! 64 Tanteidan (Japan)" region="JPN" />
+		<rom name="Kiratto Kaiketsu! 64 Tanteidan (Japan).z64" size="12582912" crc="7fdc3784" md5="32257bfffd9b2d680f582e148e9b0611" sha1="5340930ee4a26d8897c8734ee812e769c162be0f" />
 	</game>
 	<game name="Kirby 64 - The Crystal Shards (Europe)">
 		<description>Kirby 64 - The Crystal Shards (Europe)</description>
-		<release name="Kirby 64 - The Crystal Shards (Europe)" region="EUR"/>
-		<rom name="Kirby 64 - The Crystal Shards (Europe).z64" size="33554432" crc="5b8b89ef" md5="a44b7a612964a6d6139d0426e569d9c9" sha1="52e8382252ec9b629662153eae6f87ae3675b700" status="verified"/>
+		<rom name="Kirby 64 - The Crystal Shards (Europe).n64" />
+		<release name="Kirby 64 - The Crystal Shards (Europe)" region="EUR" />
+		<rom name="Kirby 64 - The Crystal Shards (Europe).z64" size="33554432" crc="5b8b89ef" md5="a44b7a612964a6d6139d0426e569d9c9" sha1="52e8382252ec9b629662153eae6f87ae3675b700" status="verified" />
 	</game>
 	<game name="Hoshi no Kirby 64 (Japan)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
 		<description>Hoshi no Kirby 64 (Japan)</description>
-		<rom name="Hoshi no Kirby 64 (Japan).z64" size="33554432" crc="ae7cb69d" md5="b1a67aebc2be89a800e5eb60c0dfa968" sha1="b9882992907a102bd33373585acc90b9c7eb1ba4"/>
+		<rom name="Hoshi no Kirby 64 (Japan).n64" />
+		<rom name="Hoshi no Kirby 64 (Japan).z64" size="33554432" crc="ae7cb69d" md5="b1a67aebc2be89a800e5eb60c0dfa968" sha1="b9882992907a102bd33373585acc90b9c7eb1ba4" />
 	</game>
 	<game name="Hoshi no Kirby 64 (Japan) (Rev 1)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
 		<description>Hoshi no Kirby 64 (Japan) (Rev 1)</description>
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 1).z64" size="33554432" crc="a263c1b9" md5="ffdb4456f799722bcfe430632c3986ae" sha1="2502ceb1afba83c90f3e7f98b283f667b85d4150"/>
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 1).n64" />
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 1).z64" size="33554432" crc="a263c1b9" md5="ffdb4456f799722bcfe430632c3986ae" sha1="2502ceb1afba83c90f3e7f98b283f667b85d4150" />
 	</game>
 	<game name="Hoshi no Kirby 64 (Japan) (Rev 2)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
 		<description>Hoshi no Kirby 64 (Japan) (Rev 2)</description>
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 2).z64" size="33554432" crc="f4589aa8" md5="3ec0471e2cbee17471ddbf80c56606d5" sha1="c177f4e37eff98ef2d18fb1e94cd253fd366a218"/>
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 2).n64" />
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 2).z64" size="33554432" crc="f4589aa8" md5="3ec0471e2cbee17471ddbf80c56606d5" sha1="c177f4e37eff98ef2d18fb1e94cd253fd366a218" />
 	</game>
 	<game name="Hoshi no Kirby 64 (Japan) (Rev 3)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
 		<description>Hoshi no Kirby 64 (Japan) (Rev 3)</description>
-		<release name="Hoshi no Kirby 64 (Japan) (Rev 3)" region="JPN"/>
-		<rom name="Hoshi no Kirby 64 (Japan) (Rev 3).z64" size="33554432" crc="6d5e1332" md5="35e039f8e79843917d02be06d00c457b" sha1="03257c820b7705400c32bde1bcc3161c55814605" status="verified"/>
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 3).n64" />
+		<release name="Hoshi no Kirby 64 (Japan) (Rev 3)" region="JPN" />
+		<rom name="Hoshi no Kirby 64 (Japan) (Rev 3).z64" size="33554432" crc="6d5e1332" md5="35e039f8e79843917d02be06d00c457b" sha1="03257c820b7705400c32bde1bcc3161c55814605" status="verified" />
 	</game>
 	<game name="Kirby 64 - The Crystal Shards (USA)" cloneof="Kirby 64 - The Crystal Shards (Europe)">
 		<description>Kirby 64 - The Crystal Shards (USA)</description>
-		<release name="Kirby 64 - The Crystal Shards (USA)" region="USA"/>
-		<rom name="Kirby 64 - The Crystal Shards (USA).z64" size="33554432" crc="20a1c120" md5="d33e4254336383a17ff4728360562ada" sha1="6cea2d46b929a3bb347b060a77fccc83526fb855" status="verified"/>
+		<rom name="Kirby 64 - The Crystal Shards (USA).n64" />
+		<release name="Kirby 64 - The Crystal Shards (USA)" region="USA" />
+		<rom name="Kirby 64 - The Crystal Shards (USA).z64" size="33554432" crc="20a1c120" md5="d33e4254336383a17ff4728360562ada" sha1="6cea2d46b929a3bb347b060a77fccc83526fb855" status="verified" />
 	</game>
 	<game name="Knife Edge - Nose Gunner (Europe)">
 		<description>Knife Edge - Nose Gunner (Europe)</description>
-		<release name="Knife Edge - Nose Gunner (Europe)" region="EUR"/>
-		<rom name="Knife Edge - Nose Gunner (Europe).z64" size="8388608" crc="b77783be" md5="d31a94a5685a21a932cc886d64cc9b21" sha1="5359c747e91c9119fde3a7920333a9d0c04d251d"/>
+		<rom name="Knife Edge - Nose Gunner (Europe).n64" />
+		<release name="Knife Edge - Nose Gunner (Europe)" region="EUR" />
+		<rom name="Knife Edge - Nose Gunner (Europe).z64" size="8388608" crc="b77783be" md5="d31a94a5685a21a932cc886d64cc9b21" sha1="5359c747e91c9119fde3a7920333a9d0c04d251d" />
 	</game>
 	<game name="Knife Edge - Nose Gunner (Japan)" cloneof="Knife Edge - Nose Gunner (Europe)">
 		<description>Knife Edge - Nose Gunner (Japan)</description>
-		<release name="Knife Edge - Nose Gunner (Japan)" region="JPN"/>
-		<rom name="Knife Edge - Nose Gunner (Japan).z64" size="8388608" crc="3bc93017" md5="436ba873e9466aab237d9429348a5f70" sha1="b3242226237a401436d9d7a8d533296333e64240"/>
+		<rom name="Knife Edge - Nose Gunner (Japan).n64" />
+		<release name="Knife Edge - Nose Gunner (Japan)" region="JPN" />
+		<rom name="Knife Edge - Nose Gunner (Japan).z64" size="8388608" crc="3bc93017" md5="436ba873e9466aab237d9429348a5f70" sha1="b3242226237a401436d9d7a8d533296333e64240" />
 	</game>
 	<game name="Knife Edge - Nose Gunner (USA)" cloneof="Knife Edge - Nose Gunner (Europe)">
 		<description>Knife Edge - Nose Gunner (USA)</description>
-		<release name="Knife Edge - Nose Gunner (USA)" region="USA"/>
-		<rom name="Knife Edge - Nose Gunner (USA).z64" size="8388608" crc="255ee1dd" md5="8043d829fcd4f8f72dd81e5c6dde916f" sha1="b247167e37e7f62924be6b0d2362a091fd2352ac"/>
+		<rom name="Knife Edge - Nose Gunner (USA).n64" />
+		<release name="Knife Edge - Nose Gunner (USA)" region="USA" />
+		<rom name="Knife Edge - Nose Gunner (USA).z64" size="8388608" crc="255ee1dd" md5="8043d829fcd4f8f72dd81e5c6dde916f" sha1="b247167e37e7f62924be6b0d2362a091fd2352ac" />
 	</game>
 	<game name="Knockout Kings 2000 (Europe)">
 		<description>Knockout Kings 2000 (Europe)</description>
-		<release name="Knockout Kings 2000 (Europe)" region="EUR"/>
-		<rom name="Knockout Kings 2000 (Europe).z64" size="16777216" crc="58ce7d80" md5="e95d73ff55fbb63e79aa9eab14608584" sha1="181d220efaa3e06ac5a7baac4b6a351b762ec384"/>
+		<rom name="Knockout Kings 2000 (Europe).n64" />
+		<release name="Knockout Kings 2000 (Europe)" region="EUR" />
+		<rom name="Knockout Kings 2000 (Europe).z64" size="16777216" crc="58ce7d80" md5="e95d73ff55fbb63e79aa9eab14608584" sha1="181d220efaa3e06ac5a7baac4b6a351b762ec384" />
 	</game>
 	<game name="Knockout Kings 2000 (USA)" cloneof="Knockout Kings 2000 (Europe)">
 		<description>Knockout Kings 2000 (USA)</description>
-		<release name="Knockout Kings 2000 (USA)" region="USA"/>
-		<rom name="Knockout Kings 2000 (USA).z64" size="16777216" crc="074690d6" md5="008b473841ce4d9ac050d55f99b4b5d4" sha1="ae7229676da9acb39becb03246969693585b7728"/>
+		<rom name="Knockout Kings 2000 (USA).n64" />
+		<release name="Knockout Kings 2000 (USA)" region="USA" />
+		<rom name="Knockout Kings 2000 (USA).z64" size="16777216" crc="074690d6" md5="008b473841ce4d9ac050d55f99b4b5d4" sha1="ae7229676da9acb39becb03246969693585b7728" />
 	</game>
 	<game name="Kobe Bryant in NBA Courtside (Europe)">
 		<description>Kobe Bryant in NBA Courtside (Europe)</description>
-		<release name="Kobe Bryant in NBA Courtside (Europe)" region="EUR"/>
-		<rom name="Kobe Bryant in NBA Courtside (Europe).z64" size="12582912" crc="1355a826" md5="c6b01c020fdfd2e5c037c5a330b161ad" sha1="6390dc1cd4600ca57069d92f39f108a4cc1b62f1"/>
+		<rom name="Kobe Bryant in NBA Courtside (Europe).n64" />
+		<release name="Kobe Bryant in NBA Courtside (Europe)" region="EUR" />
+		<rom name="Kobe Bryant in NBA Courtside (Europe).z64" size="12582912" crc="1355a826" md5="c6b01c020fdfd2e5c037c5a330b161ad" sha1="6390dc1cd4600ca57069d92f39f108a4cc1b62f1" />
 	</game>
 	<game name="Kobe Bryant in NBA Courtside (USA)" cloneof="Kobe Bryant in NBA Courtside (Europe)">
 		<description>Kobe Bryant in NBA Courtside (USA)</description>
-		<release name="Kobe Bryant in NBA Courtside (USA)" region="USA"/>
-		<rom name="Kobe Bryant in NBA Courtside (USA).z64" size="12582912" crc="86360bfb" md5="d37c79e4e4eabcb5dc6a07bd76688223" sha1="49346b3124750c14dddf56b9bb2fe38b618f28f2"/>
+		<rom name="Kobe Bryant in NBA Courtside (USA).n64" />
+		<release name="Kobe Bryant in NBA Courtside (USA)" region="USA" />
+		<rom name="Kobe Bryant in NBA Courtside (USA).z64" size="12582912" crc="86360bfb" md5="d37c79e4e4eabcb5dc6a07bd76688223" sha1="49346b3124750c14dddf56b9bb2fe38b618f28f2" />
 	</game>
 	<game name="Last Legion UX (Japan)">
 		<description>Last Legion UX (Japan)</description>
-		<release name="Last Legion UX (Japan)" region="JPN"/>
-		<rom name="Last Legion UX (Japan).z64" size="12582912" crc="9db99881" md5="eb11fc0797ae1107201c4601fee5471a" sha1="dfdf852d0939466ad1f1627f4de29b7288a77589"/>
+		<rom name="Last Legion UX (Japan).n64" />
+		<release name="Last Legion UX (Japan)" region="JPN" />
+		<rom name="Last Legion UX (Japan).z64" size="12582912" crc="9db99881" md5="eb11fc0797ae1107201c4601fee5471a" sha1="dfdf852d0939466ad1f1627f4de29b7288a77589" />
 	</game>
 	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)</description>
-		<release name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)" region="EUR"/>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1).z64" size="33554432" crc="e2e6823d" md5="beccfded43a2f159d03555027462a950" sha1="bb4e4757d10727c7584c59c1f2e5f44196e9c293"/>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1).n64" />
+		<release name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)" region="EUR" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1).z64" size="33554432" crc="e2e6823d" md5="beccfded43a2f159d03555027462a950" sha1="bb4e4757d10727c7584c59c1f2e5f44196e9c293" />
 	</game>
 	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).z64" size="33554432" crc="9ead1608" md5="13fab67e603b002ceaf0eea84130e973" sha1="c04599cdafee1c84a7af9a71df68f139179ada84" status="verified"/>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es).z64" size="33554432" crc="9ead1608" md5="13fab67e603b002ceaf0eea84130e973" sha1="c04599cdafee1c84a7af9a71df68f139179ada84" status="verified" />
 	</game>
 	<game name="Legend of Zelda, The - Majora's Mask (USA)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Legend of Zelda, The - Majora's Mask (USA)</description>
-		<release name="Legend of Zelda, The - Majora's Mask (USA)" region="USA"/>
-		<rom name="Legend of Zelda, The - Majora's Mask (USA).z64" size="33554432" crc="b428d8a7" md5="2a0a8acb61538235bc1094d297fb6556" sha1="d6133ace5afaa0882cf214cf88daba39e266c078" status="verified"/>
+		<rom name="Legend of Zelda, The - Majora's Mask (USA).n64" />
+		<release name="Legend of Zelda, The - Majora's Mask (USA)" region="USA" />
+		<rom name="Legend of Zelda, The - Majora's Mask (USA).z64" size="33554432" crc="b428d8a7" md5="2a0a8acb61538235bc1094d297fb6556" sha1="d6133ace5afaa0882cf214cf88daba39e266c078" status="verified" />
 	</game>
 	<game name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk).z64" size="33554432" crc="dcc110a0" md5="8f281800fba5ddcb1d2b377731fc0215" sha1="2f0744f2422b0421697a74b305cb1ef27041ab11"/>
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (Demo) (Kiosk).z64" size="33554432" crc="dcc110a0" md5="8f281800fba5ddcb1d2b377731fc0215" sha1="2f0744f2422b0421697a74b305cb1ef27041ab11" />
 	</game>
 	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug).z64" size="67108864" crc="04ea55ea" md5="02f963fa8f95e3a7f0b6c13d81999ba9" sha1="55541662a192c66e34a011d4bf6f4a0ec69899ae"/>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Debug).z64" size="67108864" crc="04ea55ea" md5="02f963fa8f95e3a7f0b6c13d81999ba9" sha1="55541662a192c66e34a011d4bf6f4a0ec69899ae" />
 	</game>
 	<game name="Legend of Zelda, The - Majora's Mask (USA) (GameCube)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Legend of Zelda, The - Majora's Mask (USA) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (USA) (GameCube).z64" size="33554432" crc="b008458f" md5="ac0751dbc23ab2ec0c3144203aca0003" sha1="9743aa026e9269b339eb0e3044cd5830a440c1fd" status="verified"/>
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (USA) (GameCube).z64" size="33554432" crc="b008458f" md5="ac0751dbc23ab2ec0c3144203aca0003" sha1="9743aa026e9269b339eb0e3044cd5830a440c1fd" status="verified" />
 	</game>
 	<game name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Legend of Zelda, The - Majora's Mask (Europe) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube).z64" size="33554432" crc="12836e19" md5="dbe9af0db46256e42b5c67902b696549" sha1="a849a65e56d57d4dd98b550524150f898df90a9f"/>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (GameCube).z64" size="33554432" crc="12836e19" md5="dbe9af0db46256e42b5c67902b696549" sha1="a849a65e56d57d4dd98b550524150f898df90a9f" />
 	</game>
 	<game name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console)</description>
-		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console).z64" size="33554432" crc="a83abf72" md5="609b47b79da21f3df9b31d06c95c09a1" sha1="c487db55c2c3a97ccd39ded13ef9fd9121dae729"/>
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console).n64" />
+		<rom name="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1) (Wii Virtual Console).z64" size="33554432" crc="a83abf72" md5="609b47b79da21f3df9b31d06c95c09a1" sha1="c487db55c2c3a97ccd39ded13ef9fd9121dae729" />
 	</game>
 	<game name="Zelda no Densetsu - Mujura no Kamen (Japan)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Zelda no Densetsu - Mujura no Kamen (Japan)</description>
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan).z64" size="33554432" crc="0d33e1db" md5="15d1a2217cad61c39cfecbffa0703e25" sha1="5fb2301aacbf85278af30dca3e4194ad48599e36" status="verified"/>
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan).n64" />
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan).z64" size="33554432" crc="0d33e1db" md5="15d1a2217cad61c39cfecbffa0703e25" sha1="5fb2301aacbf85278af30dca3e4194ad48599e36" status="verified" />
 	</game>
 	<game name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)</description>
-		<release name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1).z64" size="33554432" crc="356c2e19" md5="c38a7f6f6b61862ea383a75cdf888279" sha1="41fdb879ab422ec158b4eafea69087f255ea8589" status="verified"/>
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1).n64" />
+		<release name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1)" region="JPN" />
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (Rev 1).z64" size="33554432" crc="356c2e19" md5="c38a7f6f6b61862ea383a75cdf888279" sha1="41fdb879ab422ec158b4eafea69087f255ea8589" status="verified" />
 	</game>
 	<game name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube)" cloneof="Legend of Zelda, The - Majora's Mask (Europe) (En,Fr,De,Es) (Rev 1)">
 		<description>Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube)</description>
-		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube).z64" size="33554432" crc="b9bf76df" md5="d3929aadf7640f8c5b4ce8321ad4393a" sha1="1438fd501e3e5b25461770af88c02ab1e41d3a7e"/>
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube).n64" />
+		<rom name="Zelda no Densetsu - Mujura no Kamen (Japan) (GameCube).z64" size="33554432" crc="b9bf76df" md5="d3929aadf7640f8c5b4ce8321ad4393a" sha1="1438fd501e3e5b25461770af88c02ab1e41d3a7e" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)</description>
-		<release name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)" region="EUR"/>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1).z64" size="33554432" crc="a108f6e3" md5="d714580dd74c2c033f5e1b6dc0aeac77" sha1="cfbb98d392e4a9d39da8285d10cbef3974c2f012" status="verified"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1).n64" />
+		<release name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)" region="EUR" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1).z64" size="33554432" crc="a108f6e3" md5="d714580dd74c2c033f5e1b6dc0aeac77" sha1="cfbb98d392e4a9d39da8285d10cbef3974c2f012" status="verified" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).z64" size="33554432" crc="946fd0f7" md5="e040de91a74b61e3201db0e2323f768a" sha1="328a1f1beba30ce5e178f031662019eb32c5f3b5" status="verified"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De).z64" size="33554432" crc="946fd0f7" md5="e040de91a74b61e3201db0e2323f768a" sha1="328a1f1beba30ce5e178f031662019eb32c5f3b5" status="verified" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (USA)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (USA)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA).z64" size="33554432" crc="cd16c529" md5="5bd1fe107bf8106b2ab6650abecd54d6" sha1="ad69c91157f6705e8ab06c79fe08aad47bb57ba7"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA).z64" size="33554432" crc="cd16c529" md5="5bd1fe107bf8106b2ab6650abecd54d6" sha1="ad69c91157f6705e8ab06c79fe08aad47bb57ba7" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (USA) (Rev 1)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1).z64" size="33554432" crc="3fd2151e" md5="721fdcc6f5f34be55c43a807f2a16af4" sha1="d3ecb253776cd847a5aa63d859d8c89a2f37b364" status="verified"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 1).z64" size="33554432" crc="3fd2151e" md5="721fdcc6f5f34be55c43a807f2a16af4" sha1="d3ecb253776cd847a5aa63d859d8c89a2f37b364" status="verified" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)</description>
-		<release name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)" region="USA"/>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2).z64" size="33554432" crc="32120c23" md5="57a9719ad547c516342e1a15d5c28c3d" sha1="41b3bdc48d98c48529219919015a1af22f5057c2" status="verified"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2).n64" />
+		<release name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2)" region="USA" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Rev 2).z64" size="33554432" crc="32120c23" md5="57a9719ad547c516342e1a15d5c28c3d" sha1="41b3bdc48d98c48529219919015a1af22f5057c2" status="verified" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (USA) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube).z64" size="33554432" crc="346de3ae" md5="cd09029edcfb7c097ac01986a0f83d3f" sha1="b82710ba2bd3b4c6ee8aa1a7e9acf787dfc72e9b" status="verified"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (GameCube).z64" size="33554432" crc="346de3ae" md5="cd09029edcfb7c097ac01986a0f83d3f" sha1="b82710ba2bd3b4c6ee8aa1a7e9acf787dfc72e9b" status="verified" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (Europe) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube).z64" size="33554432" crc="3fbd519f" md5="2c27b4e000e85fd78dbca551f1b1c965" sha1="0227d7c0074f2d0ac935631990da8ec5914597b4"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (GameCube).z64" size="33554432" crc="3fbd519f" md5="2c27b4e000e85fd78dbca551f1b1c965" sha1="0227d7c0074f2d0ac935631990da8ec5914597b4" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube).z64" size="67108864" crc="5d1b2996" md5="3c10b67a76616ae2c162def7528724cf" sha1="cee6bc3c2a634b41728f2af8da54d9bf8cc14099"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Debug) (GameCube).z64" size="67108864" crc="5d1b2996" md5="3c10b67a76616ae2c162def7528724cf" sha1="cee6bc3c2a634b41728f2af8da54d9bf8cc14099" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (USA) (Beta)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (USA) (Beta)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Beta).z64" size="33554432" crc="6c348aa8" md5="21f7b4a4ff463464bfc23498c1ab9da1" sha1="70537a3144c8813b115252c40065c117cb139dcd"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Beta).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (USA) (Beta).z64" size="33554432" crc="6c348aa8" md5="21f7b4a4ff463464bfc23498c1ab9da1" sha1="70537a3144c8813b115252c40065c117cb139dcd" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube).z64" size="67108864" crc="c188acda" md5="ab1ca59d0039e3b34d82db650b54d7b9" sha1="da19ca4aac723c155d55ae371107b8462044e350"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time (Europe) (Beta) (2003-02-13) (GameCube).z64" size="67108864" crc="c188acda" md5="ab1ca59d0039e3b34d82db650b54d7b9" sha1="da19ca4aac723c155d55ae371107b8462044e350" />
 	</game>
 	<game name="Zelda Chuanshuo Shiguang Zhi Di (China) (iQue)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Zelda Chuanshuo Shiguang Zhi Di (China) (iQue)</description>
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (iQue).z64" size="29868032" crc="f45c5532" md5="0ab48b2d44a74b3bb2d384f6170c2742" sha1="1015d0f3af34b89149bfd773580bbc66466af54e"/>
+		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (iQue).n64" />
+		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (iQue).z64" size="29868032" crc="f45c5532" md5="0ab48b2d44a74b3bb2d384f6170c2742" sha1="1015d0f3af34b89149bfd773580bbc66466af54e" />
 	</game>
 	<game name="Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue)</description>
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue).z64" size="29868032" crc="e8e3575f" md5="a475e9f8615513666a265c464708ae8f" sha1="8668469647423735cc05f55a479c9d3135fbf838"/>
+		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue).n64" />
+		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (Chinese Traditional) (iQue).z64" size="29868032" crc="e8e3575f" md5="a475e9f8615513666a265c464708ae8f" sha1="8668469647423735cc05f55a479c9d3135fbf838" />
 	</game>
 	<game name="Zelda no Densetsu - Toki no Ocarina (Japan)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Zelda no Densetsu - Toki no Ocarina (Japan)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan).z64" size="33554432" crc="d423e8b0" md5="9f04c8e68534b870f707c247fa4b50fc" sha1="c892bbda3993e66bd0d56a10ecd30b1ee612210f"/>
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan).z64" size="33554432" crc="d423e8b0" md5="9f04c8e68534b870f707c247fa4b50fc" sha1="c892bbda3993e66bd0d56a10ecd30b1ee612210f" />
 	</game>
 	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1).z64" size="33554432" crc="26e73887" md5="1bf5f42b98c3e97948f01155f12e2d88" sha1="dbfc81f655187dc6fefd93fa6798face770d579d" status="verified"/>
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 1).z64" size="33554432" crc="26e73887" md5="1bf5f42b98c3e97948f01155f12e2d88" sha1="dbfc81f655187dc6fefd93fa6798face770d579d" status="verified" />
 	</game>
 	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)</description>
-		<release name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)" region="JPN"/>
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2).z64" size="33554432" crc="2b2721ba" md5="2258052847bdd056c8406a9ef6427f13" sha1="fa5f5942b27480d60243c2d52c0e93e26b9e6b86" status="verified"/>
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2).n64" />
+		<release name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2)" region="JPN" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (Rev 2).z64" size="33554432" crc="2b2721ba" md5="2258052847bdd056c8406a9ef6427f13" sha1="fa5f5942b27480d60243c2d52c0e93e26b9e6b86" status="verified" />
 	</game>
 	<game name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection).z64" size="33554432" crc="8c5b90c1" md5="0c13e0449a28ea5b925cdb8af8d29768" sha1="2ce2d1a9f0534c9cd9fa04ea5317b80da21e5e73"/>
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina (Japan) (GameCube, Zelda Collection).z64" size="33554432" crc="8c5b90c1" md5="0c13e0449a28ea5b925cdb8af8d29768" sha1="2ce2d1a9f0534c9cd9fa04ea5317b80da21e5e73" />
 	</game>
 	<game name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time (Europe) (En,Fr,De) (Rev 1)">
 		<description>Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube)</description>
-		<rom name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube).z64" size="33554432" crc="1c6ce8cb" md5="33fb7852c180b18ea0b9620b630f413f" sha1="0769c84615422d60f16925cd859593cdfa597f84"/>
+		<rom name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube).n64" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina GC (Japan) (GameCube).z64" size="33554432" crc="1c6ce8cb" md5="33fb7852c180b18ea0b9620b630f413f" sha1="0769c84615422d60f16925cd859593cdfa597f84" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)">
 		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)</description>
-		<release name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)" region="EUR"/>
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube).z64" size="33554432" crc="832d6449" md5="1618403427e4344a57833043db5ce3c3" sha1="f46239439f59a2a594ef83cf68ef65043b1bffe2"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube).n64" />
+		<release name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)" region="EUR" />
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube).z64" size="33554432" crc="832d6449" md5="1618403427e4344a57833043db5ce3c3" sha1="f46239439f59a2a594ef83cf68ef65043b1bffe2" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)">
 		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube)</description>
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube).z64" size="67108864" crc="62f92704" md5="8ca71e87de4ce5e9f6ec916202a623e9" sha1="50bebedad9e0f10746a52b07239e47fa6c284d03"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube).n64" />
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (Debug) (GameCube).z64" size="67108864" crc="62f92704" md5="8ca71e87de4ce5e9f6ec916202a623e9" sha1="50bebedad9e0f10746a52b07239e47fa6c284d03" />
 	</game>
 	<game name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)">
 		<description>Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)</description>
-		<release name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)" region="USA"/>
-		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube).z64" size="33554432" crc="c744c4db" md5="da35577fe54579f6a266931cc75f512d" sha1="8b5d13aac69bfbf989861cfdc50b1d840945fc1d"/>
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube).n64" />
+		<release name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube)" region="USA" />
+		<rom name="Legend of Zelda, The - Ocarina of Time - Master Quest (USA) (GameCube).z64" size="33554432" crc="c744c4db" md5="da35577fe54579f6a266931cc75f512d" sha1="8b5d13aac69bfbf989861cfdc50b1d840945fc1d" />
 	</game>
 	<game name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)" cloneof="Legend of Zelda, The - Ocarina of Time - Master Quest (Europe) (GameCube)">
 		<description>Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)</description>
-		<release name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)" region="JPN"/>
-		<rom name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube).z64" size="33554432" crc="122ff261" md5="69895c5c78442260f6eafb2506dc482a" sha1="dd14e143c4275861fe93ea79d0c02e36ae8c6c2f"/>
+		<rom name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube).n64" />
+		<release name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube)" region="JPN" />
+		<rom name="Zelda no Densetsu - Toki no Ocarina GC Ura (Japan) (GameCube).z64" size="33554432" crc="122ff261" md5="69895c5c78442260f6eafb2506dc482a" sha1="dd14e143c4275861fe93ea79d0c02e36ae8c6c2f" />
 	</game>
 	<game name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)">
 		<description>LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)</description>
-		<release name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" region="EUR"/>
-		<rom name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).z64" size="16777216" crc="c7d9b21c" md5="6310c7173385ed2b06020f3b90158e9e" sha1="6e9c4b097628f0147e9e79393dba6d7b4e59986f"/>
+		<rom name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" />
+		<release name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" region="EUR" />
+		<rom name="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).z64" size="16777216" crc="c7d9b21c" md5="6310c7173385ed2b06020f3b90158e9e" sha1="6e9c4b097628f0147e9e79393dba6d7b4e59986f" />
 	</game>
 	<game name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" cloneof="LEGO Racers (Europe) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)">
 		<description>LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)</description>
-		<release name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" region="USA"/>
-		<rom name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).z64" size="16777216" crc="4d1e1897" md5="26b5eaa13dc5b5e35307fe8c0cf5b6ba" sha1="8decc41869926e20da2eb3da526e6395aa33cece"/>
+		<rom name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).n64" />
+		<release name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi)" region="USA" />
+		<rom name="LEGO Racers (USA) (En,Fr,De,Es,It,Nl,Sv,No,Da,Fi).z64" size="16777216" crc="4d1e1897" md5="26b5eaa13dc5b5e35307fe8c0cf5b6ba" sha1="8decc41869926e20da2eb3da526e6395aa33cece" />
 	</game>
 	<game name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)">
 		<description>Lode Runner 3-D (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="7148251d" md5="e62f4fdcc82c244ba9709e40756d9b62" sha1="3b198c0117da808b25fbc4e543d282228bb4780a"/>
+		<rom name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Lode Runner 3-D (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="7148251d" md5="e62f4fdcc82c244ba9709e40756d9b62" sha1="3b198c0117da808b25fbc4e543d282228bb4780a" />
 	</game>
 	<game name="Lode Runner 3-D (Japan)" cloneof="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)">
 		<description>Lode Runner 3-D (Japan)</description>
-		<release name="Lode Runner 3-D (Japan)" region="JPN"/>
-		<rom name="Lode Runner 3-D (Japan).z64" size="8388608" crc="1d4fb466" md5="d2bd8dd8c3be1e8f0b8ae49206dbd7e5" sha1="a115c19e1dea438861437a326124c0e7a482de3b"/>
+		<rom name="Lode Runner 3-D (Japan).n64" />
+		<release name="Lode Runner 3-D (Japan)" region="JPN" />
+		<rom name="Lode Runner 3-D (Japan).z64" size="8388608" crc="1d4fb466" md5="d2bd8dd8c3be1e8f0b8ae49206dbd7e5" sha1="a115c19e1dea438861437a326124c0e7a482de3b" />
 	</game>
 	<game name="Lode Runner 3-D (USA)" cloneof="Lode Runner 3-D (Europe) (En,Fr,De,Es,It)">
 		<description>Lode Runner 3-D (USA)</description>
-		<release name="Lode Runner 3-D (USA)" region="USA"/>
-		<rom name="Lode Runner 3-D (USA).z64" size="8388608" crc="4ea07453" md5="d038813541589f0b3f1f900f4fd22c9b" sha1="d3a13c0cfdff835fdf87d5dc7c5149fba564877f"/>
+		<rom name="Lode Runner 3-D (USA).n64" />
+		<release name="Lode Runner 3-D (USA)" region="USA" />
+		<rom name="Lode Runner 3-D (USA).z64" size="8388608" crc="4ea07453" md5="d038813541589f0b3f1f900f4fd22c9b" sha1="d3a13c0cfdff835fdf87d5dc7c5149fba564877f" />
 	</game>
 	<game name="Lylatwars (Europe) (En,Fr,De)">
 		<description>Lylatwars (Europe) (En,Fr,De)</description>
-		<release name="Lylatwars (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Lylatwars (Europe) (En,Fr,De).z64" size="12582912" crc="50a9c0b1" md5="884ccca35cbeedb8ed288326f9662100" sha1="05b307b8804f992af1a1e2fbafbd588501fdf799" status="verified"/>
+		<rom name="Lylatwars (Europe) (En,Fr,De).n64" />
+		<release name="Lylatwars (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Lylatwars (Europe) (En,Fr,De).z64" size="12582912" crc="50a9c0b1" md5="884ccca35cbeedb8ed288326f9662100" sha1="05b307b8804f992af1a1e2fbafbd588501fdf799" status="verified" />
 	</game>
 	<game name="Lylat Wars (Australia) (En,Fr,De)" cloneof="Lylatwars (Europe) (En,Fr,De)">
 		<description>Lylat Wars (Australia) (En,Fr,De)</description>
-		<release name="Lylat Wars (Australia) (En,Fr,De)" region="AUS"/>
-		<rom name="Lylat Wars (Australia) (En,Fr,De).z64" size="12582912" crc="9a3425da" md5="7a99628edf0a6602d0c408f31b701435" sha1="47a8ccc11450f9044ca2292b9fc3c58949b9caac"/>
+		<rom name="Lylat Wars (Australia) (En,Fr,De).n64" />
+		<release name="Lylat Wars (Australia) (En,Fr,De)" region="AUS" />
+		<rom name="Lylat Wars (Australia) (En,Fr,De).z64" size="12582912" crc="9a3425da" md5="7a99628edf0a6602d0c408f31b701435" sha1="47a8ccc11450f9044ca2292b9fc3c58949b9caac" />
 	</game>
 	<game name="Star Fox 64 (Japan)" cloneof="Lylatwars (Europe) (En,Fr,De)">
 		<description>Star Fox 64 (Japan)</description>
-		<release name="Star Fox 64 (Japan)" region="JPN"/>
-		<rom name="Star Fox 64 (Japan).z64" size="12582912" crc="411142a7" md5="446d5215c4d34eb8ab0f355f324b8d0e" sha1="9bd71afbecf4d0a43146e4e7a893395e19bf3220" status="verified"/>
+		<rom name="Star Fox 64 (Japan).n64" />
+		<release name="Star Fox 64 (Japan)" region="JPN" />
+		<rom name="Star Fox 64 (Japan).z64" size="12582912" crc="411142a7" md5="446d5215c4d34eb8ab0f355f324b8d0e" sha1="9bd71afbecf4d0a43146e4e7a893395e19bf3220" status="verified" />
 	</game>
 	<game name="Star Fox 64 (USA)" cloneof="Lylatwars (Europe) (En,Fr,De)">
 		<description>Star Fox 64 (USA)</description>
-		<rom name="Star Fox 64 (USA).z64" size="12582912" crc="b1fcaa9c" md5="caf9a78db13ee00002ff63a3c0c5eabb" sha1="d8b1088520f7c5f81433292a9258c1184afa1457" status="verified"/>
+		<rom name="Star Fox 64 (USA).n64" />
+		<rom name="Star Fox 64 (USA).z64" size="12582912" crc="b1fcaa9c" md5="caf9a78db13ee00002ff63a3c0c5eabb" sha1="d8b1088520f7c5f81433292a9258c1184afa1457" status="verified" />
 	</game>
 	<game name="Star Fox 64 (USA) (Rev 1)" cloneof="Lylatwars (Europe) (En,Fr,De)">
 		<description>Star Fox 64 (USA) (Rev 1)</description>
-		<release name="Star Fox 64 (USA) (Rev 1)" region="USA"/>
-		<rom name="Star Fox 64 (USA) (Rev 1).z64" size="12582912" crc="b1b5fc46" md5="741a94eee093c4c8684e66b89f8685e8" sha1="09f0d105f476b00efa5303a3ebc42e60a7753b7a" status="verified"/>
+		<rom name="Star Fox 64 (USA) (Rev 1).n64" />
+		<release name="Star Fox 64 (USA) (Rev 1)" region="USA" />
+		<rom name="Star Fox 64 (USA) (Rev 1).z64" size="12582912" crc="b1b5fc46" md5="741a94eee093c4c8684e66b89f8685e8" sha1="09f0d105f476b00efa5303a3ebc42e60a7753b7a" status="verified" />
 	</game>
 	<game name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console)" cloneof="Lylatwars (Europe) (En,Fr,De)">
 		<description>Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console)</description>
-		<rom name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console).z64" size="12582912" crc="6508d4ad" md5="91fc4c63ca613530df22c8bb810cb2c3" sha1="a39f14f0d1224095717fabc021023203cb7561d5"/>
+		<rom name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console).n64" />
+		<rom name="Star Fox 64 (Japan) (Rev 1) (Wii Virtual Console).z64" size="12582912" crc="6508d4ad" md5="91fc4c63ca613530df22c8bb810cb2c3" sha1="a39f14f0d1224095717fabc021023203cb7561d5" />
 	</game>
 	<game name="Xingji Huohu (China) (v5) (iQue)" cloneof="Lylatwars (Europe) (En,Fr,De)">
 		<description>Xingji Huohu (China) (v5) (iQue)</description>
-		<rom name="Xingji Huohu (China) (v5) (iQue).z64" size="11829248" crc="0d28c3ed" md5="b2242070800bf82e78ce33dc92a1db84" sha1="c8a10699dea52f4bb2e2311935c1376dfb352e7a"/>
+		<rom name="Xingji Huohu (China) (v5) (iQue).n64" />
+		<rom name="Xingji Huohu (China) (v5) (iQue).z64" size="11829248" crc="0d28c3ed" md5="b2242070800bf82e78ce33dc92a1db84" sha1="c8a10699dea52f4bb2e2311935c1376dfb352e7a" />
 	</game>
 	<game name="Mace - The Dark Age (Europe)">
 		<description>Mace - The Dark Age (Europe)</description>
-		<release name="Mace - The Dark Age (Europe)" region="EUR"/>
-		<rom name="Mace - The Dark Age (Europe).z64" size="12582912" crc="57ddede1" md5="523883a766c662e8377cd256755b27b4" sha1="19fc1fe13a3c50a5d03d44d2e93440967c7f3618"/>
+		<rom name="Mace - The Dark Age (Europe).n64" />
+		<release name="Mace - The Dark Age (Europe)" region="EUR" />
+		<rom name="Mace - The Dark Age (Europe).z64" size="12582912" crc="57ddede1" md5="523883a766c662e8377cd256755b27b4" sha1="19fc1fe13a3c50a5d03d44d2e93440967c7f3618" />
 	</game>
 	<game name="Mace - The Dark Age (USA)" cloneof="Mace - The Dark Age (Europe)">
 		<description>Mace - The Dark Age (USA)</description>
-		<release name="Mace - The Dark Age (USA)" region="USA"/>
-		<rom name="Mace - The Dark Age (USA).z64" size="12582912" crc="d2a363a6" md5="39a2bca1c17cd4cf1a9f3ae2b725b5c6" sha1="05d82a2c73ac536180b68137dbb9972a9e8e883e"/>
+		<rom name="Mace - The Dark Age (USA).n64" />
+		<release name="Mace - The Dark Age (USA)" region="USA" />
+		<rom name="Mace - The Dark Age (USA).z64" size="12582912" crc="d2a363a6" md5="39a2bca1c17cd4cf1a9f3ae2b725b5c6" sha1="05d82a2c73ac536180b68137dbb9972a9e8e883e" />
 	</game>
 	<game name="Mace - The Dark Age (Unknown) (Beta)" cloneof="Mace - The Dark Age (Europe)">
 		<description>Mace - The Dark Age (Unknown) (Beta)</description>
-		<rom name="Mace - The Dark Age (Unknown) (Beta).z64" size="13144800" crc="2b23212f" md5="3eb81ab11b8c58305a64ce06817d0538" sha1="c515895faaa5ebf0d043d285aaf51046b5e28b8f"/>
+		<rom name="Mace - The Dark Age (Unknown) (Beta).n64" />
+		<rom name="Mace - The Dark Age (Unknown) (Beta).z64" size="13144800" crc="2b23212f" md5="3eb81ab11b8c58305a64ce06817d0538" sha1="c515895faaa5ebf0d043d285aaf51046b5e28b8f" />
 	</game>
 	<game name="Madden Football 64 (Europe)">
 		<description>Madden Football 64 (Europe)</description>
-		<release name="Madden Football 64 (Europe)" region="EUR"/>
-		<rom name="Madden Football 64 (Europe).z64" size="12582912" crc="fab3e50d" md5="67c96076459eb5f71733f39d7fcc76a3" sha1="acf22b715b11609f42df24abac143bc0221d12f4"/>
+		<rom name="Madden Football 64 (Europe).n64" />
+		<release name="Madden Football 64 (Europe)" region="EUR" />
+		<rom name="Madden Football 64 (Europe).z64" size="12582912" crc="fab3e50d" md5="67c96076459eb5f71733f39d7fcc76a3" sha1="acf22b715b11609f42df24abac143bc0221d12f4" />
 	</game>
 	<game name="Madden Football 64 (USA)" cloneof="Madden Football 64 (Europe)">
 		<description>Madden Football 64 (USA)</description>
-		<release name="Madden Football 64 (USA)" region="USA"/>
-		<rom name="Madden Football 64 (USA).z64" size="12582912" crc="42e5fafa" md5="903b912ce88626900221731224e9dbe8" sha1="b0de34b759f18ad86d39a4c68c9840d35ce25809"/>
+		<rom name="Madden Football 64 (USA).n64" />
+		<release name="Madden Football 64 (USA)" region="USA" />
+		<rom name="Madden Football 64 (USA).z64" size="12582912" crc="42e5fafa" md5="903b912ce88626900221731224e9dbe8" sha1="b0de34b759f18ad86d39a4c68c9840d35ce25809" />
 	</game>
 	<game name="Madden NFL 2000 (USA)">
 		<description>Madden NFL 2000 (USA)</description>
-		<release name="Madden NFL 2000 (USA)" region="USA"/>
-		<rom name="Madden NFL 2000 (USA).z64" size="12582912" crc="ef5f997b" md5="955d19e26b4ba7cc941f86a54a0fc13d" sha1="ec01de96960ea23a9ee997f4456c5c8ee7baf7e4"/>
+		<rom name="Madden NFL 2000 (USA).n64" />
+		<release name="Madden NFL 2000 (USA)" region="USA" />
+		<rom name="Madden NFL 2000 (USA).z64" size="12582912" crc="ef5f997b" md5="955d19e26b4ba7cc941f86a54a0fc13d" sha1="ec01de96960ea23a9ee997f4456c5c8ee7baf7e4" />
 	</game>
 	<game name="Madden NFL 2001 (USA)">
 		<description>Madden NFL 2001 (USA)</description>
-		<release name="Madden NFL 2001 (USA)" region="USA"/>
-		<rom name="Madden NFL 2001 (USA).z64" size="12582912" crc="245eaee8" md5="441fa65faa5c12339f89a0bb7db43c8f" sha1="93f5ba646098e1aa45ecec6312604a0932edd24b"/>
+		<rom name="Madden NFL 2001 (USA).n64" />
+		<release name="Madden NFL 2001 (USA)" region="USA" />
+		<rom name="Madden NFL 2001 (USA).z64" size="12582912" crc="245eaee8" md5="441fa65faa5c12339f89a0bb7db43c8f" sha1="93f5ba646098e1aa45ecec6312604a0932edd24b" />
 	</game>
 	<game name="Madden NFL 2002 (USA)">
 		<description>Madden NFL 2002 (USA)</description>
-		<release name="Madden NFL 2002 (USA)" region="USA"/>
-		<rom name="Madden NFL 2002 (USA).z64" size="12582912" crc="f573f107" md5="ad0f2ec565d7575fb37512bc8df8a092" sha1="de51147a238158adc059d0cc75fd39bbb08dcfc6"/>
+		<rom name="Madden NFL 2002 (USA).n64" />
+		<release name="Madden NFL 2002 (USA)" region="USA" />
+		<rom name="Madden NFL 2002 (USA).z64" size="12582912" crc="f573f107" md5="ad0f2ec565d7575fb37512bc8df8a092" sha1="de51147a238158adc059d0cc75fd39bbb08dcfc6" />
 	</game>
 	<game name="Madden NFL 99 (Europe)">
 		<description>Madden NFL 99 (Europe)</description>
-		<release name="Madden NFL 99 (Europe)" region="EUR"/>
-		<rom name="Madden NFL 99 (Europe).z64" size="12582912" crc="d0929942" md5="e7bf80861a0ab2a788959463d953b5d5" sha1="7c55ba6741dcf96208432507b8191b3c15f666df"/>
+		<rom name="Madden NFL 99 (Europe).n64" />
+		<release name="Madden NFL 99 (Europe)" region="EUR" />
+		<rom name="Madden NFL 99 (Europe).z64" size="12582912" crc="d0929942" md5="e7bf80861a0ab2a788959463d953b5d5" sha1="7c55ba6741dcf96208432507b8191b3c15f666df" />
 	</game>
 	<game name="Madden NFL 99 (USA)" cloneof="Madden NFL 99 (Europe)">
 		<description>Madden NFL 99 (USA)</description>
-		<rom name="Madden NFL 99 (USA).z64" size="12582912" crc="2eb64fc2" md5="507ceab72ef2a1bf145bf190f5ce1c80" sha1="2e8595c6ea0267a0344c0e203b4b08f00a42b13a"/>
+		<rom name="Madden NFL 99 (USA).n64" />
+		<rom name="Madden NFL 99 (USA).z64" size="12582912" crc="2eb64fc2" md5="507ceab72ef2a1bf145bf190f5ce1c80" sha1="2e8595c6ea0267a0344c0e203b4b08f00a42b13a" />
 	</game>
 	<game name="Madden NFL 99 (USA) (Beta) (1998-08-05)" cloneof="Madden NFL 99 (Europe)">
 		<description>Madden NFL 99 (USA) (Beta) (1998-08-05)</description>
-		<rom name="Madden NFL 99 (USA) (Beta) (1998-08-05).z64" size="16777216" crc="033a2ca6" md5="5f3d42d5f96191f3ce50d70e0e42127a" sha1="80236fc4ce2bb95de513f3b2be74acec9da4804c"/>
+		<rom name="Madden NFL 99 (USA) (Beta) (1998-08-05).n64" />
+		<rom name="Madden NFL 99 (USA) (Beta) (1998-08-05).z64" size="16777216" crc="033a2ca6" md5="5f3d42d5f96191f3ce50d70e0e42127a" sha1="80236fc4ce2bb95de513f3b2be74acec9da4804c" />
 	</game>
 	<game name="Madden NFL 99 (USA) (Rev 1)" cloneof="Madden NFL 99 (Europe)">
 		<description>Madden NFL 99 (USA) (Rev 1)</description>
-		<release name="Madden NFL 99 (USA) (Rev 1)" region="USA"/>
-		<rom name="Madden NFL 99 (USA) (Rev 1).z64" size="12582912" crc="56769a44" md5="5ad80a8ef44dee1fdc456d66104165b4" sha1="68c0c53489b790568acb1d863b74b89975db4a62"/>
+		<rom name="Madden NFL 99 (USA) (Rev 1).n64" />
+		<release name="Madden NFL 99 (USA) (Rev 1)" region="USA" />
+		<rom name="Madden NFL 99 (USA) (Rev 1).z64" size="12582912" crc="56769a44" md5="5ad80a8ef44dee1fdc456d66104165b4" sha1="68c0c53489b790568acb1d863b74b89975db4a62" />
 	</game>
 	<game name="Magical Tetris Challenge (Europe)">
 		<description>Magical Tetris Challenge (Europe)</description>
-		<release name="Magical Tetris Challenge (Europe)" region="EUR"/>
-		<rom name="Magical Tetris Challenge (Europe).z64" size="16777216" crc="af3b099e" md5="20e51b27e8098a9d101b44689014c281" sha1="ecc73f8a0a530ee42a56b46611da6f74b728fe7d"/>
+		<rom name="Magical Tetris Challenge (Europe).n64" />
+		<release name="Magical Tetris Challenge (Europe)" region="EUR" />
+		<rom name="Magical Tetris Challenge (Europe).z64" size="16777216" crc="af3b099e" md5="20e51b27e8098a9d101b44689014c281" sha1="ecc73f8a0a530ee42a56b46611da6f74b728fe7d" />
 	</game>
 	<game name="Defi au Tetris Magique (France)" cloneof="Magical Tetris Challenge (Europe)">
 		<description>Defi au Tetris Magique (France)</description>
-		<release name="Defi au Tetris Magique (France)" region="FRA"/>
-		<rom name="Defi au Tetris Magique (France).z64" size="16777216" crc="e7ef60e8" md5="c644e318b33c4ebd94695c0c3e1e80ff" sha1="e5c79cf80ae1c19d2cb7136600ec8bd2cceae934"/>
+		<rom name="Defi au Tetris Magique (France).n64" />
+		<release name="Defi au Tetris Magique (France)" region="FRA" />
+		<rom name="Defi au Tetris Magique (France).z64" size="16777216" crc="e7ef60e8" md5="c644e318b33c4ebd94695c0c3e1e80ff" sha1="e5c79cf80ae1c19d2cb7136600ec8bd2cceae934" />
 	</game>
 	<game name="Magical Tetris Challenge (Germany)" cloneof="Magical Tetris Challenge (Europe)">
 		<description>Magical Tetris Challenge (Germany)</description>
-		<release name="Magical Tetris Challenge (Germany)" region="GER"/>
-		<rom name="Magical Tetris Challenge (Germany).z64" size="16777216" crc="377f18e9" md5="e0992a90191be4f1b2ba02258599334e" sha1="ace81319209d50d074418934554cbfb261d27288"/>
+		<rom name="Magical Tetris Challenge (Germany).n64" />
+		<release name="Magical Tetris Challenge (Germany)" region="GER" />
+		<rom name="Magical Tetris Challenge (Germany).z64" size="16777216" crc="377f18e9" md5="e0992a90191be4f1b2ba02258599334e" sha1="ace81319209d50d074418934554cbfb261d27288" />
 	</game>
 	<game name="Magical Tetris Challenge (USA)" cloneof="Magical Tetris Challenge (Europe)">
 		<description>Magical Tetris Challenge (USA)</description>
-		<release name="Magical Tetris Challenge (USA)" region="USA"/>
-		<rom name="Magical Tetris Challenge (USA).z64" size="16777216" crc="22fe979c" md5="79fcc98002d1f4c79deaf55784222df8" sha1="ca3fbd17406031a88e04bb79959d851550b641d0"/>
+		<rom name="Magical Tetris Challenge (USA).n64" />
+		<release name="Magical Tetris Challenge (USA)" region="USA" />
+		<rom name="Magical Tetris Challenge (USA).z64" size="16777216" crc="22fe979c" md5="79fcc98002d1f4c79deaf55784222df8" sha1="ca3fbd17406031a88e04bb79959d851550b641d0" />
 	</game>
 	<game name="Magical Tetris Challenge featuring Mickey (Japan)" cloneof="Magical Tetris Challenge (Europe)">
 		<description>Magical Tetris Challenge featuring Mickey (Japan)</description>
-		<release name="Magical Tetris Challenge featuring Mickey (Japan)" region="JPN"/>
-		<rom name="Magical Tetris Challenge featuring Mickey (Japan).z64" size="16777216" crc="7efb2f1e" md5="f1ff1f364c459701f42beb8989675d44" sha1="fe7c8fa25ea09280f94d08623bb8838d88eec2e3"/>
+		<rom name="Magical Tetris Challenge featuring Mickey (Japan).n64" />
+		<release name="Magical Tetris Challenge featuring Mickey (Japan)" region="JPN" />
+		<rom name="Magical Tetris Challenge featuring Mickey (Japan).z64" size="16777216" crc="7efb2f1e" md5="f1ff1f364c459701f42beb8989675d44" sha1="fe7c8fa25ea09280f94d08623bb8838d88eec2e3" />
 	</game>
 	<game name="Mahjong 64 (Japan)">
 		<description>Mahjong 64 (Japan)</description>
-		<release name="Mahjong 64 (Japan)" region="JPN"/>
-		<rom name="Mahjong 64 (Japan).z64" size="8388608" crc="dbe7d51a" md5="8ae2e8f0c356fee638c8d908dcbb3381" sha1="41c73c372ff316322593b791d09934b37c461f9f"/>
+		<rom name="Mahjong 64 (Japan).n64" />
+		<release name="Mahjong 64 (Japan)" region="JPN" />
+		<rom name="Mahjong 64 (Japan).z64" size="8388608" crc="dbe7d51a" md5="8ae2e8f0c356fee638c8d908dcbb3381" sha1="41c73c372ff316322593b791d09934b37c461f9f" />
 	</game>
 	<game name="Mahjong Hourouki Classic (Japan)">
 		<description>Mahjong Hourouki Classic (Japan)</description>
-		<release name="Mahjong Hourouki Classic (Japan)" region="JPN"/>
-		<rom name="Mahjong Hourouki Classic (Japan).z64" size="12582912" crc="990a8e54" md5="e942a3eeb1eb572badd6f705eb12a22c" sha1="405e6bcb6ad4a1452fe50aac1278a3f411c378c0"/>
+		<rom name="Mahjong Hourouki Classic (Japan).n64" />
+		<release name="Mahjong Hourouki Classic (Japan)" region="JPN" />
+		<rom name="Mahjong Hourouki Classic (Japan).z64" size="12582912" crc="990a8e54" md5="e942a3eeb1eb572badd6f705eb12a22c" sha1="405e6bcb6ad4a1452fe50aac1278a3f411c378c0" />
 	</game>
 	<game name="Mahjong Master (Japan)">
 		<description>Mahjong Master (Japan)</description>
-		<release name="Mahjong Master (Japan)" region="JPN"/>
-		<rom name="Mahjong Master (Japan).z64" size="8388608" crc="b68d596f" md5="cf0d228e8efdf823a227979bb352dd5b" sha1="556dd6dbbec02680e47362552d2babd4f8720050"/>
+		<rom name="Mahjong Master (Japan).n64" />
+		<release name="Mahjong Master (Japan)" region="JPN" />
+		<rom name="Mahjong Master (Japan).z64" size="8388608" crc="b68d596f" md5="cf0d228e8efdf823a227979bb352dd5b" sha1="556dd6dbbec02680e47362552d2babd4f8720050" />
 	</game>
 	<game name="Major League Baseball Featuring Ken Griffey Jr. (USA)">
 		<description>Major League Baseball Featuring Ken Griffey Jr. (USA)</description>
-		<release name="Major League Baseball Featuring Ken Griffey Jr. (USA)" region="USA"/>
-		<rom name="Major League Baseball Featuring Ken Griffey Jr. (USA).z64" size="16777216" crc="2ef1ea20" md5="764f22ad3d0f59667a7f083d2f789b31" sha1="54b8c97523089d92754c2582a7b7a43246947122"/>
+		<rom name="Major League Baseball Featuring Ken Griffey Jr. (USA).n64" />
+		<release name="Major League Baseball Featuring Ken Griffey Jr. (USA)" region="USA" />
+		<rom name="Major League Baseball Featuring Ken Griffey Jr. (USA).z64" size="16777216" crc="2ef1ea20" md5="764f22ad3d0f59667a7f083d2f789b31" sha1="54b8c97523089d92754c2582a7b7a43246947122" />
 	</game>
 	<game name="Major League Baseball Featuring Ken Griffey Jr. (Australia)" cloneof="Major League Baseball Featuring Ken Griffey Jr. (USA)">
 		<description>Major League Baseball Featuring Ken Griffey Jr. (Australia)</description>
-		<release name="Major League Baseball Featuring Ken Griffey Jr. (Australia)" region="AUS"/>
-		<rom name="Major League Baseball Featuring Ken Griffey Jr. (Australia).z64" size="16777216" crc="e08f7578" md5="152b9939a5f50734d5401980028856b4" sha1="e300e8acb110d72bc5bfee4fc4981e09b881300e"/>
+		<rom name="Major League Baseball Featuring Ken Griffey Jr. (Australia).n64" />
+		<release name="Major League Baseball Featuring Ken Griffey Jr. (Australia)" region="AUS" />
+		<rom name="Major League Baseball Featuring Ken Griffey Jr. (Australia).z64" size="16777216" crc="e08f7578" md5="152b9939a5f50734d5401980028856b4" sha1="e300e8acb110d72bc5bfee4fc4981e09b881300e" />
 	</game>
 	<game name="Mario Golf (Europe)">
 		<description>Mario Golf (Europe)</description>
-		<release name="Mario Golf (Europe)" region="EUR"/>
-		<rom name="Mario Golf (Europe).z64" size="33554432" crc="a5071a77" md5="55634ff90ee997790781f79a5b0097ee" sha1="a3f057212e134c411258837271db8a08a6a7921e" status="verified"/>
+		<rom name="Mario Golf (Europe).n64" />
+		<release name="Mario Golf (Europe)" region="EUR" />
+		<rom name="Mario Golf (Europe).z64" size="33554432" crc="a5071a77" md5="55634ff90ee997790781f79a5b0097ee" sha1="a3f057212e134c411258837271db8a08a6a7921e" status="verified" />
 	</game>
 	<game name="Mario Golf (USA)" cloneof="Mario Golf (Europe)">
 		<description>Mario Golf (USA)</description>
-		<release name="Mario Golf (USA)" region="USA"/>
-		<rom name="Mario Golf (USA).z64" size="33554432" crc="2fc4c216" md5="903e6929666531d72d05d1e4c522e305" sha1="e2c4e7a905b29529b49a1619a401fe699224829b"/>
+		<rom name="Mario Golf (USA).n64" />
+		<release name="Mario Golf (USA)" region="USA" />
+		<rom name="Mario Golf (USA).z64" size="33554432" crc="2fc4c216" md5="903e6929666531d72d05d1e4c522e305" sha1="e2c4e7a905b29529b49a1619a401fe699224829b" />
 	</game>
 	<game name="Mario Golf 64 (Japan)" cloneof="Mario Golf (Europe)">
 		<description>Mario Golf 64 (Japan)</description>
-		<rom name="Mario Golf 64 (Japan).z64" size="33554432" crc="bb03a1a6" md5="cd87ba2998d63c13b4366eb2c54e1eb6" sha1="1e2c5b63298cd3e8ee5e5f1ebba93c3d6fcb27df"/>
+		<rom name="Mario Golf 64 (Japan).n64" />
+		<rom name="Mario Golf 64 (Japan).z64" size="33554432" crc="bb03a1a6" md5="cd87ba2998d63c13b4366eb2c54e1eb6" sha1="1e2c5b63298cd3e8ee5e5f1ebba93c3d6fcb27df" />
 	</game>
 	<game name="Mario Golf 64 (Japan) (Rev 1)" cloneof="Mario Golf (Europe)">
 		<description>Mario Golf 64 (Japan) (Rev 1)</description>
-		<release name="Mario Golf 64 (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Mario Golf 64 (Japan) (Rev 1).z64" size="33554432" crc="ad1758ac" md5="570b4f55a3005b709e6ed5d625981b90" sha1="ef0984fe1b9f925b31d74bb8fe65b6660095ed4e" status="verified"/>
+		<rom name="Mario Golf 64 (Japan) (Rev 1).n64" />
+		<release name="Mario Golf 64 (Japan) (Rev 1)" region="JPN" />
+		<rom name="Mario Golf 64 (Japan) (Rev 1).z64" size="33554432" crc="ad1758ac" md5="570b4f55a3005b709e6ed5d625981b90" sha1="ef0984fe1b9f925b31d74bb8fe65b6660095ed4e" status="verified" />
 	</game>
 	<game name="Mario Kadingche (China) (v6) (iQue) (Manual)">
 		<description>Mario Kadingche (China) (v6) (iQue) (Manual)</description>
-		<release name="Mario Kadingche (China) (v6) (iQue) (Manual)" region="CHN"/>
-		<rom name="Mario Kadingche (China) (v6) (iQue) (Manual).z64" size="425984" crc="abdbf9f4" md5="76176b237d4f60e59f98d247283d9365" sha1="b966688b8c5e2c8d70c91ec0a1caeeaa519c6170"/>
+		<rom name="Mario Kadingche (China) (v6) (iQue) (Manual).n64" />
+		<release name="Mario Kadingche (China) (v6) (iQue) (Manual)" region="CHN" />
+		<rom name="Mario Kadingche (China) (v6) (iQue) (Manual).z64" size="425984" crc="abdbf9f4" md5="76176b237d4f60e59f98d247283d9365" sha1="b966688b8c5e2c8d70c91ec0a1caeeaa519c6170" />
 	</game>
 	<game name="Mario Kadingche (China) (v2) (iQue) (Manual)" cloneof="Mario Kadingche (China) (v6) (iQue) (Manual)">
 		<description>Mario Kadingche (China) (v2) (iQue) (Manual)</description>
-		<rom name="Mario Kadingche (China) (v2) (iQue) (Manual).z64" size="245760" crc="1ad7f15b" md5="c70af6197e67b310f316c34cced64c19" sha1="d600d06eab14f9d54957b19832120ec3ee515b95"/>
+		<rom name="Mario Kadingche (China) (v2) (iQue) (Manual).n64" />
+		<rom name="Mario Kadingche (China) (v2) (iQue) (Manual).z64" size="245760" crc="1ad7f15b" md5="c70af6197e67b310f316c34cced64c19" sha1="d600d06eab14f9d54957b19832120ec3ee515b95" />
 	</game>
 	<game name="Mario Kart 64 (Europe) (Rev 1)">
 		<description>Mario Kart 64 (Europe) (Rev 1)</description>
-		<release name="Mario Kart 64 (Europe) (Rev 1)" region="EUR"/>
-		<rom name="Mario Kart 64 (Europe) (Rev 1).z64" size="12582912" crc="0248f6c3" md5="2bb149a583fdefea96805f628fe42fd9" sha1="f6b5f519dd57ea59e9f013cc64816e9d273b2329" status="verified"/>
+		<rom name="Mario Kart 64 (Europe) (Rev 1).n64" />
+		<release name="Mario Kart 64 (Europe) (Rev 1)" region="EUR" />
+		<rom name="Mario Kart 64 (Europe) (Rev 1).z64" size="12582912" crc="0248f6c3" md5="2bb149a583fdefea96805f628fe42fd9" sha1="f6b5f519dd57ea59e9f013cc64816e9d273b2329" status="verified" />
 	</game>
 	<game name="Mario Kadingche (China) (v4) (iQue)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
 		<description>Mario Kadingche (China) (v4) (iQue)</description>
-		<rom name="Mario Kadingche (China) (v4) (iQue).z64" size="12533760" crc="ea0813c7" md5="78771beb349d481e69baa9225b36d63a" sha1="219660d0a321fc200ac4295dd79fd3417da3eea8"/>
+		<rom name="Mario Kadingche (China) (v4) (iQue).n64" />
+		<rom name="Mario Kadingche (China) (v4) (iQue).z64" size="12533760" crc="ea0813c7" md5="78771beb349d481e69baa9225b36d63a" sha1="219660d0a321fc200ac4295dd79fd3417da3eea8" />
 	</game>
 	<game name="Mario Kadingche (China) (v5) (iQue)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
 		<description>Mario Kadingche (China) (v5) (iQue)</description>
-		<rom name="Mario Kadingche (China) (v5) (iQue).z64" size="12533760" crc="47e69f28" md5="5ea0ed74cf1ddaaa964d728a129e7cf9" sha1="d6605879918b0dca3eafa1c75ecbc850a3b2535d"/>
+		<rom name="Mario Kadingche (China) (v5) (iQue).n64" />
+		<rom name="Mario Kadingche (China) (v5) (iQue).z64" size="12533760" crc="47e69f28" md5="5ea0ed74cf1ddaaa964d728a129e7cf9" sha1="d6605879918b0dca3eafa1c75ecbc850a3b2535d" />
 	</game>
 	<game name="Mario Kart 64 (Europe)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
 		<description>Mario Kart 64 (Europe)</description>
-		<rom name="Mario Kart 64 (Europe).z64" size="12582912" crc="faa6b083" md5="8fad1e4fa7baf1443b7f21ad1947b429" sha1="a729039453210b84f17019dda3f248d5888f7690"/>
+		<rom name="Mario Kart 64 (Europe).n64" />
+		<rom name="Mario Kart 64 (Europe).z64" size="12582912" crc="faa6b083" md5="8fad1e4fa7baf1443b7f21ad1947b429" sha1="a729039453210b84f17019dda3f248d5888f7690" />
 	</game>
 	<game name="Mario Kart 64 (Japan)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
 		<description>Mario Kart 64 (Japan)</description>
-		<rom name="Mario Kart 64 (Japan).z64" size="12582912" crc="5d9696df" md5="bf964ceca78a13a82055ebda80b95cca" sha1="afeeec65b9a03f0cb8ec92f9ba7a9f0122e8bd0e"/>
+		<rom name="Mario Kart 64 (Japan).n64" />
+		<rom name="Mario Kart 64 (Japan).z64" size="12582912" crc="5d9696df" md5="bf964ceca78a13a82055ebda80b95cca" sha1="afeeec65b9a03f0cb8ec92f9ba7a9f0122e8bd0e" />
 	</game>
 	<game name="Mario Kart 64 (Japan) (Rev 1)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
 		<description>Mario Kart 64 (Japan) (Rev 1)</description>
-		<release name="Mario Kart 64 (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Mario Kart 64 (Japan) (Rev 1).z64" size="12582912" crc="6ced6472" md5="60535265bae43ddfcbdb0d71594b1693" sha1="9f439457585146a4e1da7e1dd9104f7f94381688" status="verified"/>
+		<rom name="Mario Kart 64 (Japan) (Rev 1).n64" />
+		<release name="Mario Kart 64 (Japan) (Rev 1)" region="JPN" />
+		<rom name="Mario Kart 64 (Japan) (Rev 1).z64" size="12582912" crc="6ced6472" md5="60535265bae43ddfcbdb0d71594b1693" sha1="9f439457585146a4e1da7e1dd9104f7f94381688" status="verified" />
 	</game>
 	<game name="Mario Kart 64 (USA)" cloneof="Mario Kart 64 (Europe) (Rev 1)">
 		<description>Mario Kart 64 (USA)</description>
-		<release name="Mario Kart 64 (USA)" region="USA"/>
-		<rom name="Mario Kart 64 (USA).z64" size="12582912" crc="434389c1" md5="3a67d9986f54eb282924fca4cd5f6dff" sha1="579c48e211ae952530ffc8738709f078d5dd215e" status="verified"/>
+		<rom name="Mario Kart 64 (USA).n64" />
+		<release name="Mario Kart 64 (USA)" region="USA" />
+		<rom name="Mario Kart 64 (USA).z64" size="12582912" crc="434389c1" md5="3a67d9986f54eb282924fca4cd5f6dff" sha1="579c48e211ae952530ffc8738709f078d5dd215e" status="verified" />
 	</game>
 	<game name="Mario no Photopie (Japan)">
 		<description>Mario no Photopie (Japan)</description>
-		<release name="Mario no Photopie (Japan)" region="JPN"/>
-		<rom name="Mario no Photopie (Japan).z64" size="16777216" crc="176b3683" md5="7f4ed2aaf94a2197b0ad63c6ece9dea9" sha1="3d591ea869696f067913308886edea544b77ed3f"/>
+		<rom name="Mario no Photopie (Japan).n64" />
+		<release name="Mario no Photopie (Japan)" region="JPN" />
+		<rom name="Mario no Photopie (Japan).z64" size="16777216" crc="176b3683" md5="7f4ed2aaf94a2197b0ad63c6ece9dea9" sha1="3d591ea869696f067913308886edea544b77ed3f" />
 	</game>
 	<game name="Mario Party (Europe) (En,Fr,De)">
 		<description>Mario Party (Europe) (En,Fr,De)</description>
-		<release name="Mario Party (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Mario Party (Europe) (En,Fr,De).z64" size="33554432" crc="da98a5d3" md5="9773150709bd804b8e57e35f1d6b0eed" sha1="d7ba071c220a71f5e4503e55c98c91ff8f027848"/>
+		<rom name="Mario Party (Europe) (En,Fr,De).n64" />
+		<release name="Mario Party (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Mario Party (Europe) (En,Fr,De).z64" size="33554432" crc="da98a5d3" md5="9773150709bd804b8e57e35f1d6b0eed" sha1="d7ba071c220a71f5e4503e55c98c91ff8f027848" />
 	</game>
 	<game name="Mario Party (Japan)" cloneof="Mario Party (Europe) (En,Fr,De)">
 		<description>Mario Party (Japan)</description>
-		<release name="Mario Party (Japan)" region="JPN"/>
-		<rom name="Mario Party (Japan).z64" size="33554432" crc="4f1adc7b" md5="3f556cc3b3a996cd2f471fa0d992d529" sha1="37fd6d27f55c468dc36efb92a255f7ab04ffc0a8"/>
+		<rom name="Mario Party (Japan).n64" />
+		<release name="Mario Party (Japan)" region="JPN" />
+		<rom name="Mario Party (Japan).z64" size="33554432" crc="4f1adc7b" md5="3f556cc3b3a996cd2f471fa0d992d529" sha1="37fd6d27f55c468dc36efb92a255f7ab04ffc0a8" />
 	</game>
 	<game name="Mario Party (USA)" cloneof="Mario Party (Europe) (En,Fr,De)">
 		<description>Mario Party (USA)</description>
-		<release name="Mario Party (USA)" region="USA"/>
-		<rom name="Mario Party (USA).z64" size="33554432" crc="4d60abe5" md5="8bc2712139fbf0c56c8ea835802c52dc" sha1="1159bd56730094bfc71be30113e1cfc8bacf34f3" status="verified"/>
+		<rom name="Mario Party (USA).n64" />
+		<release name="Mario Party (USA)" region="USA" />
+		<rom name="Mario Party (USA).z64" size="33554432" crc="4d60abe5" md5="8bc2712139fbf0c56c8ea835802c52dc" sha1="1159bd56730094bfc71be30113e1cfc8bacf34f3" status="verified" />
 	</game>
 	<game name="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
 		<description>Mario Party 2 (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Mario Party 2 (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="dc00357a" md5="f70112b652b0ee4856af83f4e8005c31" sha1="fa5d1426488b298a1c5c383360a78f1a3de18dc7" status="verified"/>
+		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Mario Party 2 (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="dc00357a" md5="f70112b652b0ee4856af83f4e8005c31" sha1="fa5d1426488b298a1c5c383360a78f1a3de18dc7" status="verified" />
 	</game>
 	<game name="Mario Party 2 (Japan)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
 		<description>Mario Party 2 (Japan)</description>
-		<release name="Mario Party 2 (Japan)" region="JPN"/>
-		<rom name="Mario Party 2 (Japan).z64" size="33554432" crc="7457b081" md5="f23e4cd437465f3e725262253cf3ea59" sha1="26f4637167aaaa0e420bb4fdb26a965fd34f8d19"/>
+		<rom name="Mario Party 2 (Japan).n64" />
+		<release name="Mario Party 2 (Japan)" region="JPN" />
+		<rom name="Mario Party 2 (Japan).z64" size="33554432" crc="7457b081" md5="f23e4cd437465f3e725262253cf3ea59" sha1="26f4637167aaaa0e420bb4fdb26a965fd34f8d19" />
 	</game>
 	<game name="Mario Party 2 (USA)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
 		<description>Mario Party 2 (USA)</description>
-		<release name="Mario Party 2 (USA)" region="USA"/>
-		<rom name="Mario Party 2 (USA).z64" size="33554432" crc="e58a1955" md5="04840612a35ece222afdb2dfbf926409" sha1="166eda1c05670d337e2c3f15a5db528ae1e5d6e3"/>
+		<rom name="Mario Party 2 (USA).n64" />
+		<release name="Mario Party 2 (USA)" region="USA" />
+		<rom name="Mario Party 2 (USA).z64" size="33554432" crc="e58a1955" md5="04840612a35ece222afdb2dfbf926409" sha1="166eda1c05670d337e2c3f15a5db528ae1e5d6e3" />
 	</game>
 	<game name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
 		<description>Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console)</description>
-		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console).z64" size="33554432" crc="dca66040" md5="4a834d275abf14a6255aa11be81e339d" sha1="3db98872699002f3e9fb82cf9a3f79f1b52e2a51"/>
+		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console).n64" />
+		<rom name="Mario Party 2 (Europe) (En,Fr,De,Es,It) (Wii Virtual Console).z64" size="33554432" crc="dca66040" md5="4a834d275abf14a6255aa11be81e339d" sha1="3db98872699002f3e9fb82cf9a3f79f1b52e2a51" />
 	</game>
 	<game name="Mario Party 2 (Japan) (Wii Virtual Console)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
 		<description>Mario Party 2 (Japan) (Wii Virtual Console)</description>
-		<rom name="Mario Party 2 (Japan) (Wii Virtual Console).z64" size="33554432" crc="fdc89220" md5="9e25ffe8fb0931f67b4e42c5f74ecbc0" sha1="3da1dfddf2117830b9f43c006970c9d78d0f1b6a"/>
+		<rom name="Mario Party 2 (Japan) (Wii Virtual Console).n64" />
+		<rom name="Mario Party 2 (Japan) (Wii Virtual Console).z64" size="33554432" crc="fdc89220" md5="9e25ffe8fb0931f67b4e42c5f74ecbc0" sha1="3da1dfddf2117830b9f43c006970c9d78d0f1b6a" />
 	</game>
 	<game name="Mario Party 2 (USA) (Wii Virtual Console)" cloneof="Mario Party 2 (Europe) (En,Fr,De,Es,It)">
 		<description>Mario Party 2 (USA) (Wii Virtual Console)</description>
-		<rom name="Mario Party 2 (USA) (Wii Virtual Console).z64" size="33554432" crc="6f45853e" md5="54765a3b1dcc6eb3c29c1891958da5e2" sha1="6b950ea20edcfc2b0c30ef3eef0da5aad628f9fa"/>
+		<rom name="Mario Party 2 (USA) (Wii Virtual Console).n64" />
+		<rom name="Mario Party 2 (USA) (Wii Virtual Console).z64" size="33554432" crc="6f45853e" md5="54765a3b1dcc6eb3c29c1891958da5e2" sha1="6b950ea20edcfc2b0c30ef3eef0da5aad628f9fa" />
 	</game>
 	<game name="Mario Party 3 (Europe) (En,Fr,De,Es)">
 		<description>Mario Party 3 (Europe) (En,Fr,De,Es)</description>
-		<release name="Mario Party 3 (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Mario Party 3 (Europe) (En,Fr,De,Es).z64" size="33554432" crc="813b13f2" md5="8e62ec6fbe3cc9ff6284191c9c88e68f" sha1="9e1ddfe872c6d43ae51010a9e8a6fe2d2e634b50"/>
+		<rom name="Mario Party 3 (Europe) (En,Fr,De,Es).n64" />
+		<release name="Mario Party 3 (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Mario Party 3 (Europe) (En,Fr,De,Es).z64" size="33554432" crc="813b13f2" md5="8e62ec6fbe3cc9ff6284191c9c88e68f" sha1="9e1ddfe872c6d43ae51010a9e8a6fe2d2e634b50" />
 	</game>
 	<game name="Mario Party 3 (Japan)" cloneof="Mario Party 3 (Europe) (En,Fr,De,Es)">
 		<description>Mario Party 3 (Japan)</description>
-		<release name="Mario Party 3 (Japan)" region="JPN"/>
-		<rom name="Mario Party 3 (Japan).z64" size="33554432" crc="3fc04053" md5="ed99f330ce7a2638ab13351012eeb86b" sha1="43cf5eb8bd68ef57ba1c9b4cae7bd18f1826e543"/>
+		<rom name="Mario Party 3 (Japan).n64" />
+		<release name="Mario Party 3 (Japan)" region="JPN" />
+		<rom name="Mario Party 3 (Japan).z64" size="33554432" crc="3fc04053" md5="ed99f330ce7a2638ab13351012eeb86b" sha1="43cf5eb8bd68ef57ba1c9b4cae7bd18f1826e543" />
 	</game>
 	<game name="Mario Party 3 (USA)" cloneof="Mario Party 3 (Europe) (En,Fr,De,Es)">
 		<description>Mario Party 3 (USA)</description>
-		<release name="Mario Party 3 (USA)" region="USA"/>
-		<rom name="Mario Party 3 (USA).z64" size="33554432" crc="b7445ddc" md5="76a8bbc81bc2060ec99c9645867237cc" sha1="6beb80ff822b96bcf85dcdb512e8b2b7969d8259"/>
+		<rom name="Mario Party 3 (USA).n64" />
+		<release name="Mario Party 3 (USA)" region="USA" />
+		<rom name="Mario Party 3 (USA).z64" size="33554432" crc="b7445ddc" md5="76a8bbc81bc2060ec99c9645867237cc" sha1="6beb80ff822b96bcf85dcdb512e8b2b7969d8259" />
 	</game>
 	<game name="Mario Tennis (Europe)">
 		<description>Mario Tennis (Europe)</description>
-		<release name="Mario Tennis (Europe)" region="EUR"/>
-		<rom name="Mario Tennis (Europe).z64" size="16777216" crc="29aa5df4" md5="fff9b3e22abb9b60215dafb13ad5a4de" sha1="b5e4aa1abf8fc8022fc47f30cd6d4ac6a6b21684"/>
+		<rom name="Mario Tennis (Europe).n64" />
+		<release name="Mario Tennis (Europe)" region="EUR" />
+		<rom name="Mario Tennis (Europe).z64" size="16777216" crc="29aa5df4" md5="fff9b3e22abb9b60215dafb13ad5a4de" sha1="b5e4aa1abf8fc8022fc47f30cd6d4ac6a6b21684" />
 	</game>
 	<game name="Mario Tennis (USA)" cloneof="Mario Tennis (Europe)">
 		<description>Mario Tennis (USA)</description>
-		<release name="Mario Tennis (USA)" region="USA"/>
-		<rom name="Mario Tennis (USA).z64" size="16777216" crc="4e9560f6" md5="759358fad1ed5ae31dcb2001a07f2fe5" sha1="999047f07cec931ffbdcc7b33b8502ef602807ee"/>
+		<rom name="Mario Tennis (USA).n64" />
+		<release name="Mario Tennis (USA)" region="USA" />
+		<rom name="Mario Tennis (USA).z64" size="16777216" crc="4e9560f6" md5="759358fad1ed5ae31dcb2001a07f2fe5" sha1="999047f07cec931ffbdcc7b33b8502ef602807ee" />
 	</game>
 	<game name="Mario Tennis (Europe) (Wii Virtual Console)" cloneof="Mario Tennis (Europe)">
 		<description>Mario Tennis (Europe) (Wii Virtual Console)</description>
-		<rom name="Mario Tennis (Europe) (Wii Virtual Console).z64" size="16777216" crc="e9ba8e6b" md5="d40fb0e87996af902eff9c194027fc3b" sha1="e1f1ec3bb2deea60ebea05a846c2ef4e5ce5d90f"/>
+		<rom name="Mario Tennis (Europe) (Wii Virtual Console).n64" />
+		<rom name="Mario Tennis (Europe) (Wii Virtual Console).z64" size="16777216" crc="e9ba8e6b" md5="d40fb0e87996af902eff9c194027fc3b" sha1="e1f1ec3bb2deea60ebea05a846c2ef4e5ce5d90f" />
 	</game>
 	<game name="Mario Tennis (USA) (Wii Virtual Console)" cloneof="Mario Tennis (Europe)">
 		<description>Mario Tennis (USA) (Wii Virtual Console)</description>
-		<rom name="Mario Tennis (USA) (Wii Virtual Console).z64" size="16777216" crc="8e85b369" md5="4731025e850faf8c0500dc04e1a3bff2" sha1="36bcbb5b9b5592d05482ac677a0c54df51b122a1"/>
+		<rom name="Mario Tennis (USA) (Wii Virtual Console).n64" />
+		<rom name="Mario Tennis (USA) (Wii Virtual Console).z64" size="16777216" crc="8e85b369" md5="4731025e850faf8c0500dc04e1a3bff2" sha1="36bcbb5b9b5592d05482ac677a0c54df51b122a1" />
 	</game>
 	<game name="Mario Tennis 64 (Japan)" cloneof="Mario Tennis (Europe)">
 		<description>Mario Tennis 64 (Japan)</description>
-		<release name="Mario Tennis 64 (Japan)" region="JPN"/>
-		<rom name="Mario Tennis 64 (Japan).z64" size="16777216" crc="c665301d" md5="8eb1c2443d0b2e6eda52a4eea66d6c35" sha1="8aa424795bbe87c659f777d0843e236340b12e16" status="verified"/>
+		<rom name="Mario Tennis 64 (Japan).n64" />
+		<release name="Mario Tennis 64 (Japan)" region="JPN" />
+		<rom name="Mario Tennis 64 (Japan).z64" size="16777216" crc="c665301d" md5="8eb1c2443d0b2e6eda52a4eea66d6c35" sha1="8aa424795bbe87c659f777d0843e236340b12e16" status="verified" />
 	</game>
 	<game name="Mario Tennis 64 (Japan) (Wii Virtual Console)" cloneof="Mario Tennis (Europe)">
 		<description>Mario Tennis 64 (Japan) (Wii Virtual Console)</description>
-		<rom name="Mario Tennis 64 (Japan) (Wii Virtual Console).z64" size="16777216" crc="32c58af3" md5="137a4e7dd0485edccb3bf598b1472d11" sha1="c188e98c6c7f4aae5d7efa2d0d4720e08f96d9b9"/>
+		<rom name="Mario Tennis 64 (Japan) (Wii Virtual Console).n64" />
+		<rom name="Mario Tennis 64 (Japan) (Wii Virtual Console).z64" size="16777216" crc="32c58af3" md5="137a4e7dd0485edccb3bf598b1472d11" sha1="c188e98c6c7f4aae5d7efa2d0d4720e08f96d9b9" />
 	</game>
 	<game name="Mario Yisheng (China) (v4) (iQue) (Manual)">
 		<description>Mario Yisheng (China) (v4) (iQue) (Manual)</description>
-		<release name="Mario Yisheng (China) (v4) (iQue) (Manual)" region="CHN"/>
-		<rom name="Mario Yisheng (China) (v4) (iQue) (Manual).z64" size="393216" crc="84a5f66c" md5="b524d10a8a26764eb2198acec3f09948" sha1="4c74e74f8af2a6ae4110aba7dbe542f8add9b61a"/>
+		<rom name="Mario Yisheng (China) (v4) (iQue) (Manual).n64" />
+		<release name="Mario Yisheng (China) (v4) (iQue) (Manual)" region="CHN" />
+		<rom name="Mario Yisheng (China) (v4) (iQue) (Manual).z64" size="393216" crc="84a5f66c" md5="b524d10a8a26764eb2198acec3f09948" sha1="4c74e74f8af2a6ae4110aba7dbe542f8add9b61a" />
 	</game>
 	<game name="Mario Yisheng (China) (v2) (iQue) (Manual)" cloneof="Mario Yisheng (China) (v4) (iQue) (Manual)">
 		<description>Mario Yisheng (China) (v2) (iQue) (Manual)</description>
-		<rom name="Mario Yisheng (China) (v2) (iQue) (Manual).z64" size="294912" crc="b862a4fe" md5="fe49420725f9c1cf0f15ba5682d27709" sha1="72e8e15a281b9fc81269f6ebc7ab3be3adeee508"/>
+		<rom name="Mario Yisheng (China) (v2) (iQue) (Manual).n64" />
+		<rom name="Mario Yisheng (China) (v2) (iQue) (Manual).z64" size="294912" crc="b862a4fe" md5="fe49420725f9c1cf0f15ba5682d27709" sha1="72e8e15a281b9fc81269f6ebc7ab3be3adeee508" />
 	</game>
 	<game name="Mega Man 64 (USA)">
 		<description>Mega Man 64 (USA)</description>
-		<release name="Mega Man 64 (USA)" region="USA"/>
-		<rom name="Mega Man 64 (USA).z64" size="33554432" crc="1bfc71f0" md5="3620674acb51e436d5150738ac1c0969" sha1="f24fe0aff01aec018e2dd558ec4f076cf328129f"/>
+		<rom name="Mega Man 64 (USA).n64" />
+		<release name="Mega Man 64 (USA)" region="USA" />
+		<rom name="Mega Man 64 (USA).z64" size="33554432" crc="1bfc71f0" md5="3620674acb51e436d5150738ac1c0969" sha1="f24fe0aff01aec018e2dd558ec4f076cf328129f" />
 	</game>
 	<game name="Mega Man 64 (USA) (Beta)" cloneof="Mega Man 64 (USA)">
 		<description>Mega Man 64 (USA) (Beta)</description>
-		<rom name="Mega Man 64 (USA) (Beta).z64" size="67108864" crc="d3562b57" md5="cd0824e9405185af434837ba1c8c0cd5" sha1="7fc1db2b88cd43a5e76697ee449bc946e9a48c03"/>
+		<rom name="Mega Man 64 (USA) (Beta).n64" />
+		<rom name="Mega Man 64 (USA) (Beta).z64" size="67108864" crc="d3562b57" md5="cd0824e9405185af434837ba1c8c0cd5" sha1="7fc1db2b88cd43a5e76697ee449bc946e9a48c03" />
 	</game>
 	<game name="Rockman Dash - Hagane no Boukenshin (Japan)" cloneof="Mega Man 64 (USA)">
 		<description>Rockman Dash - Hagane no Boukenshin (Japan)</description>
-		<release name="Rockman Dash - Hagane no Boukenshin (Japan)" region="JPN"/>
-		<rom name="Rockman Dash - Hagane no Boukenshin (Japan).z64" size="33554432" crc="61eaee83" md5="0c74b44680276ffe808cfa6045329819" sha1="e807ed78db0b3440f76b445bf989a943bc05e0ad"/>
+		<rom name="Rockman Dash - Hagane no Boukenshin (Japan).n64" />
+		<release name="Rockman Dash - Hagane no Boukenshin (Japan)" region="JPN" />
+		<rom name="Rockman Dash - Hagane no Boukenshin (Japan).z64" size="33554432" crc="61eaee83" md5="0c74b44680276ffe808cfa6045329819" sha1="e807ed78db0b3440f76b445bf989a943bc05e0ad" />
 	</game>
 	<game name="Michael Owen's WLS 2000 (Europe)">
 		<description>Michael Owen's WLS 2000 (Europe)</description>
-		<release name="Michael Owen's WLS 2000 (Europe)" region="EUR"/>
-		<rom name="Michael Owen's WLS 2000 (Europe).z64" size="16777216" crc="bb680cbe" md5="892222cc4baf9958405d20bc492175bf" sha1="f629a56ed36fb3889841a047d7c4cd2b9731eb43"/>
+		<rom name="Michael Owen's WLS 2000 (Europe).n64" />
+		<release name="Michael Owen's WLS 2000 (Europe)" region="EUR" />
+		<rom name="Michael Owen's WLS 2000 (Europe).z64" size="16777216" crc="bb680cbe" md5="892222cc4baf9958405d20bc492175bf" sha1="f629a56ed36fb3889841a047d7c4cd2b9731eb43" />
 	</game>
 	<game name="Mia Hamm Soccer 64 (USA) (En,Es)" cloneof="Michael Owen's WLS 2000 (Europe)">
 		<description>Mia Hamm Soccer 64 (USA) (En,Es)</description>
-		<release name="Mia Hamm Soccer 64 (USA) (En,Es)" region="USA"/>
-		<rom name="Mia Hamm Soccer 64 (USA) (En,Es).z64" size="16777216" crc="2db3d3d6" md5="a4039368e0472c68e3072c02c7a80f94" sha1="62ce9d1c1f4cf7beaa1ef7c456c155f63f13f057"/>
+		<rom name="Mia Hamm Soccer 64 (USA) (En,Es).n64" />
+		<release name="Mia Hamm Soccer 64 (USA) (En,Es)" region="USA" />
+		<rom name="Mia Hamm Soccer 64 (USA) (En,Es).z64" size="16777216" crc="2db3d3d6" md5="a4039368e0472c68e3072c02c7a80f94" sha1="62ce9d1c1f4cf7beaa1ef7c456c155f63f13f057" />
 	</game>
 	<game name="RTL World League Soccer 2000 (Germany)" cloneof="Michael Owen's WLS 2000 (Europe)">
 		<description>RTL World League Soccer 2000 (Germany)</description>
-		<release name="RTL World League Soccer 2000 (Germany)" region="GER"/>
-		<rom name="RTL World League Soccer 2000 (Germany).z64" size="16777216" crc="0a17da7b" md5="a1082a6676455c040843fd75e92de1a3" sha1="a68294e47c82639c9bcdae1b7306ac2a2e2f47b5"/>
+		<rom name="RTL World League Soccer 2000 (Germany).n64" />
+		<release name="RTL World League Soccer 2000 (Germany)" region="GER" />
+		<rom name="RTL World League Soccer 2000 (Germany).z64" size="16777216" crc="0a17da7b" md5="a1082a6676455c040843fd75e92de1a3" sha1="a68294e47c82639c9bcdae1b7306ac2a2e2f47b5" />
 	</game>
 	<game name="Telefoot Soccer 2000 (France)" cloneof="Michael Owen's WLS 2000 (Europe)">
 		<description>Telefoot Soccer 2000 (France)</description>
-		<release name="Telefoot Soccer 2000 (France)" region="FRA"/>
-		<rom name="Telefoot Soccer 2000 (France).z64" size="16777216" crc="7bd20931" md5="7f244aff8d729417e32b6a5b299afda5" sha1="ffc1f3271929b0e7d6467fdcbed9e0ccf2eba0a5"/>
+		<rom name="Telefoot Soccer 2000 (France).n64" />
+		<release name="Telefoot Soccer 2000 (France)" region="FRA" />
+		<rom name="Telefoot Soccer 2000 (France).z64" size="16777216" crc="7bd20931" md5="7f244aff8d729417e32b6a5b299afda5" sha1="ffc1f3271929b0e7d6467fdcbed9e0ccf2eba0a5" />
 	</game>
 	<game name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)">
 		<description>Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="0ae51ea5" md5="5ba3dc37860c08a209f24286b8dfec8c" sha1="c583ed998a6b422a22ffd3f8376c3cef0c3710d9"/>
+		<rom name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="0ae51ea5" md5="5ba3dc37860c08a209f24286b8dfec8c" sha1="c583ed998a6b422a22ffd3f8376c3cef0c3710d9" />
 	</game>
 	<game name="Mickey no Racing Challenge USA (Japan)" cloneof="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)">
 		<description>Mickey no Racing Challenge USA (Japan)</description>
-		<release name="Mickey no Racing Challenge USA (Japan)" region="JPN"/>
-		<rom name="Mickey no Racing Challenge USA (Japan).z64" size="33554432" crc="1aecfc56" md5="288a514e98972bf9d329167aa29e66b6" sha1="5b4f7bad6591de2199c095352a811a2eb7fc6f53"/>
+		<rom name="Mickey no Racing Challenge USA (Japan).n64" />
+		<release name="Mickey no Racing Challenge USA (Japan)" region="JPN" />
+		<rom name="Mickey no Racing Challenge USA (Japan).z64" size="33554432" crc="1aecfc56" md5="288a514e98972bf9d329167aa29e66b6" sha1="5b4f7bad6591de2199c095352a811a2eb7fc6f53" />
 	</game>
 	<game name="Mickey's Speedway USA (USA)" cloneof="Mickey's Speedway USA (Europe) (En,Fr,De,Es,It)">
 		<description>Mickey's Speedway USA (USA)</description>
-		<release name="Mickey's Speedway USA (USA)" region="USA"/>
-		<rom name="Mickey's Speedway USA (USA).z64" size="33554432" crc="2d4f8f1b" md5="0bf64427cf68e49c70e9ec2c9d815209" sha1="507341c0a40ca3e9a7cee969b396ee53facfb548" status="verified"/>
+		<rom name="Mickey's Speedway USA (USA).n64" />
+		<release name="Mickey's Speedway USA (USA)" region="USA" />
+		<rom name="Mickey's Speedway USA (USA).z64" size="33554432" crc="2d4f8f1b" md5="0bf64427cf68e49c70e9ec2c9d815209" sha1="507341c0a40ca3e9a7cee969b396ee53facfb548" status="verified" />
 	</game>
 	<game name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)">
 		<description>Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="10b9ff1f" md5="9a8465e302263d635557a14aa197fe3c" sha1="e5e2d6169af2663e5519795b28bec018934e86ee"/>
+		<rom name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It).z64" size="12582912" crc="10b9ff1f" md5="9a8465e302263d635557a14aa197fe3c" sha1="e5e2d6169af2663e5519795b28bec018934e86ee" />
 	</game>
 	<game name="Micro Machines 64 Turbo (USA)" cloneof="Micro Machines 64 Turbo (Europe) (En,Fr,De,Es,It)">
 		<description>Micro Machines 64 Turbo (USA)</description>
-		<release name="Micro Machines 64 Turbo (USA)" region="USA"/>
-		<rom name="Micro Machines 64 Turbo (USA).z64" size="12582912" crc="a62a2763" md5="74eb415e16c333b252847a8e09432fd9" sha1="9672fa010a06adf01074c9720ee46031f5d9e101"/>
+		<rom name="Micro Machines 64 Turbo (USA).n64" />
+		<release name="Micro Machines 64 Turbo (USA)" region="USA" />
+		<rom name="Micro Machines 64 Turbo (USA).z64" size="12582912" crc="a62a2763" md5="74eb415e16c333b252847a8e09432fd9" sha1="9672fa010a06adf01074c9720ee46031f5d9e101" />
 	</game>
 	<game name="Midway's Greatest Arcade Hits - Volume 1 (USA)">
 		<description>Midway's Greatest Arcade Hits - Volume 1 (USA)</description>
-		<release name="Midway's Greatest Arcade Hits - Volume 1 (USA)" region="USA"/>
-		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA).z64" size="4194304" crc="e5c1fedc" md5="2b86775ea4d848202e4f4a39c33571ca" sha1="e24c61aaa5cf15112258052ec78d24ad047ba5ae"/>
+		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA).n64" />
+		<release name="Midway's Greatest Arcade Hits - Volume 1 (USA)" region="USA" />
+		<rom name="Midway's Greatest Arcade Hits - Volume 1 (USA).z64" size="4194304" crc="e5c1fedc" md5="2b86775ea4d848202e4f4a39c33571ca" sha1="e24c61aaa5cf15112258052ec78d24ad047ba5ae" />
 	</game>
 	<game name="Mike Piazza's Strike Zone (USA)">
 		<description>Mike Piazza's Strike Zone (USA)</description>
-		<release name="Mike Piazza's Strike Zone (USA)" region="USA"/>
-		<rom name="Mike Piazza's Strike Zone (USA).z64" size="12582912" crc="cc253cab" md5="eb1908e51c8d10af8b9caf77797bfe00" sha1="09c90701261e345c0023c55b61b37e6aaf809e57"/>
+		<rom name="Mike Piazza's Strike Zone (USA).n64" />
+		<release name="Mike Piazza's Strike Zone (USA)" region="USA" />
+		<rom name="Mike Piazza's Strike Zone (USA).z64" size="12582912" crc="cc253cab" md5="eb1908e51c8d10af8b9caf77797bfe00" sha1="09c90701261e345c0023c55b61b37e6aaf809e57" />
 	</game>
 	<game name="Milo's Astro Lanes (Europe)">
 		<description>Milo's Astro Lanes (Europe)</description>
-		<release name="Milo's Astro Lanes (Europe)" region="EUR"/>
-		<rom name="Milo's Astro Lanes (Europe).z64" size="4194304" crc="c08ce624" md5="43b02af2789990a14f77ce020e6f135c" sha1="77da41c16cd8989291a82159a15ce98d155916a6"/>
+		<rom name="Milo's Astro Lanes (Europe).n64" />
+		<release name="Milo's Astro Lanes (Europe)" region="EUR" />
+		<rom name="Milo's Astro Lanes (Europe).z64" size="4194304" crc="c08ce624" md5="43b02af2789990a14f77ce020e6f135c" sha1="77da41c16cd8989291a82159a15ce98d155916a6" />
 	</game>
 	<game name="Milo's Astro Lanes (USA)" cloneof="Milo's Astro Lanes (Europe)">
 		<description>Milo's Astro Lanes (USA)</description>
-		<release name="Milo's Astro Lanes (USA)" region="USA"/>
-		<rom name="Milo's Astro Lanes (USA).z64" size="4194304" crc="172fca97" md5="4f256146bac4a3dde5ad0d5f9c909251" sha1="7a0246e367ff84b46c0bec9a6b760d3b67b13041"/>
+		<rom name="Milo's Astro Lanes (USA).n64" />
+		<release name="Milo's Astro Lanes (USA)" region="USA" />
+		<rom name="Milo's Astro Lanes (USA).z64" size="4194304" crc="172fca97" md5="4f256146bac4a3dde5ad0d5f9c909251" sha1="7a0246e367ff84b46c0bec9a6b760d3b67b13041" />
 	</game>
 	<game name="Mini Racers (USA) (Ja) (Proto)">
 		<description>Mini Racers (USA) (Ja) (Proto)</description>
-		<release name="Mini Racers (USA) (Ja) (Proto)" region="USA"/>
-		<rom name="Mini Racers (USA) (Ja) (Proto).z64" size="16777216" crc="f59f881b" md5="9c6cf9d3cb5852439de4ef4a399253b9" sha1="109c1960a060cdab0da75e336195ffa15f111d23"/>
+		<rom name="Mini Racers (USA) (Ja) (Proto).n64" />
+		<release name="Mini Racers (USA) (Ja) (Proto)" region="USA" />
+		<rom name="Mini Racers (USA) (Ja) (Proto).z64" size="16777216" crc="f59f881b" md5="9c6cf9d3cb5852439de4ef4a399253b9" sha1="109c1960a060cdab0da75e336195ffa15f111d23" />
 	</game>
 	<game name="Tamiya Racing 64 (USA) (Proto)" cloneof="Mini Racers (USA) (Ja) (Proto)">
 		<description>Tamiya Racing 64 (USA) (Proto)</description>
-		<rom name="Tamiya Racing 64 (USA) (Proto).z64" size="16777216" crc="1b4c53fa" md5="cecab8df02c02f38c9cf1bdd57b1da00" sha1="be11aa2170fb3900379b127241161833400bf58c"/>
+		<rom name="Tamiya Racing 64 (USA) (Proto).n64" />
+		<rom name="Tamiya Racing 64 (USA) (Proto).z64" size="16777216" crc="1b4c53fa" md5="cecab8df02c02f38c9cf1bdd57b1da00" sha1="be11aa2170fb3900379b127241161833400bf58c" />
 	</game>
 	<game name="Mischief Makers (Europe)">
 		<description>Mischief Makers (Europe)</description>
-		<release name="Mischief Makers (Europe)" region="EUR"/>
-		<rom name="Mischief Makers (Europe).z64" size="8388608" crc="68a4f072" md5="eb3b078a74d4dc827e1e79791004dfbb" sha1="e5405aad683959edab641b5da05b8159cac93e63"/>
+		<rom name="Mischief Makers (Europe).n64" />
+		<release name="Mischief Makers (Europe)" region="EUR" />
+		<rom name="Mischief Makers (Europe).z64" size="8388608" crc="68a4f072" md5="eb3b078a74d4dc827e1e79791004dfbb" sha1="e5405aad683959edab641b5da05b8159cac93e63" />
 	</game>
 	<game name="Mischief Makers (USA)" cloneof="Mischief Makers (Europe)">
 		<description>Mischief Makers (USA)</description>
-		<rom name="Mischief Makers (USA).z64" size="8388608" crc="7d222d3f" md5="495a9bffd6620be43225db7133373fc5" sha1="5eb5a9d6f413a379fe297fe1542d21f728393a27"/>
+		<rom name="Mischief Makers (USA).n64" />
+		<rom name="Mischief Makers (USA).z64" size="8388608" crc="7d222d3f" md5="495a9bffd6620be43225db7133373fc5" sha1="5eb5a9d6f413a379fe297fe1542d21f728393a27" />
 	</game>
 	<game name="Mischief Makers (USA) (Rev 1)" cloneof="Mischief Makers (Europe)">
 		<description>Mischief Makers (USA) (Rev 1)</description>
-		<release name="Mischief Makers (USA) (Rev 1)" region="USA"/>
-		<rom name="Mischief Makers (USA) (Rev 1).z64" size="8388608" crc="c3300cef" md5="2ee917366f64a06472d7622a2a05990e" sha1="811709c6473f74cbf283aa61f056e1de3046ec73"/>
+		<rom name="Mischief Makers (USA) (Rev 1).n64" />
+		<release name="Mischief Makers (USA) (Rev 1)" region="USA" />
+		<rom name="Mischief Makers (USA) (Rev 1).z64" size="8388608" crc="c3300cef" md5="2ee917366f64a06472d7622a2a05990e" sha1="811709c6473f74cbf283aa61f056e1de3046ec73" />
 	</game>
 	<game name="Yuke Yuke!! Trouble Makers (Japan)" cloneof="Mischief Makers (Europe)">
 		<description>Yuke Yuke!! Trouble Makers (Japan)</description>
-		<release name="Yuke Yuke!! Trouble Makers (Japan)" region="JPN"/>
-		<rom name="Yuke Yuke!! Trouble Makers (Japan).z64" size="8388608" crc="b69d3068" md5="2ae35bdf163613024d876a09f25063f3" sha1="039a75636c34d219d489d0a84a671d00dc23e7c4"/>
+		<rom name="Yuke Yuke!! Trouble Makers (Japan).n64" />
+		<release name="Yuke Yuke!! Trouble Makers (Japan)" region="JPN" />
+		<rom name="Yuke Yuke!! Trouble Makers (Japan).z64" size="8388608" crc="b69d3068" md5="2ae35bdf163613024d876a09f25063f3" sha1="039a75636c34d219d489d0a84a671d00dc23e7c4" />
 	</game>
 	<game name="Mission - Impossible (Europe)">
 		<description>Mission - Impossible (Europe)</description>
-		<release name="Mission - Impossible (Europe)" region="EUR"/>
-		<rom name="Mission - Impossible (Europe).z64" size="12582912" crc="2c7131d6" md5="599b5d40b51f53c2c9a909e0139702fc" sha1="1a406d19f527d1e394fa140290fde04d81d3e639" status="verified"/>
+		<rom name="Mission - Impossible (Europe).n64" />
+		<release name="Mission - Impossible (Europe)" region="EUR" />
+		<rom name="Mission - Impossible (Europe).z64" size="12582912" crc="2c7131d6" md5="599b5d40b51f53c2c9a909e0139702fc" sha1="1a406d19f527d1e394fa140290fde04d81d3e639" status="verified" />
 	</game>
 	<game name="Mission - Impossible (France)" cloneof="Mission - Impossible (Europe)">
 		<description>Mission - Impossible (France)</description>
-		<release name="Mission - Impossible (France)" region="FRA"/>
-		<rom name="Mission - Impossible (France).z64" size="12582912" crc="282a350d" md5="fd0c0e8c523437f9b6b630e369fdfc69" sha1="ea934f931124db891f12e92726faae5edde39c45"/>
+		<rom name="Mission - Impossible (France).n64" />
+		<release name="Mission - Impossible (France)" region="FRA" />
+		<rom name="Mission - Impossible (France).z64" size="12582912" crc="282a350d" md5="fd0c0e8c523437f9b6b630e369fdfc69" sha1="ea934f931124db891f12e92726faae5edde39c45" />
 	</game>
 	<game name="Mission - Impossible (Germany)" cloneof="Mission - Impossible (Europe)">
 		<description>Mission - Impossible (Germany)</description>
-		<release name="Mission - Impossible (Germany)" region="GER"/>
-		<rom name="Mission - Impossible (Germany).z64" size="12582912" crc="67c30a2d" md5="4111482c92ee806484aaa2c210893a52" sha1="906ffab2f8e8eece17e0846ffbd9ea32370206da"/>
+		<rom name="Mission - Impossible (Germany).n64" />
+		<release name="Mission - Impossible (Germany)" region="GER" />
+		<rom name="Mission - Impossible (Germany).z64" size="12582912" crc="67c30a2d" md5="4111482c92ee806484aaa2c210893a52" sha1="906ffab2f8e8eece17e0846ffbd9ea32370206da" />
 	</game>
 	<game name="Mission - Impossible (Italy)" cloneof="Mission - Impossible (Europe)">
 		<description>Mission - Impossible (Italy)</description>
-		<release name="Mission - Impossible (Italy)" region="ITA"/>
-		<rom name="Mission - Impossible (Italy).z64" size="12582912" crc="2d789d98" md5="66c7eb8148e0714b5a71f5717dff8642" sha1="9ee0e754b7afaf751df281b9411ec1d8f30a894d"/>
+		<rom name="Mission - Impossible (Italy).n64" />
+		<release name="Mission - Impossible (Italy)" region="ITA" />
+		<rom name="Mission - Impossible (Italy).z64" size="12582912" crc="2d789d98" md5="66c7eb8148e0714b5a71f5717dff8642" sha1="9ee0e754b7afaf751df281b9411ec1d8f30a894d" />
 	</game>
 	<game name="Mission - Impossible (Spain)" cloneof="Mission - Impossible (Europe)">
 		<description>Mission - Impossible (Spain)</description>
-		<rom name="Mission - Impossible (Spain).z64" size="12582912" crc="ebb060dc" md5="d1ba3b1899576a4b67908abb6544d75a" sha1="d79c313b8581b558dbeca29f797d91a8b3122841"/>
+		<rom name="Mission - Impossible (Spain).n64" />
+		<rom name="Mission - Impossible (Spain).z64" size="12582912" crc="ebb060dc" md5="d1ba3b1899576a4b67908abb6544d75a" sha1="d79c313b8581b558dbeca29f797d91a8b3122841" />
 	</game>
 	<game name="Mission - Impossible (USA)" cloneof="Mission - Impossible (Europe)">
 		<description>Mission - Impossible (USA)</description>
-		<release name="Mission - Impossible (USA)" region="USA"/>
-		<rom name="Mission - Impossible (USA).z64" size="12582912" crc="3677a8b8" md5="eebdfbd7cb57202d70cfffcaaf55e93e" sha1="7546d5df1fc93fed8205a066f1333fd7dd50c1e1"/>
+		<rom name="Mission - Impossible (USA).n64" />
+		<release name="Mission - Impossible (USA)" region="USA" />
+		<rom name="Mission - Impossible (USA).z64" size="12582912" crc="3677a8b8" md5="eebdfbd7cb57202d70cfffcaaf55e93e" sha1="7546d5df1fc93fed8205a066f1333fd7dd50c1e1" />
 	</game>
 	<game name="Mission - Impossible (Spain) (Rev 1)" cloneof="Mission - Impossible (Europe)">
 		<description>Mission - Impossible (Spain) (Rev 1)</description>
-		<release name="Mission - Impossible (Spain) (Rev 1)" region="SPA"/>
-		<rom name="Mission - Impossible (Spain) (Rev 1).z64" size="12582912" crc="e1c470fd" md5="16a3143dc0e5fe6639f49db7a51d24d4" sha1="e195bde1941f16f5bc693dcc4e47d63e770b18eb"/>
+		<rom name="Mission - Impossible (Spain) (Rev 1).n64" />
+		<release name="Mission - Impossible (Spain) (Rev 1)" region="SPA" />
+		<rom name="Mission - Impossible (Spain) (Rev 1).z64" size="12582912" crc="e1c470fd" md5="16a3143dc0e5fe6639f49db7a51d24d4" sha1="e195bde1941f16f5bc693dcc4e47d63e770b18eb" />
 	</game>
 	<game name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)">
 		<description>Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)</description>
-		<release name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)" region="EUR"/>
-		<rom name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).z64" size="16777216" crc="3f5e5830" md5="c93a17d130b96fba27a0e959cab2a450" sha1="39a7f5515dd822a32c0fc8d9e01a72f0c8b2a1f7"/>
+		<rom name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).n64" />
+		<release name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)" region="EUR" />
+		<rom name="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It).z64" size="16777216" crc="3f5e5830" md5="c93a17d130b96fba27a0e959cab2a450" sha1="39a7f5515dd822a32c0fc8d9e01a72f0c8b2a1f7" />
 	</game>
 	<game name="Monaco Grand Prix (USA)" cloneof="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)">
 		<description>Monaco Grand Prix (USA)</description>
-		<release name="Monaco Grand Prix (USA)" region="USA"/>
-		<rom name="Monaco Grand Prix (USA).z64" size="16777216" crc="e2bbeac1" md5="4ff9589a3224aaa46e9877d6b25e68e3" sha1="477f945dc38f930336e0d05cfdcba2c4c30f6a31"/>
+		<rom name="Monaco Grand Prix (USA).n64" />
+		<release name="Monaco Grand Prix (USA)" region="USA" />
+		<rom name="Monaco Grand Prix (USA).z64" size="16777216" crc="e2bbeac1" md5="4ff9589a3224aaa46e9877d6b25e68e3" sha1="477f945dc38f930336e0d05cfdcba2c4c30f6a31" />
 	</game>
 	<game name="Racing Simulation 2 (Germany)" cloneof="Monaco Grand Prix - Racing Simulation 2 (Europe) (En,Fr,Es,It)">
 		<description>Racing Simulation 2 (Germany)</description>
-		<release name="Racing Simulation 2 (Germany)" region="GER"/>
-		<rom name="Racing Simulation 2 (Germany).z64" size="16777216" crc="ba73a7e4" md5="aa57d69867f53456f351a289eba08c3d" sha1="08bc64cb8c64db9b048fc1522fd5e808ff63ce1a"/>
+		<rom name="Racing Simulation 2 (Germany).n64" />
+		<release name="Racing Simulation 2 (Germany)" region="GER" />
+		<rom name="Racing Simulation 2 (Germany).z64" size="16777216" crc="ba73a7e4" md5="aa57d69867f53456f351a289eba08c3d" sha1="08bc64cb8c64db9b048fc1522fd5e808ff63ce1a" />
 	</game>
 	<game name="Monopoly (USA)">
 		<description>Monopoly (USA)</description>
-		<release name="Monopoly (USA)" region="USA"/>
-		<rom name="Monopoly (USA).z64" size="8388608" crc="c8cad8f6" md5="d51506edb0a941a00eb45850703b32cb" sha1="fd724bdc323aa81d4873768acf789529cc1c08e5"/>
+		<rom name="Monopoly (USA).n64" />
+		<release name="Monopoly (USA)" region="USA" />
+		<rom name="Monopoly (USA).z64" size="8388608" crc="c8cad8f6" md5="d51506edb0a941a00eb45850703b32cb" sha1="fd724bdc323aa81d4873768acf789529cc1c08e5" />
 	</game>
 	<game name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)">
 		<description>Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="4731df5c" md5="e3b408997d7db91f8219f168c6d57d26" sha1="a702b0616030bfc5feb78feaf365eab74f1a8b6e" status="verified"/>
+		<rom name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It).z64" size="8388608" crc="4731df5c" md5="e3b408997d7db91f8219f168c6d57d26" sha1="a702b0616030bfc5feb78feaf365eab74f1a8b6e" status="verified" />
 	</game>
 	<game name="Monster Truck Madness 64 (USA)" cloneof="Monster Truck Madness 64 (Europe) (En,Fr,De,Es,It)">
 		<description>Monster Truck Madness 64 (USA)</description>
-		<release name="Monster Truck Madness 64 (USA)" region="USA"/>
-		<rom name="Monster Truck Madness 64 (USA).z64" size="8388608" crc="3fd0604d" md5="514d61d3b3d5e6326869783eb2e84a00" sha1="f8c7ae14df7341881346b1ceaf838d2219291279"/>
+		<rom name="Monster Truck Madness 64 (USA).n64" />
+		<release name="Monster Truck Madness 64 (USA)" region="USA" />
+		<rom name="Monster Truck Madness 64 (USA).z64" size="8388608" crc="3fd0604d" md5="514d61d3b3d5e6326869783eb2e84a00" sha1="f8c7ae14df7341881346b1ceaf838d2219291279" />
 	</game>
 	<game name="Morita Shougi 64 (Japan)">
 		<description>Morita Shougi 64 (Japan)</description>
-		<release name="Morita Shougi 64 (Japan)" region="JPN"/>
-		<rom name="Morita Shougi 64 (Japan).z64" size="8388608" crc="88c83511" md5="462b9c4f38758c2e558312ac60df2b91" sha1="d079ae0f578032347541b7eae8935907c8ab79e3"/>
+		<rom name="Morita Shougi 64 (Japan).n64" />
+		<release name="Morita Shougi 64 (Japan)" region="JPN" />
+		<rom name="Morita Shougi 64 (Japan).z64" size="8388608" crc="88c83511" md5="462b9c4f38758c2e558312ac60df2b91" sha1="d079ae0f578032347541b7eae8935907c8ab79e3" />
 	</game>
 	<game name="Mortal Kombat 4 (Europe)">
 		<description>Mortal Kombat 4 (Europe)</description>
-		<release name="Mortal Kombat 4 (Europe)" region="EUR"/>
-		<rom name="Mortal Kombat 4 (Europe).z64" size="16777216" crc="635adeca" md5="264b82f0fc2431d6eefde9c9f3ed7596" sha1="34a25cc52f0d2b5ff3a65552f9d43d8714a8e10c"/>
+		<rom name="Mortal Kombat 4 (Europe).n64" />
+		<release name="Mortal Kombat 4 (Europe)" region="EUR" />
+		<rom name="Mortal Kombat 4 (Europe).z64" size="16777216" crc="635adeca" md5="264b82f0fc2431d6eefde9c9f3ed7596" sha1="34a25cc52f0d2b5ff3a65552f9d43d8714a8e10c" />
 	</game>
 	<game name="Mortal Kombat 4 (USA)" cloneof="Mortal Kombat 4 (Europe)">
 		<description>Mortal Kombat 4 (USA)</description>
-		<release name="Mortal Kombat 4 (USA)" region="USA"/>
-		<rom name="Mortal Kombat 4 (USA).z64" size="16777216" crc="b7f46516" md5="c70b91430866300ce38b49098019ef9d" sha1="f47d05bbd1bcadddff2ec7a21bc2e795cbef9f9b" status="verified"/>
+		<rom name="Mortal Kombat 4 (USA).n64" />
+		<release name="Mortal Kombat 4 (USA)" region="USA" />
+		<rom name="Mortal Kombat 4 (USA).z64" size="16777216" crc="b7f46516" md5="c70b91430866300ce38b49098019ef9d" sha1="f47d05bbd1bcadddff2ec7a21bc2e795cbef9f9b" status="verified" />
 	</game>
 	<game name="Mortal Kombat Mythologies - Sub-Zero (Europe)">
 		<description>Mortal Kombat Mythologies - Sub-Zero (Europe)</description>
-		<release name="Mortal Kombat Mythologies - Sub-Zero (Europe)" region="EUR"/>
-		<rom name="Mortal Kombat Mythologies - Sub-Zero (Europe).z64" size="16777216" crc="ea21015a" md5="38a82a56ae61a4d354c6a26e64d25e1c" sha1="e674e0f08d7218136f31ca99a9c5323f0d2bb4d4"/>
+		<rom name="Mortal Kombat Mythologies - Sub-Zero (Europe).n64" />
+		<release name="Mortal Kombat Mythologies - Sub-Zero (Europe)" region="EUR" />
+		<rom name="Mortal Kombat Mythologies - Sub-Zero (Europe).z64" size="16777216" crc="ea21015a" md5="38a82a56ae61a4d354c6a26e64d25e1c" sha1="e674e0f08d7218136f31ca99a9c5323f0d2bb4d4" />
 	</game>
 	<game name="Mortal Kombat Mythologies - Sub-Zero (USA)" cloneof="Mortal Kombat Mythologies - Sub-Zero (Europe)">
 		<description>Mortal Kombat Mythologies - Sub-Zero (USA)</description>
-		<release name="Mortal Kombat Mythologies - Sub-Zero (USA)" region="USA"/>
-		<rom name="Mortal Kombat Mythologies - Sub-Zero (USA).z64" size="16777216" crc="51a07fd9" md5="deec4faec416f4e02d934c2e42c0caad" sha1="ef3df4e1496260d44c44ab7dd145751141f11c60"/>
+		<rom name="Mortal Kombat Mythologies - Sub-Zero (USA).n64" />
+		<release name="Mortal Kombat Mythologies - Sub-Zero (USA)" region="USA" />
+		<rom name="Mortal Kombat Mythologies - Sub-Zero (USA).z64" size="16777216" crc="51a07fd9" md5="deec4faec416f4e02d934c2e42c0caad" sha1="ef3df4e1496260d44c44ab7dd145751141f11c60" />
 	</game>
 	<game name="Mortal Kombat Trilogy (Europe)">
 		<description>Mortal Kombat Trilogy (Europe)</description>
-		<release name="Mortal Kombat Trilogy (Europe)" region="EUR"/>
-		<rom name="Mortal Kombat Trilogy (Europe).z64" size="12582912" crc="bc04c62f" md5="7a558bbad8ce8828414a9cf3b044a87d" sha1="5796aaf21bfa0e8532ef225ba4be3b39eef1be63"/>
+		<rom name="Mortal Kombat Trilogy (Europe).n64" />
+		<release name="Mortal Kombat Trilogy (Europe)" region="EUR" />
+		<rom name="Mortal Kombat Trilogy (Europe).z64" size="12582912" crc="bc04c62f" md5="7a558bbad8ce8828414a9cf3b044a87d" sha1="5796aaf21bfa0e8532ef225ba4be3b39eef1be63" />
 	</game>
 	<game name="Mortal Kombat Trilogy (USA)" cloneof="Mortal Kombat Trilogy (Europe)">
 		<description>Mortal Kombat Trilogy (USA)</description>
-		<rom name="Mortal Kombat Trilogy (USA).z64" size="12582912" crc="50a99d60" md5="9b7f29aab911d6753f2011c48da752bf" sha1="39b3cb20417c503f1c047d5037df814d1ccf90dd"/>
+		<rom name="Mortal Kombat Trilogy (USA).n64" />
+		<rom name="Mortal Kombat Trilogy (USA).z64" size="12582912" crc="50a99d60" md5="9b7f29aab911d6753f2011c48da752bf" sha1="39b3cb20417c503f1c047d5037df814d1ccf90dd" />
 	</game>
 	<game name="Mortal Kombat Trilogy (USA) (Rev 2)" cloneof="Mortal Kombat Trilogy (Europe)">
 		<description>Mortal Kombat Trilogy (USA) (Rev 2)</description>
-		<release name="Mortal Kombat Trilogy (USA) (Rev 2)" region="USA"/>
-		<rom name="Mortal Kombat Trilogy (USA) (Rev 2).z64" size="12582912" crc="0f323d00" md5="3dcb15043063bd656a0223c519218cfb" sha1="11f2488b21f9f7185c25905dd02c2955c35ad5c1"/>
+		<rom name="Mortal Kombat Trilogy (USA) (Rev 2).n64" />
+		<release name="Mortal Kombat Trilogy (USA) (Rev 2)" region="USA" />
+		<rom name="Mortal Kombat Trilogy (USA) (Rev 2).z64" size="12582912" crc="0f323d00" md5="3dcb15043063bd656a0223c519218cfb" sha1="11f2488b21f9f7185c25905dd02c2955c35ad5c1" />
 	</game>
 	<game name="Mortal Kombat Trilogy (USA) (Rev 1)" cloneof="Mortal Kombat Trilogy (Europe)">
 		<description>Mortal Kombat Trilogy (USA) (Rev 1)</description>
-		<rom name="Mortal Kombat Trilogy (USA) (Rev 1).z64" size="12582912" crc="ba64f824" md5="26129419799db01bfe79f279ec43b334" sha1="2a10cb20332beaa067d61e5923cd18bedd6436d7"/>
+		<rom name="Mortal Kombat Trilogy (USA) (Rev 1).n64" />
+		<rom name="Mortal Kombat Trilogy (USA) (Rev 1).z64" size="12582912" crc="ba64f824" md5="26129419799db01bfe79f279ec43b334" sha1="2a10cb20332beaa067d61e5923cd18bedd6436d7" />
 	</game>
 	<game name="Mortal Kombat Trilogy (USA) (Beta) (1996-05-13)" cloneof="Mortal Kombat Trilogy (Europe)">
 		<description>Mortal Kombat Trilogy (USA) (Beta) (1996-05-13)</description>
-		<rom name="Mortal Kombat Trilogy (USA) (Beta) (1996-05-13).z64" size="16777216" crc="eab22c06" md5="b6a7b85c123df4e0b9cc118578dbc9a2" sha1="2f95ce7f8233f1df82e0ad39ad5ba6a5ebfb6db7"/>
+		<rom name="Mortal Kombat Trilogy (USA) (Beta) (1996-05-13).n64" />
+		<rom name="Mortal Kombat Trilogy (USA) (Beta) (1996-05-13).z64" size="16777216" crc="eab22c06" md5="b6a7b85c123df4e0b9cc118578dbc9a2" sha1="2f95ce7f8233f1df82e0ad39ad5ba6a5ebfb6db7" />
 	</game>
 	<game name="MRC - Multi-Racing Championship (Europe) (En,Fr,De)">
 		<description>MRC - Multi-Racing Championship (Europe) (En,Fr,De)</description>
-		<release name="MRC - Multi-Racing Championship (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="MRC - Multi-Racing Championship (Europe) (En,Fr,De).z64" size="12582912" crc="bc966b10" md5="0054b7fc0c2acbed650efe727cdba472" sha1="6d8600a1326c39b4b80bb1d4a6500c3f0c6202a1"/>
+		<rom name="MRC - Multi-Racing Championship (Europe) (En,Fr,De).n64" />
+		<release name="MRC - Multi-Racing Championship (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="MRC - Multi-Racing Championship (Europe) (En,Fr,De).z64" size="12582912" crc="bc966b10" md5="0054b7fc0c2acbed650efe727cdba472" sha1="6d8600a1326c39b4b80bb1d4a6500c3f0c6202a1" />
 	</game>
 	<game name="MRC - Multi-Racing Championship (Japan)" cloneof="MRC - Multi-Racing Championship (Europe) (En,Fr,De)">
 		<description>MRC - Multi-Racing Championship (Japan)</description>
-		<release name="MRC - Multi-Racing Championship (Japan)" region="JPN"/>
-		<rom name="MRC - Multi-Racing Championship (Japan).z64" size="12582912" crc="bea43300" md5="8e18064a2c4b3ec15a20c3d676644b3a" sha1="b0992a8029622df74d3165814aa40df19a14b4a4"/>
+		<rom name="MRC - Multi-Racing Championship (Japan).n64" />
+		<release name="MRC - Multi-Racing Championship (Japan)" region="JPN" />
+		<rom name="MRC - Multi-Racing Championship (Japan).z64" size="12582912" crc="bea43300" md5="8e18064a2c4b3ec15a20c3d676644b3a" sha1="b0992a8029622df74d3165814aa40df19a14b4a4" />
 	</game>
 	<game name="MRC - Multi-Racing Championship (USA)" cloneof="MRC - Multi-Racing Championship (Europe) (En,Fr,De)">
 		<description>MRC - Multi-Racing Championship (USA)</description>
-		<release name="MRC - Multi-Racing Championship (USA)" region="USA"/>
-		<rom name="MRC - Multi-Racing Championship (USA).z64" size="12582912" crc="1dc1c812" md5="fc61d60f2c6fe4610f70ce4949a7a062" sha1="8bea68833d63b2f17daad4477a572c274a9468be"/>
+		<rom name="MRC - Multi-Racing Championship (USA).n64" />
+		<release name="MRC - Multi-Racing Championship (USA)" region="USA" />
+		<rom name="MRC - Multi-Racing Championship (USA).z64" size="12582912" crc="1dc1c812" md5="fc61d60f2c6fe4610f70ce4949a7a062" sha1="8bea68833d63b2f17daad4477a572c274a9468be" />
 	</game>
 	<game name="Ms. Pac-Man - Maze Madness (USA)">
 		<description>Ms. Pac-Man - Maze Madness (USA)</description>
-		<release name="Ms. Pac-Man - Maze Madness (USA)" region="USA"/>
-		<rom name="Ms. Pac-Man - Maze Madness (USA).z64" size="12582912" crc="e34c7060" md5="08bea3310e778a6584eb64cd3f15f86e" sha1="99028c738b5ac5ff99d73698b50d14f5e58ddea7"/>
+		<rom name="Ms. Pac-Man - Maze Madness (USA).n64" />
+		<release name="Ms. Pac-Man - Maze Madness (USA)" region="USA" />
+		<rom name="Ms. Pac-Man - Maze Madness (USA).z64" size="12582912" crc="e34c7060" md5="08bea3310e778a6584eb64cd3f15f86e" sha1="99028c738b5ac5ff99d73698b50d14f5e58ddea7" />
 	</game>
 	<game name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)">
 		<description>Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)</description>
-		<release name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De).z64" size="16777216" crc="3502dbbe" md5="e6b5c17b7bbbb7c432b3506c085d16c4" sha1="aadd1d7e943cbfa5496a370158b5f8fe17b06415"/>
+		<rom name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De).n64" />
+		<release name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De).z64" size="16777216" crc="3502dbbe" md5="e6b5c17b7bbbb7c432b3506c085d16c4" sha1="aadd1d7e943cbfa5496a370158b5f8fe17b06415" />
 	</game>
 	<game name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)" cloneof="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)">
 		<description>Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)</description>
-		<release name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)" region="JPN"/>
-		<rom name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).z64" size="16777216" crc="08c41e0e" md5="96ca36d474e82c270a129d775c63167a" sha1="2ab71b71665a688d40832e16d897548ece9f0dd4"/>
+		<rom name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).n64" />
+		<release name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan)" region="JPN" />
+		<rom name="Ganbare Goemon - Dero Dero Douchuu Obake Tenkomori (Japan).z64" size="16777216" crc="08c41e0e" md5="96ca36d474e82c270a129d775c63167a" sha1="2ab71b71665a688d40832e16d897548ece9f0dd4" />
 	</game>
 	<game name="Goemon's Great Adventure (USA)" cloneof="Mystical Ninja 2 Starring Goemon (Europe) (En,Fr,De)">
 		<description>Goemon's Great Adventure (USA)</description>
-		<release name="Goemon's Great Adventure (USA)" region="USA"/>
-		<rom name="Goemon's Great Adventure (USA).z64" size="16777216" crc="52d418e1" md5="29bc5c1a24d3979d376ad421000ac9cb" sha1="9f9e860816f9e2a68bb5f4f56086e0c7450c64d7"/>
+		<rom name="Goemon's Great Adventure (USA).n64" />
+		<release name="Goemon's Great Adventure (USA)" region="USA" />
+		<rom name="Goemon's Great Adventure (USA).z64" size="16777216" crc="52d418e1" md5="29bc5c1a24d3979d376ad421000ac9cb" sha1="9f9e860816f9e2a68bb5f4f56086e0c7450c64d7" />
 	</game>
 	<game name="Mystical Ninja Starring Goemon (Europe)">
 		<description>Mystical Ninja Starring Goemon (Europe)</description>
-		<release name="Mystical Ninja Starring Goemon (Europe)" region="EUR"/>
-		<rom name="Mystical Ninja Starring Goemon (Europe).z64" size="16777216" crc="3bd9059a" md5="698930c7ccd844673d77ffeccb3dd66e" sha1="f7304934ba4e8d98a71500c249bacb168bca5af0" status="verified"/>
+		<rom name="Mystical Ninja Starring Goemon (Europe).n64" />
+		<release name="Mystical Ninja Starring Goemon (Europe)" region="EUR" />
+		<rom name="Mystical Ninja Starring Goemon (Europe).z64" size="16777216" crc="3bd9059a" md5="698930c7ccd844673d77ffeccb3dd66e" sha1="f7304934ba4e8d98a71500c249bacb168bca5af0" status="verified" />
 	</game>
 	<game name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)" cloneof="Mystical Ninja Starring Goemon (Europe)">
 		<description>Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)</description>
-		<release name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)" region="JPN"/>
-		<rom name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).z64" size="16777216" crc="2e91efc9" md5="9b929e0bf8d63e62820f2fa6257cc5cf" sha1="9843ee979b5f6c80f5eda85df0baed9ae7c4e73b"/>
+		<rom name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).n64" />
+		<release name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan)" region="JPN" />
+		<rom name="Ganbare Goemon - Neo Momoyama Bakufu no Odori (Japan).z64" size="16777216" crc="2e91efc9" md5="9b929e0bf8d63e62820f2fa6257cc5cf" sha1="9843ee979b5f6c80f5eda85df0baed9ae7c4e73b" />
 	</game>
 	<game name="Mystical Ninja Starring Goemon (USA)" cloneof="Mystical Ninja Starring Goemon (Europe)">
 		<description>Mystical Ninja Starring Goemon (USA)</description>
-		<release name="Mystical Ninja Starring Goemon (USA)" region="USA"/>
-		<rom name="Mystical Ninja Starring Goemon (USA).z64" size="16777216" crc="4180c296" md5="643cce1ab06f97e9590241d27e5c2363" sha1="df8083a54296b8c151917c5333e1c85f014a2a66"/>
+		<rom name="Mystical Ninja Starring Goemon (USA).n64" />
+		<release name="Mystical Ninja Starring Goemon (USA)" region="USA" />
+		<rom name="Mystical Ninja Starring Goemon (USA).z64" size="16777216" crc="4180c296" md5="643cce1ab06f97e9590241d27e5c2363" sha1="df8083a54296b8c151917c5333e1c85f014a2a66" />
 	</game>
 	<game name="Nagano Winter Olympics '98 (Europe)">
 		<description>Nagano Winter Olympics '98 (Europe)</description>
-		<release name="Nagano Winter Olympics '98 (Europe)" region="EUR"/>
-		<rom name="Nagano Winter Olympics '98 (Europe).z64" size="12582912" crc="c44de11c" md5="b935b87f3dcca8aeeb6a9365124846dc" sha1="8faca645020857b87ed3842bd26cccbdf31bec39"/>
+		<rom name="Nagano Winter Olympics '98 (Europe).n64" />
+		<release name="Nagano Winter Olympics '98 (Europe)" region="EUR" />
+		<rom name="Nagano Winter Olympics '98 (Europe).z64" size="12582912" crc="c44de11c" md5="b935b87f3dcca8aeeb6a9365124846dc" sha1="8faca645020857b87ed3842bd26cccbdf31bec39" />
 	</game>
 	<game name="Hyper Olympics in Nagano 64 (Japan)" cloneof="Nagano Winter Olympics '98 (Europe)">
 		<description>Hyper Olympics in Nagano 64 (Japan)</description>
-		<release name="Hyper Olympics in Nagano 64 (Japan)" region="JPN"/>
-		<rom name="Hyper Olympics in Nagano 64 (Japan).z64" size="12582912" crc="c1ea5d33" md5="d2f7b3ace75a2ce7a06beac929711d94" sha1="3d0f36371f99c8abc8e835dae4e0913757ee4827"/>
+		<rom name="Hyper Olympics in Nagano 64 (Japan).n64" />
+		<release name="Hyper Olympics in Nagano 64 (Japan)" region="JPN" />
+		<rom name="Hyper Olympics in Nagano 64 (Japan).z64" size="12582912" crc="c1ea5d33" md5="d2f7b3ace75a2ce7a06beac929711d94" sha1="3d0f36371f99c8abc8e835dae4e0913757ee4827" />
 	</game>
 	<game name="Nagano Winter Olympics '98 (USA)" cloneof="Nagano Winter Olympics '98 (Europe)">
 		<description>Nagano Winter Olympics '98 (USA)</description>
-		<release name="Nagano Winter Olympics '98 (USA)" region="USA"/>
-		<rom name="Nagano Winter Olympics '98 (USA).z64" size="12582912" crc="ee8288d4" md5="c17f78a103d99b21533f0c1566378ef6" sha1="eaf543e195731031a84f4136b506449209e3a8f5"/>
+		<rom name="Nagano Winter Olympics '98 (USA).n64" />
+		<release name="Nagano Winter Olympics '98 (USA)" region="USA" />
+		<rom name="Nagano Winter Olympics '98 (USA).z64" size="12582912" crc="ee8288d4" md5="c17f78a103d99b21533f0c1566378ef6" sha1="eaf543e195731031a84f4136b506449209e3a8f5" />
 	</game>
 	<game name="Namco Museum 64 (USA)">
 		<description>Namco Museum 64 (USA)</description>
-		<release name="Namco Museum 64 (USA)" region="USA"/>
-		<rom name="Namco Museum 64 (USA).z64" size="4194304" crc="ce361f92" md5="e61251d2819e3bf3a9c0b95329f60f70" sha1="a934e08f80778111d1bc03caf0a170a2d8c4e6a7"/>
+		<rom name="Namco Museum 64 (USA).n64" />
+		<release name="Namco Museum 64 (USA)" region="USA" />
+		<rom name="Namco Museum 64 (USA).z64" size="4194304" crc="ce361f92" md5="e61251d2819e3bf3a9c0b95329f60f70" sha1="a934e08f80778111d1bc03caf0a170a2d8c4e6a7" />
 	</game>
 	<game name="NASCAR 2000 (USA)">
 		<description>NASCAR 2000 (USA)</description>
-		<release name="NASCAR 2000 (USA)" region="USA"/>
-		<rom name="NASCAR 2000 (USA).z64" size="12582912" crc="02bf7c2d" md5="45feb0fbbec6cb48ff21deae176e9b6b" sha1="36cd848be9196c9e04eb3a9b0371a04afc8baea3"/>
+		<rom name="NASCAR 2000 (USA).n64" />
+		<release name="NASCAR 2000 (USA)" region="USA" />
+		<rom name="NASCAR 2000 (USA).z64" size="12582912" crc="02bf7c2d" md5="45feb0fbbec6cb48ff21deae176e9b6b" sha1="36cd848be9196c9e04eb3a9b0371a04afc8baea3" />
 	</game>
 	<game name="NASCAR 99 (Europe) (En,Fr,De)">
 		<description>NASCAR 99 (Europe) (En,Fr,De)</description>
-		<release name="NASCAR 99 (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="NASCAR 99 (Europe) (En,Fr,De).z64" size="12582912" crc="76e79cea" md5="15a87a6d01dba1a7c4375ffbc1214bb8" sha1="cb43ee3d86a7b85befec8d068d72192fa8174eb0"/>
+		<rom name="NASCAR 99 (Europe) (En,Fr,De).n64" />
+		<release name="NASCAR 99 (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="NASCAR 99 (Europe) (En,Fr,De).z64" size="12582912" crc="76e79cea" md5="15a87a6d01dba1a7c4375ffbc1214bb8" sha1="cb43ee3d86a7b85befec8d068d72192fa8174eb0" />
 	</game>
 	<game name="NASCAR 99 (USA)" cloneof="NASCAR 99 (Europe) (En,Fr,De)">
 		<description>NASCAR 99 (USA)</description>
-		<release name="NASCAR 99 (USA)" region="USA"/>
-		<rom name="NASCAR 99 (USA).z64" size="12582912" crc="3d8eb950" md5="dc5f1a814c8423b4b43f71c229d65a84" sha1="0fbbaeb4c286d45d27c977d5722e38415efd1a74"/>
+		<rom name="NASCAR 99 (USA).n64" />
+		<release name="NASCAR 99 (USA)" region="USA" />
+		<rom name="NASCAR 99 (USA).z64" size="12582912" crc="3d8eb950" md5="dc5f1a814c8423b4b43f71c229d65a84" sha1="0fbbaeb4c286d45d27c977d5722e38415efd1a74" />
 	</game>
 	<game name="NBA Courtside 2 featuring Kobe Bryant (USA)">
 		<description>NBA Courtside 2 featuring Kobe Bryant (USA)</description>
-		<release name="NBA Courtside 2 featuring Kobe Bryant (USA)" region="USA"/>
-		<rom name="NBA Courtside 2 featuring Kobe Bryant (USA).z64" size="16777216" crc="a7cc4ce2" md5="73bb54ffd3c0fc71f941d9a8cc57e2a1" sha1="8c27333189fc19570bc494bc3ed9e3879d6e54be"/>
+		<rom name="NBA Courtside 2 featuring Kobe Bryant (USA).n64" />
+		<release name="NBA Courtside 2 featuring Kobe Bryant (USA)" region="USA" />
+		<rom name="NBA Courtside 2 featuring Kobe Bryant (USA).z64" size="16777216" crc="a7cc4ce2" md5="73bb54ffd3c0fc71f941d9a8cc57e2a1" sha1="8c27333189fc19570bc494bc3ed9e3879d6e54be" />
 	</game>
 	<game name="NBA Hangtime (Europe)">
 		<description>NBA Hangtime (Europe)</description>
-		<release name="NBA Hangtime (Europe)" region="EUR"/>
-		<rom name="NBA Hangtime (Europe).z64" size="12582912" crc="7e6d00ae" md5="62365463743857cfc823978e0e590d84" sha1="2bcbdd92ccb4c72757739d32557098f4eec36312"/>
+		<rom name="NBA Hangtime (Europe).n64" />
+		<release name="NBA Hangtime (Europe)" region="EUR" />
+		<rom name="NBA Hangtime (Europe).z64" size="12582912" crc="7e6d00ae" md5="62365463743857cfc823978e0e590d84" sha1="2bcbdd92ccb4c72757739d32557098f4eec36312" />
 	</game>
 	<game name="NBA Hangtime (USA)" cloneof="NBA Hangtime (Europe)">
 		<description>NBA Hangtime (USA)</description>
-		<release name="NBA Hangtime (USA)" region="USA"/>
-		<rom name="NBA Hangtime (USA).z64" size="12582912" crc="714cf532" md5="dc15fcbeae0f1fef7bee141d77bb25a0" sha1="3c96741db636938f140e9592ad34e93ac25c7762"/>
+		<rom name="NBA Hangtime (USA).n64" />
+		<release name="NBA Hangtime (USA)" region="USA" />
+		<rom name="NBA Hangtime (USA).z64" size="12582912" crc="714cf532" md5="dc15fcbeae0f1fef7bee141d77bb25a0" sha1="3c96741db636938f140e9592ad34e93ac25c7762" />
 	</game>
 	<game name="NBA in the Zone 2000 (Europe)">
 		<description>NBA in the Zone 2000 (Europe)</description>
-		<release name="NBA in the Zone 2000 (Europe)" region="EUR"/>
-		<rom name="NBA in the Zone 2000 (Europe).z64" size="16777216" crc="a4973197" md5="4244cc48674c26bd848718c05688f821" sha1="255aadf60e9de652247bb1f7c63b50415d6c4354"/>
+		<rom name="NBA in the Zone 2000 (Europe).n64" />
+		<release name="NBA in the Zone 2000 (Europe)" region="EUR" />
+		<rom name="NBA in the Zone 2000 (Europe).z64" size="16777216" crc="a4973197" md5="4244cc48674c26bd848718c05688f821" sha1="255aadf60e9de652247bb1f7c63b50415d6c4354" />
 	</game>
 	<game name="NBA in the Zone 2000 (USA)" cloneof="NBA in the Zone 2000 (Europe)">
 		<description>NBA in the Zone 2000 (USA)</description>
-		<release name="NBA in the Zone 2000 (USA)" region="USA"/>
-		<rom name="NBA in the Zone 2000 (USA).z64" size="16777216" crc="cbb4b730" md5="1942833ac1a71be8bae74bbdfd6de278" sha1="7e838c203f29336cbdaba77051ebe48d9eae798d"/>
+		<rom name="NBA in the Zone 2000 (USA).n64" />
+		<release name="NBA in the Zone 2000 (USA)" region="USA" />
+		<rom name="NBA in the Zone 2000 (USA).z64" size="16777216" crc="cbb4b730" md5="1942833ac1a71be8bae74bbdfd6de278" sha1="7e838c203f29336cbdaba77051ebe48d9eae798d" />
 	</game>
 	<game name="NBA Jam 2000 (Europe)">
 		<description>NBA Jam 2000 (Europe)</description>
-		<release name="NBA Jam 2000 (Europe)" region="EUR"/>
-		<rom name="NBA Jam 2000 (Europe).z64" size="16777216" crc="9f95485e" md5="604feb17258044a3e6c3aa9d2c5b62f9" sha1="a91c52ac8af8de6172411c5bf8e57f5795be7f78" status="verified"/>
+		<rom name="NBA Jam 2000 (Europe).n64" />
+		<release name="NBA Jam 2000 (Europe)" region="EUR" />
+		<rom name="NBA Jam 2000 (Europe).z64" size="16777216" crc="9f95485e" md5="604feb17258044a3e6c3aa9d2c5b62f9" sha1="a91c52ac8af8de6172411c5bf8e57f5795be7f78" status="verified" />
 	</game>
 	<game name="NBA Jam 2000 (USA)" cloneof="NBA Jam 2000 (Europe)">
 		<description>NBA Jam 2000 (USA)</description>
-		<release name="NBA Jam 2000 (USA)" region="USA"/>
-		<rom name="NBA Jam 2000 (USA).z64" size="16777216" crc="163dadf9" md5="afecc9a2df7b1a66a6b7ab3aa8b4bd2e" sha1="94139439d6c234a560fc5d0e5d9c0aa4508fc7b6"/>
+		<rom name="NBA Jam 2000 (USA).n64" />
+		<release name="NBA Jam 2000 (USA)" region="USA" />
+		<rom name="NBA Jam 2000 (USA).z64" size="16777216" crc="163dadf9" md5="afecc9a2df7b1a66a6b7ab3aa8b4bd2e" sha1="94139439d6c234a560fc5d0e5d9c0aa4508fc7b6" />
 	</game>
 	<game name="NBA Jam 99 (Europe)">
 		<description>NBA Jam 99 (Europe)</description>
-		<release name="NBA Jam 99 (Europe)" region="EUR"/>
-		<rom name="NBA Jam 99 (Europe).z64" size="12582912" crc="90e4275b" md5="be72be370bc0a76d403ff2b9ed2a9173" sha1="cf6c46785b75f9bc1d5b1fd08dafb72dd595f68a"/>
+		<rom name="NBA Jam 99 (Europe).n64" />
+		<release name="NBA Jam 99 (Europe)" region="EUR" />
+		<rom name="NBA Jam 99 (Europe).z64" size="12582912" crc="90e4275b" md5="be72be370bc0a76d403ff2b9ed2a9173" sha1="cf6c46785b75f9bc1d5b1fd08dafb72dd595f68a" />
 	</game>
 	<game name="NBA Jam 99 (USA)" cloneof="NBA Jam 99 (Europe)">
 		<description>NBA Jam 99 (USA)</description>
-		<release name="NBA Jam 99 (USA)" region="USA"/>
-		<rom name="NBA Jam 99 (USA).z64" size="12582912" crc="559cd6b1" md5="adbe5ca10f659af2be712038e8522704" sha1="2e306d2123ad4220e672d8a07874ca7b515d57e0"/>
+		<rom name="NBA Jam 99 (USA).n64" />
+		<release name="NBA Jam 99 (USA)" region="USA" />
+		<rom name="NBA Jam 99 (USA).z64" size="12582912" crc="559cd6b1" md5="adbe5ca10f659af2be712038e8522704" sha1="2e306d2123ad4220e672d8a07874ca7b515d57e0" />
 	</game>
 	<game name="NBA Live 2000 (Europe) (En,Fr,De,Es)">
 		<description>NBA Live 2000 (Europe) (En,Fr,De,Es)</description>
-		<release name="NBA Live 2000 (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="NBA Live 2000 (Europe) (En,Fr,De,Es).z64" size="16777216" crc="0e4b944c" md5="7fec099d1a989d5222d3f9e1a7770404" sha1="d4cb60eb3645ae803a1efc234ceffd8f424dc8f7"/>
+		<rom name="NBA Live 2000 (Europe) (En,Fr,De,Es).n64" />
+		<release name="NBA Live 2000 (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="NBA Live 2000 (Europe) (En,Fr,De,Es).z64" size="16777216" crc="0e4b944c" md5="7fec099d1a989d5222d3f9e1a7770404" sha1="d4cb60eb3645ae803a1efc234ceffd8f424dc8f7" />
 	</game>
 	<game name="NBA Live 2000 (USA) (En,Fr,De,Es)" cloneof="NBA Live 2000 (Europe) (En,Fr,De,Es)">
 		<description>NBA Live 2000 (USA) (En,Fr,De,Es)</description>
-		<release name="NBA Live 2000 (USA) (En,Fr,De,Es)" region="USA"/>
-		<rom name="NBA Live 2000 (USA) (En,Fr,De,Es).z64" size="16777216" crc="7c3bc95e" md5="fc47f85cc501c8c5bd9d0ca4db48258f" sha1="4ba671a132125bcaa6552542b7fc2c7f6dc56a0e"/>
+		<rom name="NBA Live 2000 (USA) (En,Fr,De,Es).n64" />
+		<release name="NBA Live 2000 (USA) (En,Fr,De,Es)" region="USA" />
+		<rom name="NBA Live 2000 (USA) (En,Fr,De,Es).z64" size="16777216" crc="7c3bc95e" md5="fc47f85cc501c8c5bd9d0ca4db48258f" sha1="4ba671a132125bcaa6552542b7fc2c7f6dc56a0e" />
 	</game>
 	<game name="NBA Live 99 (Europe) (En,Fr,De,Es,It)">
 		<description>NBA Live 99 (Europe) (En,Fr,De,Es,It)</description>
-		<release name="NBA Live 99 (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="NBA Live 99 (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="a316df37" md5="226c19c8759314ac740420ddc3a34eb4" sha1="530ef95c12f0ca73bc4e178a397ce677a57ad858"/>
+		<rom name="NBA Live 99 (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="NBA Live 99 (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="NBA Live 99 (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="a316df37" md5="226c19c8759314ac740420ddc3a34eb4" sha1="530ef95c12f0ca73bc4e178a397ce677a57ad858" />
 	</game>
 	<game name="NBA Live 99 (USA) (En,Fr,De,Es,It)" cloneof="NBA Live 99 (Europe) (En,Fr,De,Es,It)">
 		<description>NBA Live 99 (USA) (En,Fr,De,Es,It)</description>
-		<release name="NBA Live 99 (USA) (En,Fr,De,Es,It)" region="USA"/>
-		<rom name="NBA Live 99 (USA) (En,Fr,De,Es,It).z64" size="16777216" crc="9be0a7ac" md5="dbe79ae6531b491b8f8ee8b2b814d665" sha1="89e47ffac3eae25b37e1a20ce66ca24e343912dd"/>
+		<rom name="NBA Live 99 (USA) (En,Fr,De,Es,It).n64" />
+		<release name="NBA Live 99 (USA) (En,Fr,De,Es,It)" region="USA" />
+		<rom name="NBA Live 99 (USA) (En,Fr,De,Es,It).z64" size="16777216" crc="9be0a7ac" md5="dbe79ae6531b491b8f8ee8b2b814d665" sha1="89e47ffac3eae25b37e1a20ce66ca24e343912dd" />
 	</game>
 	<game name="NBA Pro 98 (Europe)">
 		<description>NBA Pro 98 (Europe)</description>
-		<release name="NBA Pro 98 (Europe)" region="EUR"/>
-		<rom name="NBA Pro 98 (Europe).z64" size="12582912" crc="04b75ccc" md5="a4111a6cddbde0a45489106f0df0ca2b" sha1="94416270d83a87e360bac5059cc5f7365ca120ac"/>
+		<rom name="NBA Pro 98 (Europe).n64" />
+		<release name="NBA Pro 98 (Europe)" region="EUR" />
+		<rom name="NBA Pro 98 (Europe).z64" size="12582912" crc="04b75ccc" md5="a4111a6cddbde0a45489106f0df0ca2b" sha1="94416270d83a87e360bac5059cc5f7365ca120ac" />
 	</game>
 	<game name="NBA in the Zone '98 (Japan)" cloneof="NBA Pro 98 (Europe)">
 		<description>NBA in the Zone '98 (Japan)</description>
-		<release name="NBA in the Zone '98 (Japan)" region="JPN"/>
-		<rom name="NBA in the Zone '98 (Japan).z64" size="12582912" crc="aed2700a" md5="4c7a2f4881eaca75dc2fc36673ae2a20" sha1="c4dc9049094100d48a010d39f2901e1ab164a8fa"/>
+		<rom name="NBA in the Zone '98 (Japan).n64" />
+		<release name="NBA in the Zone '98 (Japan)" region="JPN" />
+		<rom name="NBA in the Zone '98 (Japan).z64" size="12582912" crc="aed2700a" md5="4c7a2f4881eaca75dc2fc36673ae2a20" sha1="c4dc9049094100d48a010d39f2901e1ab164a8fa" />
 	</game>
 	<game name="NBA in the Zone '98 (USA)" cloneof="NBA Pro 98 (Europe)">
 		<description>NBA in the Zone '98 (USA)</description>
-		<release name="NBA in the Zone '98 (USA)" region="USA"/>
-		<rom name="NBA in the Zone '98 (USA).z64" size="12582912" crc="a245d737" md5="bbb48be198089a26050c84fe5b7b8bd5" sha1="a306d80f483f8bb5891a543919c53fac61d9348f"/>
+		<rom name="NBA in the Zone '98 (USA).n64" />
+		<release name="NBA in the Zone '98 (USA)" region="USA" />
+		<rom name="NBA in the Zone '98 (USA).z64" size="12582912" crc="a245d737" md5="bbb48be198089a26050c84fe5b7b8bd5" sha1="a306d80f483f8bb5891a543919c53fac61d9348f" />
 	</game>
 	<game name="NBA Pro 99 (Europe)">
 		<description>NBA Pro 99 (Europe)</description>
-		<release name="NBA Pro 99 (Europe)" region="EUR"/>
-		<rom name="NBA Pro 99 (Europe).z64" size="12582912" crc="588e60e8" md5="c5ebbdd41eaea8bd02cf520640ccccdf" sha1="5decf930d859e8b834a5f897955880556ca6aadf"/>
+		<rom name="NBA Pro 99 (Europe).n64" />
+		<release name="NBA Pro 99 (Europe)" region="EUR" />
+		<rom name="NBA Pro 99 (Europe).z64" size="12582912" crc="588e60e8" md5="c5ebbdd41eaea8bd02cf520640ccccdf" sha1="5decf930d859e8b834a5f897955880556ca6aadf" />
 	</game>
 	<game name="NBA in the Zone '99 (USA)" cloneof="NBA Pro 99 (Europe)">
 		<description>NBA in the Zone '99 (USA)</description>
-		<release name="NBA in the Zone '99 (USA)" region="USA"/>
-		<rom name="NBA in the Zone '99 (USA).z64" size="12582912" crc="eab083b8" md5="6cbf4014c053e16852a3db80aeb4c853" sha1="6964baec49592e64c34782b55e234c7bd32c8a99"/>
+		<rom name="NBA in the Zone '99 (USA).n64" />
+		<release name="NBA in the Zone '99 (USA)" region="USA" />
+		<rom name="NBA in the Zone '99 (USA).z64" size="12582912" crc="eab083b8" md5="6cbf4014c053e16852a3db80aeb4c853" sha1="6964baec49592e64c34782b55e234c7bd32c8a99" />
 	</game>
 	<game name="NBA in the Zone 2 (Japan)" cloneof="NBA Pro 99 (Europe)">
 		<description>NBA in the Zone 2 (Japan)</description>
-		<release name="NBA in the Zone 2 (Japan)" region="JPN"/>
-		<rom name="NBA in the Zone 2 (Japan).z64" size="12582912" crc="41093b73" md5="f8f87aeb2c537c9cb2e9913050bfc928" sha1="a7685c8833256ecd1033862ea077e75147f9c49a"/>
+		<rom name="NBA in the Zone 2 (Japan).n64" />
+		<release name="NBA in the Zone 2 (Japan)" region="JPN" />
+		<rom name="NBA in the Zone 2 (Japan).z64" size="12582912" crc="41093b73" md5="f8f87aeb2c537c9cb2e9913050bfc928" sha1="a7685c8833256ecd1033862ea077e75147f9c49a" />
 	</game>
 	<game name="NBA Showtime - NBA on NBC (USA)">
 		<description>NBA Showtime - NBA on NBC (USA)</description>
-		<release name="NBA Showtime - NBA on NBC (USA)" region="USA"/>
-		<rom name="NBA Showtime - NBA on NBC (USA).z64" size="16777216" crc="a4e378f4" md5="881e98b47f32093c330a8b0dad6bb65d" sha1="702d6d55fc23c56b8a57d7348d159098fff98650"/>
+		<rom name="NBA Showtime - NBA on NBC (USA).n64" />
+		<release name="NBA Showtime - NBA on NBC (USA)" region="USA" />
+		<rom name="NBA Showtime - NBA on NBC (USA).z64" size="16777216" crc="a4e378f4" md5="881e98b47f32093c330a8b0dad6bb65d" sha1="702d6d55fc23c56b8a57d7348d159098fff98650" />
 	</game>
 	<game name="Neon Genesis Evangelion (Japan)">
 		<description>Neon Genesis Evangelion (Japan)</description>
-		<release name="Neon Genesis Evangelion (Japan)" region="JPN"/>
-		<rom name="Neon Genesis Evangelion (Japan).z64" size="33554432" crc="a10a86af" md5="5e1940ca1236a76e8f2d15de0414ae55" sha1="a9ba0a4afeed48080f54aa237850f3676b3d9980"/>
+		<rom name="Neon Genesis Evangelion (Japan).n64" />
+		<release name="Neon Genesis Evangelion (Japan)" region="JPN" />
+		<rom name="Neon Genesis Evangelion (Japan).z64" size="33554432" crc="a10a86af" md5="5e1940ca1236a76e8f2d15de0414ae55" sha1="a9ba0a4afeed48080f54aa237850f3676b3d9980" />
 	</game>
 	<game name="New Tetris, The (Europe)">
 		<description>New Tetris, The (Europe)</description>
-		<release name="New Tetris, The (Europe)" region="EUR"/>
-		<rom name="New Tetris, The (Europe).z64" size="12582912" crc="983263d7" md5="c4ecfec66eceea23f39632ab6753300f" sha1="2392f403b0993f838912cefa83aefd35d34a05a0"/>
+		<rom name="New Tetris, The (Europe).n64" />
+		<release name="New Tetris, The (Europe)" region="EUR" />
+		<rom name="New Tetris, The (Europe).z64" size="12582912" crc="983263d7" md5="c4ecfec66eceea23f39632ab6753300f" sha1="2392f403b0993f838912cefa83aefd35d34a05a0" />
 	</game>
 	<game name="New Tetris, The (USA)" cloneof="New Tetris, The (Europe)">
 		<description>New Tetris, The (USA)</description>
-		<release name="New Tetris, The (USA)" region="USA"/>
-		<rom name="New Tetris, The (USA).z64" size="12582912" crc="528a07fa" md5="7a28179b00734c9aa0f0609fafaafd5f" sha1="83fff25e82181a6993f28c91b9eeb8430396838b"/>
+		<rom name="New Tetris, The (USA).n64" />
+		<release name="New Tetris, The (USA)" region="USA" />
+		<rom name="New Tetris, The (USA).z64" size="12582912" crc="528a07fa" md5="7a28179b00734c9aa0f0609fafaafd5f" sha1="83fff25e82181a6993f28c91b9eeb8430396838b" />
 	</game>
 	<game name="NFL Blitz (USA)">
 		<description>NFL Blitz (USA)</description>
-		<release name="NFL Blitz (USA)" region="USA"/>
-		<rom name="NFL Blitz (USA).z64" size="16777216" crc="9bcd670f" md5="7f6c5e71711dec81e77ccf71060f67ca" sha1="2853afd9e38d63d913c8484f546804708c8ad712"/>
+		<rom name="NFL Blitz (USA).n64" />
+		<release name="NFL Blitz (USA)" region="USA" />
+		<rom name="NFL Blitz (USA).z64" size="16777216" crc="9bcd670f" md5="7f6c5e71711dec81e77ccf71060f67ca" sha1="2853afd9e38d63d913c8484f546804708c8ad712" />
 	</game>
 	<game name="NFL Blitz - Special Edition (USA)">
 		<description>NFL Blitz - Special Edition (USA)</description>
-		<release name="NFL Blitz - Special Edition (USA)" region="USA"/>
-		<rom name="NFL Blitz - Special Edition (USA).z64" size="16777216" crc="5d1907f7" md5="7e856fa8f743900feba5a4e28c234af7" sha1="a109f44bbb3270205205755ba9a889bafc6ff5ab"/>
+		<rom name="NFL Blitz - Special Edition (USA).n64" />
+		<release name="NFL Blitz - Special Edition (USA)" region="USA" />
+		<rom name="NFL Blitz - Special Edition (USA).z64" size="16777216" crc="5d1907f7" md5="7e856fa8f743900feba5a4e28c234af7" sha1="a109f44bbb3270205205755ba9a889bafc6ff5ab" />
 	</game>
 	<game name="NFL Blitz 2000 (USA) (Rev 1)">
 		<description>NFL Blitz 2000 (USA) (Rev 1)</description>
-		<release name="NFL Blitz 2000 (USA) (Rev 1)" region="USA"/>
-		<rom name="NFL Blitz 2000 (USA) (Rev 1).z64" size="16777216" crc="b591cfea" md5="dd96bb80e652cd1cf23ca4b8294ba7b5" sha1="3754c8fdf5cdce5de62685ce9be73e06ba5e3577" status="verified"/>
+		<rom name="NFL Blitz 2000 (USA) (Rev 1).n64" />
+		<release name="NFL Blitz 2000 (USA) (Rev 1)" region="USA" />
+		<rom name="NFL Blitz 2000 (USA) (Rev 1).z64" size="16777216" crc="b591cfea" md5="dd96bb80e652cd1cf23ca4b8294ba7b5" sha1="3754c8fdf5cdce5de62685ce9be73e06ba5e3577" status="verified" />
 	</game>
 	<game name="NFL Blitz 2000 (USA)" cloneof="NFL Blitz 2000 (USA) (Rev 1)">
 		<description>NFL Blitz 2000 (USA)</description>
-		<rom name="NFL Blitz 2000 (USA).z64" size="16777216" crc="7f471773" md5="ba49514441023722f02d41c62612f6c3" sha1="36e124746a842a2e1f72480f122dfe9188fc5575"/>
+		<rom name="NFL Blitz 2000 (USA).n64" />
+		<rom name="NFL Blitz 2000 (USA).z64" size="16777216" crc="7f471773" md5="ba49514441023722f02d41c62612f6c3" sha1="36e124746a842a2e1f72480f122dfe9188fc5575" />
 	</game>
 	<game name="NFL Blitz 2001 (USA)">
 		<description>NFL Blitz 2001 (USA)</description>
-		<release name="NFL Blitz 2001 (USA)" region="USA"/>
-		<rom name="NFL Blitz 2001 (USA).z64" size="16777216" crc="18eeb41b" md5="e4edd73cb036c6b143cee9aeeed60341" sha1="279bc9ed596663610265a618a1656dbb8ea4237a"/>
+		<rom name="NFL Blitz 2001 (USA).n64" />
+		<release name="NFL Blitz 2001 (USA)" region="USA" />
+		<rom name="NFL Blitz 2001 (USA).z64" size="16777216" crc="18eeb41b" md5="e4edd73cb036c6b143cee9aeeed60341" sha1="279bc9ed596663610265a618a1656dbb8ea4237a" />
 	</game>
 	<game name="NFL QB Club 2001 (USA)">
 		<description>NFL QB Club 2001 (USA)</description>
-		<release name="NFL QB Club 2001 (USA)" region="USA"/>
-		<rom name="NFL QB Club 2001 (USA).z64" size="12582912" crc="6d849e17" md5="fd2cbdea0992452b52e2803224232d12" sha1="c81421bb204270ef5ddd8f60dda51cdf73482fe2"/>
+		<rom name="NFL QB Club 2001 (USA).n64" />
+		<release name="NFL QB Club 2001 (USA)" region="USA" />
+		<rom name="NFL QB Club 2001 (USA).z64" size="12582912" crc="6d849e17" md5="fd2cbdea0992452b52e2803224232d12" sha1="c81421bb204270ef5ddd8f60dda51cdf73482fe2" />
 	</game>
 	<game name="NFL Quarterback Club 2000 (Europe)">
 		<description>NFL Quarterback Club 2000 (Europe)</description>
-		<release name="NFL Quarterback Club 2000 (Europe)" region="EUR"/>
-		<rom name="NFL Quarterback Club 2000 (Europe).z64" size="12582912" crc="ceef5c29" md5="75c0121d84915bf5c1fbd389cf9f9c17" sha1="cd97aece871f0ae5d29af9f92142a470a34273b9"/>
+		<rom name="NFL Quarterback Club 2000 (Europe).n64" />
+		<release name="NFL Quarterback Club 2000 (Europe)" region="EUR" />
+		<rom name="NFL Quarterback Club 2000 (Europe).z64" size="12582912" crc="ceef5c29" md5="75c0121d84915bf5c1fbd389cf9f9c17" sha1="cd97aece871f0ae5d29af9f92142a470a34273b9" />
 	</game>
 	<game name="NFL Quarterback Club 2000 (USA)" cloneof="NFL Quarterback Club 2000 (Europe)">
 		<description>NFL Quarterback Club 2000 (USA)</description>
-		<release name="NFL Quarterback Club 2000 (USA)" region="USA"/>
-		<rom name="NFL Quarterback Club 2000 (USA).z64" size="12582912" crc="8f54f999" md5="ec18e3131040842e32ebab66c7496ebd" sha1="390fea44c8df84f601b20a3e506fdd611ab34a8b"/>
+		<rom name="NFL Quarterback Club 2000 (USA).n64" />
+		<release name="NFL Quarterback Club 2000 (USA)" region="USA" />
+		<rom name="NFL Quarterback Club 2000 (USA).z64" size="12582912" crc="8f54f999" md5="ec18e3131040842e32ebab66c7496ebd" sha1="390fea44c8df84f601b20a3e506fdd611ab34a8b" />
 	</game>
 	<game name="NFL Quarterback Club 98 (Europe)">
 		<description>NFL Quarterback Club 98 (Europe)</description>
-		<release name="NFL Quarterback Club 98 (Europe)" region="EUR"/>
-		<rom name="NFL Quarterback Club 98 (Europe).z64" size="8388608" crc="34a21417" md5="a18ca5dbc85668667aa467add6a62b39" sha1="1f00635179fb741fbbcf31ffaff399469da16ecf"/>
+		<rom name="NFL Quarterback Club 98 (Europe).n64" />
+		<release name="NFL Quarterback Club 98 (Europe)" region="EUR" />
+		<rom name="NFL Quarterback Club 98 (Europe).z64" size="8388608" crc="34a21417" md5="a18ca5dbc85668667aa467add6a62b39" sha1="1f00635179fb741fbbcf31ffaff399469da16ecf" />
 	</game>
 	<game name="NFL Quarterback Club 98 (USA)" cloneof="NFL Quarterback Club 98 (Europe)">
 		<description>NFL Quarterback Club 98 (USA)</description>
-		<release name="NFL Quarterback Club 98 (USA)" region="USA"/>
-		<rom name="NFL Quarterback Club 98 (USA).z64" size="8388608" crc="abf0e8f2" md5="709f966c30ce6df1833e95740a5a2ab2" sha1="8e53de9eb6dcecb3b0bb3e707ef01690de7efab2"/>
+		<rom name="NFL Quarterback Club 98 (USA).n64" />
+		<release name="NFL Quarterback Club 98 (USA)" region="USA" />
+		<rom name="NFL Quarterback Club 98 (USA).z64" size="8388608" crc="abf0e8f2" md5="709f966c30ce6df1833e95740a5a2ab2" sha1="8e53de9eb6dcecb3b0bb3e707ef01690de7efab2" />
 	</game>
 	<game name="NFL Quarterback Club 99 (Europe)">
 		<description>NFL Quarterback Club 99 (Europe)</description>
-		<release name="NFL Quarterback Club 99 (Europe)" region="EUR"/>
-		<rom name="NFL Quarterback Club 99 (Europe).z64" size="12582912" crc="f688bdf3" md5="7ec0484c2ba6aa9f0a45d7ac1f4117da" sha1="1ee4ebaf6b0c189164397ea257f17b45eedf0767"/>
+		<rom name="NFL Quarterback Club 99 (Europe).n64" />
+		<release name="NFL Quarterback Club 99 (Europe)" region="EUR" />
+		<rom name="NFL Quarterback Club 99 (Europe).z64" size="12582912" crc="f688bdf3" md5="7ec0484c2ba6aa9f0a45d7ac1f4117da" sha1="1ee4ebaf6b0c189164397ea257f17b45eedf0767" />
 	</game>
 	<game name="NFL Quarterback Club 99 (USA)" cloneof="NFL Quarterback Club 99 (Europe)">
 		<description>NFL Quarterback Club 99 (USA)</description>
-		<release name="NFL Quarterback Club 99 (USA)" region="USA"/>
-		<rom name="NFL Quarterback Club 99 (USA).z64" size="12582912" crc="44496b26" md5="928869d1ce001b813ba908dfe18d7f94" sha1="8dba75859d21219b3638e337991851db31b4d70e"/>
+		<rom name="NFL Quarterback Club 99 (USA).n64" />
+		<release name="NFL Quarterback Club 99 (USA)" region="USA" />
+		<rom name="NFL Quarterback Club 99 (USA).z64" size="12582912" crc="44496b26" md5="928869d1ce001b813ba908dfe18d7f94" sha1="8dba75859d21219b3638e337991851db31b4d70e" />
 	</game>
 	<game name="NHL 99 (Europe) (En,De,Sv,Fi)">
 		<description>NHL 99 (Europe) (En,De,Sv,Fi)</description>
-		<release name="NHL 99 (Europe) (En,De,Sv,Fi)" region="EUR"/>
-		<rom name="NHL 99 (Europe) (En,De,Sv,Fi).z64" size="12582912" crc="f3b2aa4d" md5="b7e41d34d209b6cfa92e3d622f911c4e" sha1="87cd5ecff93d5b34c246cb96a6249b78b5b90126"/>
+		<rom name="NHL 99 (Europe) (En,De,Sv,Fi).n64" />
+		<release name="NHL 99 (Europe) (En,De,Sv,Fi)" region="EUR" />
+		<rom name="NHL 99 (Europe) (En,De,Sv,Fi).z64" size="12582912" crc="f3b2aa4d" md5="b7e41d34d209b6cfa92e3d622f911c4e" sha1="87cd5ecff93d5b34c246cb96a6249b78b5b90126" />
 	</game>
 	<game name="NHL 99 (USA)" cloneof="NHL 99 (Europe) (En,De,Sv,Fi)">
 		<description>NHL 99 (USA)</description>
-		<release name="NHL 99 (USA)" region="USA"/>
-		<rom name="NHL 99 (USA).z64" size="12582912" crc="e5df2afe" md5="a62fa044bcb5507d358424abda6419db" sha1="d730540d8c447420de4aa81f6a2776c2e310d12a"/>
+		<rom name="NHL 99 (USA).n64" />
+		<release name="NHL 99 (USA)" region="USA" />
+		<rom name="NHL 99 (USA).z64" size="12582912" crc="e5df2afe" md5="a62fa044bcb5507d358424abda6419db" sha1="d730540d8c447420de4aa81f6a2776c2e310d12a" />
 	</game>
 	<game name="NHL Breakaway 98 (Europe)">
 		<description>NHL Breakaway 98 (Europe)</description>
-		<release name="NHL Breakaway 98 (Europe)" region="EUR"/>
-		<rom name="NHL Breakaway 98 (Europe).z64" size="12582912" crc="8c0c9669" md5="46476a5626cd99b3749ac1ee1e234fac" sha1="6d6631fe93b7c70ae28960f4141ac7656b333aa4"/>
+		<rom name="NHL Breakaway 98 (Europe).n64" />
+		<release name="NHL Breakaway 98 (Europe)" region="EUR" />
+		<rom name="NHL Breakaway 98 (Europe).z64" size="12582912" crc="8c0c9669" md5="46476a5626cd99b3749ac1ee1e234fac" sha1="6d6631fe93b7c70ae28960f4141ac7656b333aa4" />
 	</game>
 	<game name="NHL Breakaway 98 (USA)" cloneof="NHL Breakaway 98 (Europe)">
 		<description>NHL Breakaway 98 (USA)</description>
-		<release name="NHL Breakaway 98 (USA)" region="USA"/>
-		<rom name="NHL Breakaway 98 (USA).z64" size="12582912" crc="49d86c00" md5="b62076fa1421b8e7fdec2b4f8a910ea3" sha1="2658334bf4091d0d3ed2de3327592d04fc0b6849"/>
+		<rom name="NHL Breakaway 98 (USA).n64" />
+		<release name="NHL Breakaway 98 (USA)" region="USA" />
+		<rom name="NHL Breakaway 98 (USA).z64" size="12582912" crc="49d86c00" md5="b62076fa1421b8e7fdec2b4f8a910ea3" sha1="2658334bf4091d0d3ed2de3327592d04fc0b6849" />
 	</game>
 	<game name="NHL Breakaway 99 (Europe)">
 		<description>NHL Breakaway 99 (Europe)</description>
-		<release name="NHL Breakaway 99 (Europe)" region="EUR"/>
-		<rom name="NHL Breakaway 99 (Europe).z64" size="12582912" crc="572060e0" md5="4ba95aa97ecfee36051ebe0a9024eee8" sha1="46147db00bd9d80f0d22e8eb1b00603106de2692"/>
+		<rom name="NHL Breakaway 99 (Europe).n64" />
+		<release name="NHL Breakaway 99 (Europe)" region="EUR" />
+		<rom name="NHL Breakaway 99 (Europe).z64" size="12582912" crc="572060e0" md5="4ba95aa97ecfee36051ebe0a9024eee8" sha1="46147db00bd9d80f0d22e8eb1b00603106de2692" />
 	</game>
 	<game name="NHL Breakaway 99 (USA)" cloneof="NHL Breakaway 99 (Europe)">
 		<description>NHL Breakaway 99 (USA)</description>
-		<release name="NHL Breakaway 99 (USA)" region="USA"/>
-		<rom name="NHL Breakaway 99 (USA).z64" size="12582912" crc="75f75b9d" md5="af1d07679014760b88923a4827658caf" sha1="65c0f8bf81d8dec3e5d719b167a61a73b2436e84"/>
+		<rom name="NHL Breakaway 99 (USA).n64" />
+		<release name="NHL Breakaway 99 (USA)" region="USA" />
+		<rom name="NHL Breakaway 99 (USA).z64" size="12582912" crc="75f75b9d" md5="af1d07679014760b88923a4827658caf" sha1="65c0f8bf81d8dec3e5d719b167a61a73b2436e84" />
 	</game>
 	<game name="NHL Pro 99 (Europe)">
 		<description>NHL Pro 99 (Europe)</description>
-		<release name="NHL Pro 99 (Europe)" region="EUR"/>
-		<rom name="NHL Pro 99 (Europe).z64" size="12582912" crc="e272867e" md5="a61854cf27e536c8513174faef08dfcb" sha1="4ff557ccd19982699b3aa82d4c44f436d1d87f93"/>
+		<rom name="NHL Pro 99 (Europe).n64" />
+		<release name="NHL Pro 99 (Europe)" region="EUR" />
+		<rom name="NHL Pro 99 (Europe).z64" size="12582912" crc="e272867e" md5="a61854cf27e536c8513174faef08dfcb" sha1="4ff557ccd19982699b3aa82d4c44f436d1d87f93" />
 	</game>
 	<game name="NHL Blades of Steel '99 (USA)" cloneof="NHL Pro 99 (Europe)">
 		<description>NHL Blades of Steel '99 (USA)</description>
-		<release name="NHL Blades of Steel '99 (USA)" region="USA"/>
-		<rom name="NHL Blades of Steel '99 (USA).z64" size="12582912" crc="1ee678fe" md5="349f61f9747f2d2098f305924c97a1bf" sha1="c55e9771b1548cfe4297646adcfcafe85712da5e"/>
+		<rom name="NHL Blades of Steel '99 (USA).n64" />
+		<release name="NHL Blades of Steel '99 (USA)" region="USA" />
+		<rom name="NHL Blades of Steel '99 (USA).z64" size="12582912" crc="1ee678fe" md5="349f61f9747f2d2098f305924c97a1bf" sha1="c55e9771b1548cfe4297646adcfcafe85712da5e" />
 	</game>
 	<game name="Nightmare Creatures (USA)">
 		<description>Nightmare Creatures (USA)</description>
-		<release name="Nightmare Creatures (USA)" region="USA"/>
-		<rom name="Nightmare Creatures (USA).z64" size="16777216" crc="6a1eb795" md5="4116cf435db315a2481af8d1e9352feb" sha1="bea6c21b3ef5950bdf8cdb255955da6c4746eea8"/>
+		<rom name="Nightmare Creatures (USA).n64" />
+		<release name="Nightmare Creatures (USA)" region="USA" />
+		<rom name="Nightmare Creatures (USA).z64" size="16777216" crc="6a1eb795" md5="4116cf435db315a2481af8d1e9352feb" sha1="bea6c21b3ef5950bdf8cdb255955da6c4746eea8" />
 	</game>
 	<game name="Nintama Rantarou 64 Game Gallery (Japan)">
 		<description>Nintama Rantarou 64 Game Gallery (Japan)</description>
-		<release name="Nintama Rantarou 64 Game Gallery (Japan)" region="JPN"/>
-		<rom name="Nintama Rantarou 64 Game Gallery (Japan).z64" size="8388608" crc="8c7c2dca" md5="b04957d052ef850c5edece69db7377b3" sha1="1bf5217924c5fb00f8e8829e9ebf3fbceb89b9cd"/>
+		<rom name="Nintama Rantarou 64 Game Gallery (Japan).n64" />
+		<release name="Nintama Rantarou 64 Game Gallery (Japan)" region="JPN" />
+		<rom name="Nintama Rantarou 64 Game Gallery (Japan).z64" size="8388608" crc="8c7c2dca" md5="b04957d052ef850c5edece69db7377b3" sha1="1bf5217924c5fb00f8e8829e9ebf3fbceb89b9cd" />
 	</game>
 	<game name="Nuclear Strike 64 (Europe) (En,Fr)">
 		<description>Nuclear Strike 64 (Europe) (En,Fr)</description>
-		<release name="Nuclear Strike 64 (Europe) (En,Fr)" region="EUR"/>
-		<rom name="Nuclear Strike 64 (Europe) (En,Fr).z64" size="33554432" crc="9afbfcaf" md5="710ba49ebd5c9a2b26653fae93bd667a" sha1="34a23cfa247de4e8ecdb8d72431af93d35c69753"/>
+		<rom name="Nuclear Strike 64 (Europe) (En,Fr).n64" />
+		<release name="Nuclear Strike 64 (Europe) (En,Fr)" region="EUR" />
+		<rom name="Nuclear Strike 64 (Europe) (En,Fr).z64" size="33554432" crc="9afbfcaf" md5="710ba49ebd5c9a2b26653fae93bd667a" sha1="34a23cfa247de4e8ecdb8d72431af93d35c69753" />
 	</game>
 	<game name="Nuclear Strike 64 (Germany)" cloneof="Nuclear Strike 64 (Europe) (En,Fr)">
 		<description>Nuclear Strike 64 (Germany)</description>
-		<release name="Nuclear Strike 64 (Germany)" region="GER"/>
-		<rom name="Nuclear Strike 64 (Germany).z64" size="33554432" crc="d175397b" md5="ca996f7a126da8104b806d4c7bfa20b8" sha1="141aafb638f782809943fff526ddb2e542e6df52"/>
+		<rom name="Nuclear Strike 64 (Germany).n64" />
+		<release name="Nuclear Strike 64 (Germany)" region="GER" />
+		<rom name="Nuclear Strike 64 (Germany).z64" size="33554432" crc="d175397b" md5="ca996f7a126da8104b806d4c7bfa20b8" sha1="141aafb638f782809943fff526ddb2e542e6df52" />
 	</game>
 	<game name="Nuclear Strike 64 (USA)" cloneof="Nuclear Strike 64 (Europe) (En,Fr)">
 		<description>Nuclear Strike 64 (USA)</description>
-		<release name="Nuclear Strike 64 (USA)" region="USA"/>
-		<rom name="Nuclear Strike 64 (USA).z64" size="33554432" crc="d7467294" md5="ffc584040d0d052fbab4cb6c19245449" sha1="6a8b0b450e87fbfbadeee3854ada0731deb6e8b5" status="verified"/>
+		<rom name="Nuclear Strike 64 (USA).n64" />
+		<release name="Nuclear Strike 64 (USA)" region="USA" />
+		<rom name="Nuclear Strike 64 (USA).z64" size="33554432" crc="d7467294" md5="ffc584040d0d052fbab4cb6c19245449" sha1="6a8b0b450e87fbfbadeee3854ada0731deb6e8b5" status="verified" />
 	</game>
 	<game name="Nuclear Strike 64 (Germany) (Beta) (1999-11-17)" cloneof="Nuclear Strike 64 (Europe) (En,Fr)">
 		<description>Nuclear Strike 64 (Germany) (Beta) (1999-11-17)</description>
-		<rom name="Nuclear Strike 64 (Germany) (Beta) (1999-11-17).z64" size="33554432" crc="020b6443" md5="aced6f89b3500c618afe47c04f0256e8" sha1="fb1c682546b02b5d76fd83cf5b24e2a3c8285adf"/>
+		<rom name="Nuclear Strike 64 (Germany) (Beta) (1999-11-17).n64" />
+		<rom name="Nuclear Strike 64 (Germany) (Beta) (1999-11-17).z64" size="33554432" crc="020b6443" md5="aced6f89b3500c618afe47c04f0256e8" sha1="fb1c682546b02b5d76fd83cf5b24e2a3c8285adf" />
 	</game>
 	<game name="Nushi Zuri 64 (Japan) (Rev 1)">
 		<description>Nushi Zuri 64 (Japan) (Rev 1)</description>
-		<release name="Nushi Zuri 64 (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Nushi Zuri 64 (Japan) (Rev 1).z64" size="16777216" crc="16414ae4" md5="d2af6993e4d657d00520c2cce741480e" sha1="a33d47bf0007467c7380c9a37d9a0c30abc67df5"/>
+		<rom name="Nushi Zuri 64 (Japan) (Rev 1).n64" />
+		<release name="Nushi Zuri 64 (Japan) (Rev 1)" region="JPN" />
+		<rom name="Nushi Zuri 64 (Japan) (Rev 1).z64" size="16777216" crc="16414ae4" md5="d2af6993e4d657d00520c2cce741480e" sha1="a33d47bf0007467c7380c9a37d9a0c30abc67df5" />
 	</game>
 	<game name="Nushi Zuri 64 (Japan)" cloneof="Nushi Zuri 64 (Japan) (Rev 1)">
 		<description>Nushi Zuri 64 (Japan)</description>
-		<rom name="Nushi Zuri 64 (Japan).z64" size="16777216" crc="a6800ec0" md5="50c10082d0c077fdb5658ef5a6e3f54f" sha1="5f20d41669458e1c981292f17cd8b29032406287"/>
+		<rom name="Nushi Zuri 64 (Japan).n64" />
+		<rom name="Nushi Zuri 64 (Japan).z64" size="16777216" crc="a6800ec0" md5="50c10082d0c077fdb5658ef5a6e3f54f" sha1="5f20d41669458e1c981292f17cd8b29032406287" />
 	</game>
 	<game name="Nushi Zuri 64 - Shiokaze ni Notte (Japan)">
 		<description>Nushi Zuri 64 - Shiokaze ni Notte (Japan)</description>
-		<release name="Nushi Zuri 64 - Shiokaze ni Notte (Japan)" region="JPN"/>
-		<rom name="Nushi Zuri 64 - Shiokaze ni Notte (Japan).z64" size="33554432" crc="f0bcd1ce" md5="eeb69597e42e2f5d2914070acf161b4f" sha1="85d8b412e3045c7a06062d3e155fef9ea918e800"/>
+		<rom name="Nushi Zuri 64 - Shiokaze ni Notte (Japan).n64" />
+		<release name="Nushi Zuri 64 - Shiokaze ni Notte (Japan)" region="JPN" />
+		<rom name="Nushi Zuri 64 - Shiokaze ni Notte (Japan).z64" size="33554432" crc="f0bcd1ce" md5="eeb69597e42e2f5d2914070acf161b4f" sha1="85d8b412e3045c7a06062d3e155fef9ea918e800" />
 	</game>
 	<game name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)">
 		<description>O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)</description>
-		<release name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)" region="EUR"/>
-		<rom name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto).z64" size="16777216" crc="7b870026" md5="e2fb4f16a039a0e302d28aca94d5d928" sha1="092fb7c560b40cc3a2a0e6b48a6afc10948c4166"/>
+		<rom name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto).n64" />
+		<release name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)" region="EUR" />
+		<rom name="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto).z64" size="16777216" crc="7b870026" md5="e2fb4f16a039a0e302d28aca94d5d928" sha1="092fb7c560b40cc3a2a0e6b48a6afc10948c4166" />
 	</game>
 	<game name="O.D.T. (USA) (En,Fr,Es) (Proto)" cloneof="O.D.T. (Europe) (En,Fr,De,Es,It) (Proto)">
 		<description>O.D.T. (USA) (En,Fr,Es) (Proto)</description>
-		<release name="O.D.T. (USA) (En,Fr,Es) (Proto)" region="USA"/>
-		<rom name="O.D.T. (USA) (En,Fr,Es) (Proto).z64" size="16777216" crc="1d4a8659" md5="4116e492168aafff1bd3100c7b0aa28f" sha1="453a7a636b05c8b9dad6aa6fb5e265baae568074"/>
+		<rom name="O.D.T. (USA) (En,Fr,Es) (Proto).n64" />
+		<release name="O.D.T. (USA) (En,Fr,Es) (Proto)" region="USA" />
+		<rom name="O.D.T. (USA) (En,Fr,Es) (Proto).z64" size="16777216" crc="1d4a8659" md5="4116e492168aafff1bd3100c7b0aa28f" sha1="453a7a636b05c8b9dad6aa6fb5e265baae568074" />
 	</game>
 	<game name="Off Road Challenge (Europe)">
 		<description>Off Road Challenge (Europe)</description>
-		<release name="Off Road Challenge (Europe)" region="EUR"/>
-		<rom name="Off Road Challenge (Europe).z64" size="16777216" crc="d9fe9ee7" md5="e96fecba52905db14addad7cfd61091f" sha1="3476e0eb4048c76107bd2b404d19a136bfc15ad9"/>
+		<rom name="Off Road Challenge (Europe).n64" />
+		<release name="Off Road Challenge (Europe)" region="EUR" />
+		<rom name="Off Road Challenge (Europe).z64" size="16777216" crc="d9fe9ee7" md5="e96fecba52905db14addad7cfd61091f" sha1="3476e0eb4048c76107bd2b404d19a136bfc15ad9" />
 	</game>
 	<game name="Off Road Challenge (USA)" cloneof="Off Road Challenge (Europe)">
 		<description>Off Road Challenge (USA)</description>
-		<release name="Off Road Challenge (USA)" region="USA"/>
-		<rom name="Off Road Challenge (USA).z64" size="16777216" crc="1a45c5ab" md5="af7083fc0abcfd5a2c6a5e971453d831" sha1="9e754ca37d69424e9f82a421d5e69d4ad73046c1"/>
+		<rom name="Off Road Challenge (USA).n64" />
+		<release name="Off Road Challenge (USA)" region="USA" />
+		<rom name="Off Road Challenge (USA).z64" size="16777216" crc="1a45c5ab" md5="af7083fc0abcfd5a2c6a5e971453d831" sha1="9e754ca37d69424e9f82a421d5e69d4ad73046c1" />
 	</game>
 	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)</description>
-		<release name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)" region="USA"/>
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1).z64" size="41943040" crc="410f6510" md5="ebb4b4d2808df427aaa3085a41b8a954" sha1="d26b14bee422a09581ce438d45ba9fec9783fbb8"/>
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1).n64" />
+		<release name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)" region="USA" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1).z64" size="41943040" crc="410f6510" md5="ebb4b4d2808df427aaa3085a41b8a954" sha1="d26b14bee422a09581ce438d45ba9fec9783fbb8" />
 	</game>
 	<game name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1)" cloneof="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1)</description>
-		<release name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1).z64" size="41943040" crc="845b8711" md5="a45c39767d33ac21956a3d4e6c03cfa1" sha1="244a92df46863964ec507c78b72c226f48754967"/>
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1).n64" />
+		<release name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1)" region="JPN" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1).z64" size="41943040" crc="845b8711" md5="a45c39767d33ac21956a3d4e6c03cfa1" sha1="244a92df46863964ec507c78b72c226f48754967" />
 	</game>
 	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA)" cloneof="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (USA)</description>
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA).z64" size="41943040" crc="a05aea85" md5="f666e020218392e52662fddfa1ea4f21" sha1="9cd0cfb50b883edb068e0c30d213193b9cf89895" status="verified"/>
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA).n64" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA).z64" size="41943040" crc="a05aea85" md5="f666e020218392e52662fddfa1ea4f21" sha1="9cd0cfb50b883edb068e0c30d213193b9cf89895" status="verified" />
 	</game>
 	<game name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console)" cloneof="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console)</description>
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console).z64" size="41943040" crc="19337b04" md5="f04c8f511b678301b21c54a27cb08bb9" sha1="604c5bc450d0c33b536c185f53725c2baf622f3b" status="verified"/>
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console).n64" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (USA, Europe) (Rev 1) (Wii Virtual Console).z64" size="41943040" crc="19337b04" md5="f04c8f511b678301b21c54a27cb08bb9" sha1="604c5bc450d0c33b536c185f53725c2baf622f3b" status="verified" />
 	</game>
 	<game name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console)" cloneof="Ogre Battle 64 - Person of Lordly Caliber (USA) (Rev 1)">
 		<description>Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console)</description>
-		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console).z64" size="41943040" crc="991f569c" md5="55cd360f12be8063c9e7b6f59f268170" sha1="127b7a9fdca399494db8409a99874672ca200cb6"/>
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console).n64" />
+		<rom name="Ogre Battle 64 - Person of Lordly Caliber (Japan) (Rev 1) (Wii Virtual Console).z64" size="41943040" crc="991f569c" md5="55cd360f12be8063c9e7b6f59f268170" sha1="127b7a9fdca399494db8409a99874672ca200cb6" />
 	</game>
 	<game name="Olympic Hockey 98 (Europe) (En,Fr,De,Es)">
 		<description>Olympic Hockey 98 (Europe) (En,Fr,De,Es)</description>
-		<release name="Olympic Hockey 98 (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Olympic Hockey 98 (Europe) (En,Fr,De,Es).z64" size="8388608" crc="5a805c2e" md5="465dfd27ddab4f5488f4dadc09b7f938" sha1="e01404fac7e9afc02d48bf889aba51f843165b7c"/>
+		<rom name="Olympic Hockey 98 (Europe) (En,Fr,De,Es).n64" />
+		<release name="Olympic Hockey 98 (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Olympic Hockey 98 (Europe) (En,Fr,De,Es).z64" size="8388608" crc="5a805c2e" md5="465dfd27ddab4f5488f4dadc09b7f938" sha1="e01404fac7e9afc02d48bf889aba51f843165b7c" />
 	</game>
 	<game name="Olympic Hockey 98 (Japan)" cloneof="Olympic Hockey 98 (Europe) (En,Fr,De,Es)">
 		<description>Olympic Hockey 98 (Japan)</description>
-		<release name="Olympic Hockey 98 (Japan)" region="JPN"/>
-		<rom name="Olympic Hockey 98 (Japan).z64" size="8388608" crc="9e98fce8" md5="8a964671c5a4f4fc62787f1f25edd70d" sha1="a5359e35839b40c414eae498ca633b28176629aa"/>
+		<rom name="Olympic Hockey 98 (Japan).n64" />
+		<release name="Olympic Hockey 98 (Japan)" region="JPN" />
+		<rom name="Olympic Hockey 98 (Japan).z64" size="8388608" crc="9e98fce8" md5="8a964671c5a4f4fc62787f1f25edd70d" sha1="a5359e35839b40c414eae498ca633b28176629aa" />
 	</game>
 	<game name="Olympic Hockey 98 (USA)" cloneof="Olympic Hockey 98 (Europe) (En,Fr,De,Es)">
 		<description>Olympic Hockey 98 (USA)</description>
-		<release name="Olympic Hockey 98 (USA)" region="USA"/>
-		<rom name="Olympic Hockey 98 (USA).z64" size="8388608" crc="2d777652" md5="9c99c6d9ea98a960056c531cb78eb35b" sha1="02310067defd4c7eac235dff5e71ef0566ce916c"/>
+		<rom name="Olympic Hockey 98 (USA).n64" />
+		<release name="Olympic Hockey 98 (USA)" region="USA" />
+		<rom name="Olympic Hockey 98 (USA).z64" size="8388608" crc="2d777652" md5="9c99c6d9ea98a960056c531cb78eb35b" sha1="02310067defd4c7eac235dff5e71ef0566ce916c" />
 	</game>
 	<game name="Onegai Monsters (Japan)">
 		<description>Onegai Monsters (Japan)</description>
-		<release name="Onegai Monsters (Japan)" region="JPN"/>
-		<rom name="Onegai Monsters (Japan).z64" size="16777216" crc="ac72a1c7" md5="3796829f54958ce103dcf5e3e8eb80b4" sha1="7592f4c16b8e040539b5dcc201fab2965a5e8c8d"/>
+		<rom name="Onegai Monsters (Japan).n64" />
+		<release name="Onegai Monsters (Japan)" region="JPN" />
+		<rom name="Onegai Monsters (Japan).z64" size="16777216" crc="ac72a1c7" md5="3796829f54958ce103dcf5e3e8eb80b4" sha1="7592f4c16b8e040539b5dcc201fab2965a5e8c8d" />
 	</game>
 	<game name="Operation WinBack (Europe) (En,Fr,De,Es,It)">
 		<description>Operation WinBack (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Operation WinBack (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Operation WinBack (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="fb96f166" md5="91cf1982f309bd73822165087dad4371" sha1="133f17162b2734286f9e94f64acb1538b11506b2"/>
+		<rom name="Operation WinBack (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Operation WinBack (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Operation WinBack (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="fb96f166" md5="91cf1982f309bd73822165087dad4371" sha1="133f17162b2734286f9e94f64acb1538b11506b2" />
 	</game>
 	<game name="WinBack (Japan)" cloneof="Operation WinBack (Europe) (En,Fr,De,Es,It)">
 		<description>WinBack (Japan)</description>
-		<rom name="WinBack (Japan).z64" size="16777216" crc="d35360b0" md5="ee3d3550acc463ca57408bf14e541f68" sha1="d6db9e2509b760403f5db330142055af842fb52c"/>
+		<rom name="WinBack (Japan).n64" />
+		<rom name="WinBack (Japan).z64" size="16777216" crc="d35360b0" md5="ee3d3550acc463ca57408bf14e541f68" sha1="d6db9e2509b760403f5db330142055af842fb52c" />
 	</game>
 	<game name="WinBack (Japan) (Rev 1)" cloneof="Operation WinBack (Europe) (En,Fr,De,Es,It)">
 		<description>WinBack (Japan) (Rev 1)</description>
-		<release name="WinBack (Japan) (Rev 1)" region="JPN"/>
-		<rom name="WinBack (Japan) (Rev 1).z64" size="16777216" crc="927383bb" md5="9789a48e1d9e42c2f69c59964371089f" sha1="660f8778bc816046e1bcc11e1a975fed5db17410"/>
+		<rom name="WinBack (Japan) (Rev 1).n64" />
+		<release name="WinBack (Japan) (Rev 1)" region="JPN" />
+		<rom name="WinBack (Japan) (Rev 1).z64" size="16777216" crc="927383bb" md5="9789a48e1d9e42c2f69c59964371089f" sha1="660f8778bc816046e1bcc11e1a975fed5db17410" />
 	</game>
 	<game name="WinBack - Covert Operations (USA)" cloneof="Operation WinBack (Europe) (En,Fr,De,Es,It)">
 		<description>WinBack - Covert Operations (USA)</description>
-		<release name="WinBack - Covert Operations (USA)" region="USA"/>
-		<rom name="WinBack - Covert Operations (USA).z64" size="16777216" crc="64c817c5" md5="48da6cdcab838153caa2ecc3dd592a65" sha1="fa04477b321a95e1f7a2edcac5c09bfa6ef72041"/>
+		<rom name="WinBack - Covert Operations (USA).n64" />
+		<release name="WinBack - Covert Operations (USA)" region="USA" />
+		<rom name="WinBack - Covert Operations (USA).z64" size="16777216" crc="64c817c5" md5="48da6cdcab838153caa2ecc3dd592a65" sha1="fa04477b321a95e1f7a2edcac5c09bfa6ef72041" />
 	</game>
 	<game name="Pachinko 365 Nichi (Japan)">
 		<description>Pachinko 365 Nichi (Japan)</description>
-		<release name="Pachinko 365 Nichi (Japan)" region="JPN"/>
-		<rom name="Pachinko 365 Nichi (Japan).z64" size="12582912" crc="42d06e32" md5="d60046c23400bfebd5b051f89e7f2f07" sha1="b8f29e8efcf51ee9a6a16e2a1e60442b4f304950"/>
+		<rom name="Pachinko 365 Nichi (Japan).n64" />
+		<release name="Pachinko 365 Nichi (Japan)" region="JPN" />
+		<rom name="Pachinko 365 Nichi (Japan).z64" size="12582912" crc="42d06e32" md5="d60046c23400bfebd5b051f89e7f2f07" sha1="b8f29e8efcf51ee9a6a16e2a1e60442b4f304950" />
 	</game>
 	<game name="Paper Mario (Europe) (En,Fr,De,Es)">
 		<description>Paper Mario (Europe) (En,Fr,De,Es)</description>
-		<release name="Paper Mario (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Paper Mario (Europe) (En,Fr,De,Es).z64" size="50331648" crc="9fc00ce3" md5="3b5c99f5e7dba06bf8237e58f6d4196b" sha1="1273275142b79f7443f55bd35679a19670adfe3a" status="verified"/>
+		<rom name="Paper Mario (Europe) (En,Fr,De,Es).n64" />
+		<release name="Paper Mario (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Paper Mario (Europe) (En,Fr,De,Es).z64" size="50331648" crc="9fc00ce3" md5="3b5c99f5e7dba06bf8237e58f6d4196b" sha1="1273275142b79f7443f55bd35679a19670adfe3a" status="verified" />
 	</game>
 	<game name="Mario Story (Japan)" cloneof="Paper Mario (Europe) (En,Fr,De,Es)">
 		<description>Mario Story (Japan)</description>
-		<release name="Mario Story (Japan)" region="JPN"/>
-		<rom name="Mario Story (Japan).z64" size="41943040" crc="bd60ca66" md5="df54f17fb84fb5b5bcf6aa9af65b0942" sha1="b9cca3ff260b9ff427d981626b82f96de73586d3" status="verified"/>
+		<rom name="Mario Story (Japan).n64" />
+		<release name="Mario Story (Japan)" region="JPN" />
+		<rom name="Mario Story (Japan).z64" size="41943040" crc="bd60ca66" md5="df54f17fb84fb5b5bcf6aa9af65b0942" sha1="b9cca3ff260b9ff427d981626b82f96de73586d3" status="verified" />
 	</game>
 	<game name="Paper Mario (USA)" cloneof="Paper Mario (Europe) (En,Fr,De,Es)">
 		<description>Paper Mario (USA)</description>
-		<release name="Paper Mario (USA)" region="USA"/>
-		<rom name="Paper Mario (USA).z64" size="41943040" crc="a7f5cd7e" md5="a722f8161ff489943191330bf8416496" sha1="3837f44cda784b466c9a2d99df70d77c322b97a0" status="verified"/>
+		<rom name="Paper Mario (USA).n64" />
+		<release name="Paper Mario (USA)" region="USA" />
+		<rom name="Paper Mario (USA).z64" size="41943040" crc="a7f5cd7e" md5="a722f8161ff489943191330bf8416496" sha1="3837f44cda784b466c9a2d99df70d77c322b97a0" status="verified" />
 	</game>
 	<game name="Zhi Pian Mario (China) (iQue)" cloneof="Paper Mario (Europe) (En,Fr,De,Es)">
 		<description>Zhi Pian Mario (China) (iQue)</description>
-		<rom name="Zhi Pian Mario (China) (iQue).z64" size="41943040" crc="18c02ad5" md5="8f8f50ab00c4089ae32c6b9fefd69543" sha1="5c724685085eba796537573dd6f84aaddedc8582"/>
+		<rom name="Zhi Pian Mario (China) (iQue).n64" />
+		<rom name="Zhi Pian Mario (China) (iQue).z64" size="41943040" crc="18c02ad5" md5="8f8f50ab00c4089ae32c6b9fefd69543" sha1="5c724685085eba796537573dd6f84aaddedc8582" />
 	</game>
 	<game name="Paperboy (Europe)">
 		<description>Paperboy (Europe)</description>
-		<release name="Paperboy (Europe)" region="EUR"/>
-		<rom name="Paperboy (Europe).z64" size="12582912" crc="f00c5053" md5="b7f2eb7989c9c00096655d087d72ec51" sha1="7db4808042b9651b47592e814ac4c125b51d4d2f"/>
+		<rom name="Paperboy (Europe).n64" />
+		<release name="Paperboy (Europe)" region="EUR" />
+		<rom name="Paperboy (Europe).z64" size="12582912" crc="f00c5053" md5="b7f2eb7989c9c00096655d087d72ec51" sha1="7db4808042b9651b47592e814ac4c125b51d4d2f" />
 	</game>
 	<game name="Paperboy (USA)" cloneof="Paperboy (Europe)">
 		<description>Paperboy (USA)</description>
-		<release name="Paperboy (USA)" region="USA"/>
-		<rom name="Paperboy (USA).z64" size="12582912" crc="f27114e6" md5="c4cbcb54b010a5a71fe5caa391e5c25f" sha1="b043c47b9758fa6bb289ca7dba2068bda6cafa3a"/>
+		<rom name="Paperboy (USA).n64" />
+		<release name="Paperboy (USA)" region="USA" />
+		<rom name="Paperboy (USA).z64" size="12582912" crc="f27114e6" md5="c4cbcb54b010a5a71fe5caa391e5c25f" sha1="b043c47b9758fa6bb289ca7dba2068bda6cafa3a" />
 	</game>
 	<game name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)">
 		<description>Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)</description>
-		<release name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)" region="JPN"/>
-		<rom name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan).z64" size="12582912" crc="a33146e0" md5="d78e10c6b3e98f3b32fe0f23ed72db42" sha1="9887a0e4bfe3c5e85e31638853574069f6c41cd3"/>
+		<rom name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan).n64" />
+		<release name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan)" region="JPN" />
+		<rom name="Parlor! Pro 64 - Pachinko Jikki Simulation Game (Japan).z64" size="12582912" crc="a33146e0" md5="d78e10c6b3e98f3b32fe0f23ed72db42" sha1="9887a0e4bfe3c5e85e31638853574069f6c41cd3" />
 	</game>
 	<game name="PD Ultraman Battle Collection 64 (Japan)">
 		<description>PD Ultraman Battle Collection 64 (Japan)</description>
-		<release name="PD Ultraman Battle Collection 64 (Japan)" region="JPN"/>
-		<rom name="PD Ultraman Battle Collection 64 (Japan).z64" size="33554432" crc="86cc80b5" md5="52f4f3320607f3e8dd1a16a2f1bfbdb0" sha1="16783d9de1ff772e215f47441612d6805aa98c67"/>
+		<rom name="PD Ultraman Battle Collection 64 (Japan).n64" />
+		<release name="PD Ultraman Battle Collection 64 (Japan)" region="JPN" />
+		<rom name="PD Ultraman Battle Collection 64 (Japan).z64" size="33554432" crc="86cc80b5" md5="52f4f3320607f3e8dd1a16a2f1bfbdb0" sha1="16783d9de1ff772e215f47441612d6805aa98c67" />
 	</game>
 	<game name="Penny Racers (Europe)">
 		<description>Penny Racers (Europe)</description>
-		<release name="Penny Racers (Europe)" region="EUR"/>
-		<rom name="Penny Racers (Europe).z64" size="8388608" crc="a1d6eb5b" md5="20da62ece553ede84d02283174becc8f" sha1="9848cc288b388d23e0ae026ef58da8fc936d7605"/>
+		<rom name="Penny Racers (Europe).n64" />
+		<release name="Penny Racers (Europe)" region="EUR" />
+		<rom name="Penny Racers (Europe).z64" size="8388608" crc="a1d6eb5b" md5="20da62ece553ede84d02283174becc8f" sha1="9848cc288b388d23e0ae026ef58da8fc936d7605" />
 	</game>
 	<game name="Choro Q 64 (Japan)" cloneof="Penny Racers (Europe)">
 		<description>Choro Q 64 (Japan)</description>
-		<release name="Choro Q 64 (Japan)" region="JPN"/>
-		<rom name="Choro Q 64 (Japan).z64" size="8388608" crc="231f9284" md5="8287a908e36e79b2d3af0bd22c43ecd9" sha1="288cdbabe30349b70ddd68931e697af03e0d2ee8"/>
+		<rom name="Choro Q 64 (Japan).n64" />
+		<release name="Choro Q 64 (Japan)" region="JPN" />
+		<rom name="Choro Q 64 (Japan).z64" size="8388608" crc="231f9284" md5="8287a908e36e79b2d3af0bd22c43ecd9" sha1="288cdbabe30349b70ddd68931e697af03e0d2ee8" />
 	</game>
 	<game name="Penny Racers (USA)" cloneof="Penny Racers (Europe)">
 		<description>Penny Racers (USA)</description>
-		<release name="Penny Racers (USA)" region="USA"/>
-		<rom name="Penny Racers (USA).z64" size="8388608" crc="c1e57337" md5="518b14054a667a3b9e0b72d3bf784e41" sha1="1d4fce8ad6b1f0072d89aeb4c3187bc853b750a0"/>
+		<rom name="Penny Racers (USA).n64" />
+		<release name="Penny Racers (USA)" region="USA" />
+		<rom name="Penny Racers (USA).z64" size="8388608" crc="c1e57337" md5="518b14054a667a3b9e0b72d3bf784e41" sha1="1d4fce8ad6b1f0072d89aeb4c3187bc853b750a0" />
 	</game>
 	<game name="Perfect Dark (Europe) (En,Fr,De,Es,It)">
 		<description>Perfect Dark (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Perfect Dark (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Perfect Dark (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="7718a714" md5="d9b5cd305d228424891ce38e71bc9213" sha1="a663d3f4eee0b198471132db92e9639a9edd1985" status="verified"/>
+		<rom name="Perfect Dark (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Perfect Dark (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Perfect Dark (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="7718a714" md5="d9b5cd305d228424891ce38e71bc9213" sha1="a663d3f4eee0b198471132db92e9639a9edd1985" status="verified" />
 	</game>
 	<game name="Perfect Dark (Japan)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
 		<description>Perfect Dark (Japan)</description>
-		<release name="Perfect Dark (Japan)" region="JPN"/>
-		<rom name="Perfect Dark (Japan).z64" size="33554432" crc="639c0da9" md5="538d2b75945eae069b29c46193e74790" sha1="99bcaaa4841b09c845e1094006df8f637862f02e"/>
+		<rom name="Perfect Dark (Japan).n64" />
+		<release name="Perfect Dark (Japan)" region="JPN" />
+		<rom name="Perfect Dark (Japan).z64" size="33554432" crc="639c0da9" md5="538d2b75945eae069b29c46193e74790" sha1="99bcaaa4841b09c845e1094006df8f637862f02e" />
 	</game>
 	<game name="Perfect Dark (USA)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
 		<description>Perfect Dark (USA)</description>
-		<rom name="Perfect Dark (USA).z64" size="33554432" crc="68446ad4" md5="7f4171b0c8d17815be37913f535e4e93" sha1="60dfe17923c03875b499b3cd3200f05cb538b7ad"/>
+		<rom name="Perfect Dark (USA).n64" />
+		<rom name="Perfect Dark (USA).z64" size="33554432" crc="68446ad4" md5="7f4171b0c8d17815be37913f535e4e93" sha1="60dfe17923c03875b499b3cd3200f05cb538b7ad" />
 	</game>
 	<game name="Perfect Dark (USA) (Rev 1)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
 		<description>Perfect Dark (USA) (Rev 1)</description>
-		<release name="Perfect Dark (USA) (Rev 1)" region="USA"/>
-		<rom name="Perfect Dark (USA) (Rev 1).z64" size="33554432" crc="4c1677f7" md5="e03b088b6ac9e0080440efed07c1e40f" sha1="af8788ac4d1a57260eae9c53ffe851fcf2a3319b" status="verified"/>
+		<rom name="Perfect Dark (USA) (Rev 1).n64" />
+		<release name="Perfect Dark (USA) (Rev 1)" region="USA" />
+		<rom name="Perfect Dark (USA) (Rev 1).z64" size="33554432" crc="4c1677f7" md5="e03b088b6ac9e0080440efed07c1e40f" sha1="af8788ac4d1a57260eae9c53ffe851fcf2a3319b" status="verified" />
 	</game>
 	<game name="Perfect Dark (Europe) (Debug Version) (2000-04-26)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
 		<description>Perfect Dark (Europe) (Debug Version) (2000-04-26)</description>
-		<rom name="Perfect Dark (Europe) (Debug Version) (2000-04-26).z64" size="33554432" crc="b33c4a54" md5="ad2de210a3455ba5ec541f0c78d91444" sha1="79e3213bbac19b8e196e97e6348006c0506b27a9"/>
+		<rom name="Perfect Dark (Europe) (Debug Version) (2000-04-26).n64" />
+		<rom name="Perfect Dark (Europe) (Debug Version) (2000-04-26).z64" size="33554432" crc="b33c4a54" md5="ad2de210a3455ba5ec541f0c78d91444" sha1="79e3213bbac19b8e196e97e6348006c0506b27a9" />
 	</game>
 	<game name="Perfect Dark (USA) (Debug Version) (2000-03-22)" cloneof="Perfect Dark (Europe) (En,Fr,De,Es,It)">
 		<description>Perfect Dark (USA) (Debug Version) (2000-03-22)</description>
-		<rom name="Perfect Dark (USA) (Debug Version) (2000-03-22).z64" size="33554432" crc="b568a9fe" md5="aa93f4df16fceada399a749f5ad2f273" sha1="c831dc3d3068e0f2098db55889da0d6a08f26080"/>
+		<rom name="Perfect Dark (USA) (Debug Version) (2000-03-22).n64" />
+		<rom name="Perfect Dark (USA) (Debug Version) (2000-03-22).z64" size="33554432" crc="b568a9fe" md5="aa93f4df16fceada399a749f5ad2f273" sha1="c831dc3d3068e0f2098db55889da0d6a08f26080" />
 	</game>
 	<game name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It)">
 		<description>PGA European Tour Golf (Europe) (En,Fr,De,Es,It)</description>
-		<release name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="6b5ff959" md5="0112ffaada116d172abce136e9043a93" sha1="f9e838cf5cfd0fa493d5e5f7a7d450a80787c814"/>
+		<rom name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="PGA European Tour Golf (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="6b5ff959" md5="0112ffaada116d172abce136e9043a93" sha1="f9e838cf5cfd0fa493d5e5f7a7d450a80787c814" />
 	</game>
 	<game name="PGA European Tour (USA)" cloneof="PGA European Tour Golf (Europe) (En,Fr,De,Es,It)">
 		<description>PGA European Tour (USA)</description>
-		<release name="PGA European Tour (USA)" region="USA"/>
-		<rom name="PGA European Tour (USA).z64" size="16777216" crc="7cdfcdaa" md5="617ceca1d2beffce943ef832326898bf" sha1="6e8dfccfe93318a597e99c9186d5e8cdca3be987"/>
+		<rom name="PGA European Tour (USA).n64" />
+		<release name="PGA European Tour (USA)" region="USA" />
+		<rom name="PGA European Tour (USA).z64" size="16777216" crc="7cdfcdaa" md5="617ceca1d2beffce943ef832326898bf" sha1="6e8dfccfe93318a597e99c9186d5e8cdca3be987" />
 	</game>
 	<game name="Pilotwings 64 (Europe) (En,Fr,De)">
 		<description>Pilotwings 64 (Europe) (En,Fr,De)</description>
-		<release name="Pilotwings 64 (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Pilotwings 64 (Europe) (En,Fr,De).z64" size="8388608" crc="c902e57c" md5="3fcd4969f9a080bd2bcb913ec5d7a3bd" sha1="fa4e0a1941eea83e09ca00197569e2464d70ecb0"/>
+		<rom name="Pilotwings 64 (Europe) (En,Fr,De).n64" />
+		<release name="Pilotwings 64 (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Pilotwings 64 (Europe) (En,Fr,De).z64" size="8388608" crc="c902e57c" md5="3fcd4969f9a080bd2bcb913ec5d7a3bd" sha1="fa4e0a1941eea83e09ca00197569e2464d70ecb0" />
 	</game>
 	<game name="Pilotwings 64 (Japan)" cloneof="Pilotwings 64 (Europe) (En,Fr,De)">
 		<description>Pilotwings 64 (Japan)</description>
-		<release name="Pilotwings 64 (Japan)" region="JPN"/>
-		<rom name="Pilotwings 64 (Japan).z64" size="8388608" crc="3d3a84a9" md5="e8e6ec0692009009f5dca6827b21f59a" sha1="892a5472d9a6811b881d093020de81f72baeeec9" status="verified"/>
+		<rom name="Pilotwings 64 (Japan).n64" />
+		<release name="Pilotwings 64 (Japan)" region="JPN" />
+		<rom name="Pilotwings 64 (Japan).z64" size="8388608" crc="3d3a84a9" md5="e8e6ec0692009009f5dca6827b21f59a" sha1="892a5472d9a6811b881d093020de81f72baeeec9" status="verified" />
 	</game>
 	<game name="Pilotwings 64 (USA)" cloneof="Pilotwings 64 (Europe) (En,Fr,De)">
 		<description>Pilotwings 64 (USA)</description>
-		<release name="Pilotwings 64 (USA)" region="USA"/>
-		<rom name="Pilotwings 64 (USA).z64" size="8388608" crc="728807e7" md5="8b346182730ceaffe5e2ccf6d223c5ef" sha1="ec771aedf54ee1b214c25404fb4ec51cfd43191a"/>
+		<rom name="Pilotwings 64 (USA).n64" />
+		<release name="Pilotwings 64 (USA)" region="USA" />
+		<rom name="Pilotwings 64 (USA).z64" size="8388608" crc="728807e7" md5="8b346182730ceaffe5e2ccf6d223c5ef" sha1="ec771aedf54ee1b214c25404fb4ec51cfd43191a" />
 	</game>
 	<game name="Pokemon Puzzle League (Europe)">
 		<description>Pokemon Puzzle League (Europe)</description>
-		<release name="Pokemon Puzzle League (Europe)" region="EUR"/>
-		<rom name="Pokemon Puzzle League (Europe).z64" size="33554432" crc="75839254" md5="2ef9fa16de2a09ea15b6289447f40490" sha1="184f0cac8fdfad47590c515fc637076d2ded58d7"/>
+		<rom name="Pokemon Puzzle League (Europe).n64" />
+		<release name="Pokemon Puzzle League (Europe)" region="EUR" />
+		<rom name="Pokemon Puzzle League (Europe).z64" size="33554432" crc="75839254" md5="2ef9fa16de2a09ea15b6289447f40490" sha1="184f0cac8fdfad47590c515fc637076d2ded58d7" />
 	</game>
 	<game name="Pokemon Puzzle League (France)" cloneof="Pokemon Puzzle League (Europe)">
 		<description>Pokemon Puzzle League (France)</description>
-		<release name="Pokemon Puzzle League (France)" region="FRA"/>
-		<rom name="Pokemon Puzzle League (France).z64" size="33554432" crc="c3aa0074" md5="a3ba044dfc00bb766b4b2bfb9d4b5be9" sha1="72760a2d87ed3e70756a4aa689b9b26786669a52"/>
+		<rom name="Pokemon Puzzle League (France).n64" />
+		<release name="Pokemon Puzzle League (France)" region="FRA" />
+		<rom name="Pokemon Puzzle League (France).z64" size="33554432" crc="c3aa0074" md5="a3ba044dfc00bb766b4b2bfb9d4b5be9" sha1="72760a2d87ed3e70756a4aa689b9b26786669a52" />
 	</game>
 	<game name="Pokemon Puzzle League (Germany)" cloneof="Pokemon Puzzle League (Europe)">
 		<description>Pokemon Puzzle League (Germany)</description>
-		<release name="Pokemon Puzzle League (Germany)" region="GER"/>
-		<rom name="Pokemon Puzzle League (Germany).z64" size="33554432" crc="ac543150" md5="000364bac80e41d9060a31a5923874b7" sha1="dbc9d0de131f3604a9115b58368e9050f1a6303f"/>
+		<rom name="Pokemon Puzzle League (Germany).n64" />
+		<release name="Pokemon Puzzle League (Germany)" region="GER" />
+		<rom name="Pokemon Puzzle League (Germany).z64" size="33554432" crc="ac543150" md5="000364bac80e41d9060a31a5923874b7" sha1="dbc9d0de131f3604a9115b58368e9050f1a6303f" />
 	</game>
 	<game name="Pokemon Puzzle League (USA)" cloneof="Pokemon Puzzle League (Europe)">
 		<description>Pokemon Puzzle League (USA)</description>
-		<release name="Pokemon Puzzle League (USA)" region="USA"/>
-		<rom name="Pokemon Puzzle League (USA).z64" size="33554432" crc="8b9c598f" md5="e722576a15182cfed6782379ce4bc8be" sha1="8173866fc8c7652abd44c48efcab85441c6806a1"/>
+		<rom name="Pokemon Puzzle League (USA).n64" />
+		<release name="Pokemon Puzzle League (USA)" region="USA" />
+		<rom name="Pokemon Puzzle League (USA).z64" size="33554432" crc="8b9c598f" md5="e722576a15182cfed6782379ce4bc8be" sha1="8173866fc8c7652abd44c48efcab85441c6806a1" />
 	</game>
 	<game name="Pokemon Puzzle League (Europe) (Wii Virtual Console)" cloneof="Pokemon Puzzle League (Europe)">
 		<description>Pokemon Puzzle League (Europe) (Wii Virtual Console)</description>
-		<rom name="Pokemon Puzzle League (Europe) (Wii Virtual Console).z64" size="33554432" crc="13f996b2" md5="fbf566693bca3145d86df34d18dcdd43" sha1="7ecc46ee186118d49b174ad4bc1367d343130330"/>
+		<rom name="Pokemon Puzzle League (Europe) (Wii Virtual Console).n64" />
+		<rom name="Pokemon Puzzle League (Europe) (Wii Virtual Console).z64" size="33554432" crc="13f996b2" md5="fbf566693bca3145d86df34d18dcdd43" sha1="7ecc46ee186118d49b174ad4bc1367d343130330" />
 	</game>
 	<game name="Pokemon Puzzle League (France) (Wii Virtual Console)" cloneof="Pokemon Puzzle League (Europe)">
 		<description>Pokemon Puzzle League (France) (Wii Virtual Console)</description>
-		<rom name="Pokemon Puzzle League (France) (Wii Virtual Console).z64" size="33554432" crc="8671137d" md5="866d401c51cc05a3188c9a2d4e7bfee5" sha1="94742de682f1b52f3fe45c3a7235eb9bcbc4abbc"/>
+		<rom name="Pokemon Puzzle League (France) (Wii Virtual Console).n64" />
+		<rom name="Pokemon Puzzle League (France) (Wii Virtual Console).z64" size="33554432" crc="8671137d" md5="866d401c51cc05a3188c9a2d4e7bfee5" sha1="94742de682f1b52f3fe45c3a7235eb9bcbc4abbc" />
 	</game>
 	<game name="Pokemon Puzzle League (Germany) (Wii Virtual Console)" cloneof="Pokemon Puzzle League (Europe)">
 		<description>Pokemon Puzzle League (Germany) (Wii Virtual Console)</description>
-		<rom name="Pokemon Puzzle League (Germany) (Wii Virtual Console).z64" size="33554432" crc="00e73008" md5="45b507aaaf0ccdb6efe3cd717f0ddb95" sha1="5ec354fdc1469c1e8a89b31d6ee5e59af37dee16"/>
+		<rom name="Pokemon Puzzle League (Germany) (Wii Virtual Console).n64" />
+		<rom name="Pokemon Puzzle League (Germany) (Wii Virtual Console).z64" size="33554432" crc="00e73008" md5="45b507aaaf0ccdb6efe3cd717f0ddb95" sha1="5ec354fdc1469c1e8a89b31d6ee5e59af37dee16" />
 	</game>
 	<game name="Pokemon Puzzle League (USA) (Wii Virtual Console)" cloneof="Pokemon Puzzle League (Europe)">
 		<description>Pokemon Puzzle League (USA) (Wii Virtual Console)</description>
-		<rom name="Pokemon Puzzle League (USA) (Wii Virtual Console).z64" size="33554432" crc="91623130" md5="d6f58b98115e78d841089074401ae524" sha1="f0837f92a16b2226d9b72ff60a924404536c051e"/>
+		<rom name="Pokemon Puzzle League (USA) (Wii Virtual Console).n64" />
+		<rom name="Pokemon Puzzle League (USA) (Wii Virtual Console).z64" size="33554432" crc="91623130" md5="d6f58b98115e78d841089074401ae524" sha1="f0837f92a16b2226d9b72ff60a924404536c051e" />
 	</game>
 	<game name="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (Europe)</description>
-		<release name="Pokemon Snap (Europe)" region="EUR"/>
-		<rom name="Pokemon Snap (Europe).z64" size="16777216" crc="f824a057" md5="f2a8106403d2bf9350bfeab08689d54a" sha1="d575b393812a0a59fbb52f3ce55ce4d7bc5f3225" status="verified"/>
+		<rom name="Pokemon Snap (Europe).n64" />
+		<release name="Pokemon Snap (Europe)" region="EUR" />
+		<rom name="Pokemon Snap (Europe).z64" size="16777216" crc="f824a057" md5="f2a8106403d2bf9350bfeab08689d54a" sha1="d575b393812a0a59fbb52f3ce55ce4d7bc5f3225" status="verified" />
 	</game>
 	<game name="Pokemon Snap (Japan)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (Japan)</description>
-		<release name="Pokemon Snap (Japan)" region="JPN"/>
-		<rom name="Pokemon Snap (Japan).z64" size="16777216" crc="a091bd56" md5="fbdd74ed68e6a0cd734562d56ccb752d" sha1="5d7b3b8d4bb64da5b7ae5e1f132b26a282c33909"/>
+		<rom name="Pokemon Snap (Japan).n64" />
+		<release name="Pokemon Snap (Japan)" region="JPN" />
+		<rom name="Pokemon Snap (Japan).z64" size="16777216" crc="a091bd56" md5="fbdd74ed68e6a0cd734562d56ccb752d" sha1="5d7b3b8d4bb64da5b7ae5e1f132b26a282c33909" />
 	</game>
 	<game name="Pokemon Snap (Australia)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (Australia)</description>
-		<release name="Pokemon Snap (Australia)" region="AUS"/>
-		<rom name="Pokemon Snap (Australia).z64" size="16777216" crc="cdea6d4c" md5="e5a0ca3dc54b38ea7fcd927e3cffad3b" sha1="eb388731bb7530f60e3ad4a1652f79296b5063ec"/>
+		<rom name="Pokemon Snap (Australia).n64" />
+		<release name="Pokemon Snap (Australia)" region="AUS" />
+		<rom name="Pokemon Snap (Australia).z64" size="16777216" crc="cdea6d4c" md5="e5a0ca3dc54b38ea7fcd927e3cffad3b" sha1="eb388731bb7530f60e3ad4a1652f79296b5063ec" />
 	</game>
 	<game name="Pokemon Snap (France)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (France)</description>
-		<release name="Pokemon Snap (France)" region="FRA"/>
-		<rom name="Pokemon Snap (France).z64" size="16777216" crc="ec843586" md5="e9028f9ccc307806695dd81742d05d5d" sha1="9ee1ed91ad6e00cc50e1a1513a256ccceb9a41df" status="verified"/>
+		<rom name="Pokemon Snap (France).n64" />
+		<release name="Pokemon Snap (France)" region="FRA" />
+		<rom name="Pokemon Snap (France).z64" size="16777216" crc="ec843586" md5="e9028f9ccc307806695dd81742d05d5d" sha1="9ee1ed91ad6e00cc50e1a1513a256ccceb9a41df" status="verified" />
 	</game>
 	<game name="Pokemon Snap (Germany)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (Germany)</description>
-		<release name="Pokemon Snap (Germany)" region="GER"/>
-		<rom name="Pokemon Snap (Germany).z64" size="16777216" crc="10c27b3c" md5="144b8906dc40534cfbef6d7b994a982b" sha1="f1fe20e26c3803c0e4ea33711be5e0edf8e9c4be" status="verified"/>
+		<rom name="Pokemon Snap (Germany).n64" />
+		<release name="Pokemon Snap (Germany)" region="GER" />
+		<rom name="Pokemon Snap (Germany).z64" size="16777216" crc="10c27b3c" md5="144b8906dc40534cfbef6d7b994a982b" sha1="f1fe20e26c3803c0e4ea33711be5e0edf8e9c4be" status="verified" />
 	</game>
 	<game name="Pokemon Snap (Italy)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (Italy)</description>
-		<release name="Pokemon Snap (Italy)" region="ITA"/>
-		<rom name="Pokemon Snap (Italy).z64" size="16777216" crc="df56e922" md5="8e1968191dd27655c03be812cf041a95" sha1="a4dae7f86e463fe5351b3e74a1d044a95f3cbf41" status="verified"/>
+		<rom name="Pokemon Snap (Italy).n64" />
+		<release name="Pokemon Snap (Italy)" region="ITA" />
+		<rom name="Pokemon Snap (Italy).z64" size="16777216" crc="df56e922" md5="8e1968191dd27655c03be812cf041a95" sha1="a4dae7f86e463fe5351b3e74a1d044a95f3cbf41" status="verified" />
 	</game>
 	<game name="Pokemon Snap (Spain)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (Spain)</description>
-		<release name="Pokemon Snap (Spain)" region="SPA"/>
-		<rom name="Pokemon Snap (Spain).z64" size="16777216" crc="371b787f" md5="a45d7115be5a06fd1567f9f913c3bdf8" sha1="24da787140662d1fb40d8e17199ce6412d72dedc" status="verified"/>
+		<rom name="Pokemon Snap (Spain).n64" />
+		<release name="Pokemon Snap (Spain)" region="SPA" />
+		<rom name="Pokemon Snap (Spain).z64" size="16777216" crc="371b787f" md5="a45d7115be5a06fd1567f9f913c3bdf8" sha1="24da787140662d1fb40d8e17199ce6412d72dedc" status="verified" />
 	</game>
 	<game name="Pokemon Snap (USA)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (USA)</description>
-		<release name="Pokemon Snap (USA)" region="USA"/>
-		<rom name="Pokemon Snap (USA).z64" size="16777216" crc="86a69756" md5="fc3c9329b7cdd67cf7650abf63b9a580" sha1="edc7c49cc568c045fe48be0d18011c30f393cbaf" status="verified"/>
+		<rom name="Pokemon Snap (USA).n64" />
+		<release name="Pokemon Snap (USA)" region="USA" />
+		<rom name="Pokemon Snap (USA).z64" size="16777216" crc="86a69756" md5="fc3c9329b7cdd67cf7650abf63b9a580" sha1="edc7c49cc568c045fe48be0d18011c30f393cbaf" status="verified" />
 	</game>
 	<game name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console)</description>
-		<rom name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console).z64" size="16777216" crc="a761daef" md5="33fdab9712d9fea793a3ae44293999c3" sha1="635be62b427be4c2dab9617aa9f58cddea9d4155"/>
+		<rom name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console).n64" />
+		<rom name="Pokemon Snap (Japan) (Rev 1) (Wii Virtual Console).z64" size="16777216" crc="a761daef" md5="33fdab9712d9fea793a3ae44293999c3" sha1="635be62b427be4c2dab9617aa9f58cddea9d4155" />
 	</game>
 	<game name="Pokemon Snap Station (USA) (Demo) (Kiosk)" cloneof="Pokemon Snap (Europe)">
 		<description>Pokemon Snap Station (USA) (Demo) (Kiosk)</description>
-		<rom name="Pokemon Snap Station (USA) (Demo) (Kiosk).z64" size="16777216" crc="e22a00d0" md5="a9c272687dabd59c5144774b53bcc35a" sha1="1e16c19ff303f9283d7b53545c4d575c6df43158"/>
+		<rom name="Pokemon Snap Station (USA) (Demo) (Kiosk).n64" />
+		<rom name="Pokemon Snap Station (USA) (Demo) (Kiosk).z64" size="16777216" crc="e22a00d0" md5="a9c272687dabd59c5144774b53bcc35a" sha1="1e16c19ff303f9283d7b53545c4d575c6df43158" />
 	</game>
 	<game name="Pokemon Stadium (Japan)">
 		<description>Pokemon Stadium (Japan)</description>
-		<release name="Pokemon Stadium (Japan)" region="JPN"/>
-		<rom name="Pokemon Stadium (Japan).z64" size="16777216" crc="3139189c" md5="c46e087d966a35095df96799b0b4ffae" sha1="8bc8d2ff7df25b26bd0c353d2adfe83e4e3a7a87"/>
+		<rom name="Pokemon Stadium (Japan).n64" />
+		<release name="Pokemon Stadium (Japan)" region="JPN" />
+		<rom name="Pokemon Stadium (Japan).z64" size="16777216" crc="3139189c" md5="c46e087d966a35095df96799b0b4ffae" sha1="8bc8d2ff7df25b26bd0c353d2adfe83e4e3a7a87" />
 	</game>
 	<game name="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (Europe) (Rev 1)</description>
-		<release name="Pokemon Stadium (Europe) (Rev 1)" region="EUR"/>
-		<rom name="Pokemon Stadium (Europe) (Rev 1).z64" size="33554432" crc="da889668" md5="31ee2de8e65e30f5934c450dbaa924f0" sha1="9470f899ad0107677b7dfd24e1dd567723a5f84f"/>
+		<rom name="Pokemon Stadium (Europe) (Rev 1).n64" />
+		<release name="Pokemon Stadium (Europe) (Rev 1)" region="EUR" />
+		<rom name="Pokemon Stadium (Europe) (Rev 1).z64" size="33554432" crc="da889668" md5="31ee2de8e65e30f5934c450dbaa924f0" sha1="9470f899ad0107677b7dfd24e1dd567723a5f84f" />
 	</game>
 	<game name="Pokemon Stadium (Europe)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (Europe)</description>
-		<rom name="Pokemon Stadium (Europe).z64" size="33554432" crc="dc57508d" md5="2859090d78581e0925a3af8045e81e4b" sha1="6f26e3c8b35c3232058375e30d19665facb23123"/>
+		<rom name="Pokemon Stadium (Europe).n64" />
+		<rom name="Pokemon Stadium (Europe).z64" size="33554432" crc="dc57508d" md5="2859090d78581e0925a3af8045e81e4b" sha1="6f26e3c8b35c3232058375e30d19665facb23123" />
 	</game>
 	<game name="Pokemon Stadium (France)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (France)</description>
-		<release name="Pokemon Stadium (France)" region="FRA"/>
-		<rom name="Pokemon Stadium (France).z64" size="33554432" crc="5dd92d4c" md5="0e85a098d0f0e8a7eb572a69612a6873" sha1="4f7267ccaba4a8a9b0ae2cb89e191bc69b153ddc"/>
+		<rom name="Pokemon Stadium (France).n64" />
+		<release name="Pokemon Stadium (France)" region="FRA" />
+		<rom name="Pokemon Stadium (France).z64" size="33554432" crc="5dd92d4c" md5="0e85a098d0f0e8a7eb572a69612a6873" sha1="4f7267ccaba4a8a9b0ae2cb89e191bc69b153ddc" />
 	</game>
 	<game name="Pokemon Stadium (Germany)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (Germany)</description>
-		<release name="Pokemon Stadium (Germany)" region="GER"/>
-		<rom name="Pokemon Stadium (Germany).z64" size="33554432" crc="9f22a945" md5="24be2ccb0dea0755908c02bf67e22fe5" sha1="6a25903e733f071e7d6ea54529b7fd60b760cda3" status="verified"/>
+		<rom name="Pokemon Stadium (Germany).n64" />
+		<release name="Pokemon Stadium (Germany)" region="GER" />
+		<rom name="Pokemon Stadium (Germany).z64" size="33554432" crc="9f22a945" md5="24be2ccb0dea0755908c02bf67e22fe5" sha1="6a25903e733f071e7d6ea54529b7fd60b760cda3" status="verified" />
 	</game>
 	<game name="Pokemon Stadium (Italy)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (Italy)</description>
-		<release name="Pokemon Stadium (Italy)" region="ITA"/>
-		<rom name="Pokemon Stadium (Italy).z64" size="33554432" crc="f155c465" md5="a81321759af38beb30a40fdaca2ea22a" sha1="db5f2797c377fa8957b97465fc5738d6999ff240"/>
+		<rom name="Pokemon Stadium (Italy).n64" />
+		<release name="Pokemon Stadium (Italy)" region="ITA" />
+		<rom name="Pokemon Stadium (Italy).z64" size="33554432" crc="f155c465" md5="a81321759af38beb30a40fdaca2ea22a" sha1="db5f2797c377fa8957b97465fc5738d6999ff240" />
 	</game>
 	<game name="Pokemon Stadium (Spain)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (Spain)</description>
-		<release name="Pokemon Stadium (Spain)" region="SPA"/>
-		<rom name="Pokemon Stadium (Spain).z64" size="33554432" crc="f02cd5eb" md5="d14a499bc4e324974eae3e42dec58625" sha1="f39911ad0bedccc3e44d4338507c73bfa97856bf"/>
+		<rom name="Pokemon Stadium (Spain).n64" />
+		<release name="Pokemon Stadium (Spain)" region="SPA" />
+		<rom name="Pokemon Stadium (Spain).z64" size="33554432" crc="f02cd5eb" md5="d14a499bc4e324974eae3e42dec58625" sha1="f39911ad0bedccc3e44d4338507c73bfa97856bf" />
 	</game>
 	<game name="Pokemon Stadium (USA)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (USA)</description>
-		<rom name="Pokemon Stadium (USA).z64" size="33554432" crc="72f66f05" md5="ed1378bc12115f71209a77844965ba50" sha1="ed7bef5a306f88c0a6e96b15e71fee2ef32058f3"/>
+		<rom name="Pokemon Stadium (USA).n64" />
+		<rom name="Pokemon Stadium (USA).z64" size="33554432" crc="72f66f05" md5="ed1378bc12115f71209a77844965ba50" sha1="ed7bef5a306f88c0a6e96b15e71fee2ef32058f3" />
 	</game>
 	<game name="Pokemon Stadium (USA) (Rev 1)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (USA) (Rev 1)</description>
-		<rom name="Pokemon Stadium (USA) (Rev 1).z64" size="33554432" crc="4b1bc2ac" md5="40e03eda831c01e0a12294287fd240e2" sha1="488bb6d112427823d77fcecdd9297fd86875263d" status="verified"/>
+		<rom name="Pokemon Stadium (USA) (Rev 1).n64" />
+		<rom name="Pokemon Stadium (USA) (Rev 1).z64" size="33554432" crc="4b1bc2ac" md5="40e03eda831c01e0a12294287fd240e2" sha1="488bb6d112427823d77fcecdd9297fd86875263d" status="verified" />
 	</game>
 	<game name="Pokemon Stadium (USA) (Rev 2)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium (USA) (Rev 2)</description>
-		<release name="Pokemon Stadium (USA) (Rev 2)" region="USA"/>
-		<rom name="Pokemon Stadium (USA) (Rev 2).z64" size="33554432" crc="235b1842" md5="6dc6820cef755fc1253d06df45c9bd2a" sha1="0d3b1d740c6ee6da6923550bf24ad827262fd8c0" status="verified"/>
+		<rom name="Pokemon Stadium (USA) (Rev 2).n64" />
+		<release name="Pokemon Stadium (USA) (Rev 2)" region="USA" />
+		<rom name="Pokemon Stadium (USA) (Rev 2).z64" size="33554432" crc="235b1842" md5="6dc6820cef755fc1253d06df45c9bd2a" sha1="0d3b1d740c6ee6da6923550bf24ad827262fd8c0" status="verified" />
 	</game>
 	<game name="Pokemon Stadium 2 (Japan)" cloneof="Pokemon Stadium (Europe) (Rev 1)">
 		<description>Pokemon Stadium 2 (Japan)</description>
-		<release name="Pokemon Stadium 2 (Japan)" region="JPN"/>
-		<rom name="Pokemon Stadium 2 (Japan).z64" size="33554432" crc="40aa4874" md5="2449bb712a64e3363a6cbd56f5adeda5" sha1="074582744c71d7f0569ce960964a7bbe947efd3c"/>
+		<rom name="Pokemon Stadium 2 (Japan).n64" />
+		<release name="Pokemon Stadium 2 (Japan)" region="JPN" />
+		<rom name="Pokemon Stadium 2 (Japan).z64" size="33554432" crc="40aa4874" md5="2449bb712a64e3363a6cbd56f5adeda5" sha1="074582744c71d7f0569ce960964a7bbe947efd3c" />
 	</game>
 	<game name="Pokemon Stadium 2 (Europe)">
 		<description>Pokemon Stadium 2 (Europe)</description>
-		<release name="Pokemon Stadium 2 (Europe)" region="EUR"/>
-		<rom name="Pokemon Stadium 2 (Europe).z64" size="67108864" crc="6b3096c4" md5="b1271db50d6ef8f6b53cc640c3743e4f" sha1="f6a7e8146433a48bf101722e30bf86311a641f7b"/>
+		<rom name="Pokemon Stadium 2 (Europe).n64" />
+		<release name="Pokemon Stadium 2 (Europe)" region="EUR" />
+		<rom name="Pokemon Stadium 2 (Europe).z64" size="67108864" crc="6b3096c4" md5="b1271db50d6ef8f6b53cc640c3743e4f" sha1="f6a7e8146433a48bf101722e30bf86311a641f7b" />
 	</game>
 	<game name="Pokemon Stadium 2 (France)" cloneof="Pokemon Stadium 2 (Europe)">
 		<description>Pokemon Stadium 2 (France)</description>
-		<release name="Pokemon Stadium 2 (France)" region="FRA"/>
-		<rom name="Pokemon Stadium 2 (France).z64" size="67108864" crc="e2a78066" md5="4748d96916ae2bcc5fc1630515ee2561" sha1="d7e13535b671024a92822db01507e87bd42f68ec"/>
+		<rom name="Pokemon Stadium 2 (France).n64" />
+		<release name="Pokemon Stadium 2 (France)" region="FRA" />
+		<rom name="Pokemon Stadium 2 (France).z64" size="67108864" crc="e2a78066" md5="4748d96916ae2bcc5fc1630515ee2561" sha1="d7e13535b671024a92822db01507e87bd42f68ec" />
 	</game>
 	<game name="Pokemon Stadium 2 (Germany)" cloneof="Pokemon Stadium 2 (Europe)">
 		<description>Pokemon Stadium 2 (Germany)</description>
-		<release name="Pokemon Stadium 2 (Germany)" region="GER"/>
-		<rom name="Pokemon Stadium 2 (Germany).z64" size="67108864" crc="1146a43a" md5="484f3e696c94980acf3d7068f9acc98f" sha1="6de05180d77e73dcf32d57af7c8c1529c7acda59" status="verified"/>
+		<rom name="Pokemon Stadium 2 (Germany).n64" />
+		<release name="Pokemon Stadium 2 (Germany)" region="GER" />
+		<rom name="Pokemon Stadium 2 (Germany).z64" size="67108864" crc="1146a43a" md5="484f3e696c94980acf3d7068f9acc98f" sha1="6de05180d77e73dcf32d57af7c8c1529c7acda59" status="verified" />
 	</game>
 	<game name="Pokemon Stadium 2 (Italy)" cloneof="Pokemon Stadium 2 (Europe)">
 		<description>Pokemon Stadium 2 (Italy)</description>
-		<release name="Pokemon Stadium 2 (Italy)" region="ITA"/>
-		<rom name="Pokemon Stadium 2 (Italy).z64" size="67108864" crc="9fa5c095" md5="5a04d7f1ab9c6b080176567aa7168d3a" sha1="4926db649c76521f61ae51c13e452a2c8001354c"/>
+		<rom name="Pokemon Stadium 2 (Italy).n64" />
+		<release name="Pokemon Stadium 2 (Italy)" region="ITA" />
+		<rom name="Pokemon Stadium 2 (Italy).z64" size="67108864" crc="9fa5c095" md5="5a04d7f1ab9c6b080176567aa7168d3a" sha1="4926db649c76521f61ae51c13e452a2c8001354c" />
 	</game>
 	<game name="Pokemon Stadium 2 (Spain)" cloneof="Pokemon Stadium 2 (Europe)">
 		<description>Pokemon Stadium 2 (Spain)</description>
-		<release name="Pokemon Stadium 2 (Spain)" region="SPA"/>
-		<rom name="Pokemon Stadium 2 (Spain).z64" size="67108864" crc="283e7641" md5="b26aafd452c9816e1b7aa0954e75825f" sha1="ab1cdf753bed70487923ea3129278e45d6325773"/>
+		<rom name="Pokemon Stadium 2 (Spain).n64" />
+		<release name="Pokemon Stadium 2 (Spain)" region="SPA" />
+		<rom name="Pokemon Stadium 2 (Spain).z64" size="67108864" crc="283e7641" md5="b26aafd452c9816e1b7aa0954e75825f" sha1="ab1cdf753bed70487923ea3129278e45d6325773" />
 	</game>
 	<game name="Pokemon Stadium 2 (USA)" cloneof="Pokemon Stadium 2 (Europe)">
 		<description>Pokemon Stadium 2 (USA)</description>
-		<release name="Pokemon Stadium 2 (USA)" region="USA"/>
-		<rom name="Pokemon Stadium 2 (USA).z64" size="67108864" crc="a9998e09" md5="1561c75d11cedf356a8ddb1a4a5f9d5d" sha1="d8343e69a7dc63b869cf6361d87cde64444281d3" status="verified"/>
+		<rom name="Pokemon Stadium 2 (USA).n64" />
+		<release name="Pokemon Stadium 2 (USA)" region="USA" />
+		<rom name="Pokemon Stadium 2 (USA).z64" size="67108864" crc="a9998e09" md5="1561c75d11cedf356a8ddb1a4a5f9d5d" sha1="d8343e69a7dc63b869cf6361d87cde64444281d3" status="verified" />
 	</game>
 	<game name="Pokemon Stadium Kin Gin (Japan)" cloneof="Pokemon Stadium 2 (Europe)">
 		<description>Pokemon Stadium Kin Gin (Japan)</description>
-		<release name="Pokemon Stadium Kin Gin (Japan)" region="JPN"/>
-		<rom name="Pokemon Stadium Kin Gin (Japan).z64" size="67108864" crc="cbc3b935" md5="a17aadcc962393d476edc321e59c504b" sha1="05682e60b13479ca1c54656e5a5b1ee6d099c1a4"/>
+		<rom name="Pokemon Stadium Kin Gin (Japan).n64" />
+		<release name="Pokemon Stadium Kin Gin (Japan)" region="JPN" />
+		<rom name="Pokemon Stadium Kin Gin (Japan).z64" size="67108864" crc="cbc3b935" md5="a17aadcc962393d476edc321e59c504b" sha1="05682e60b13479ca1c54656e5a5b1ee6d099c1a4" />
 	</game>
 	<game name="Polaris SnoCross (USA)">
 		<description>Polaris SnoCross (USA)</description>
-		<release name="Polaris SnoCross (USA)" region="USA"/>
-		<rom name="Polaris SnoCross (USA).z64" size="12582912" crc="8dd735ef" md5="bbdc4c4f1c474298189312008a1768c4" sha1="cb56812d41fb96d722774b845100ef421fbc318d"/>
+		<rom name="Polaris SnoCross (USA).n64" />
+		<release name="Polaris SnoCross (USA)" region="USA" />
+		<rom name="Polaris SnoCross (USA).z64" size="12582912" crc="8dd735ef" md5="bbdc4c4f1c474298189312008a1768c4" sha1="cb56812d41fb96d722774b845100ef421fbc318d" />
 	</game>
 	<game name="Power League 64 (Japan)">
 		<description>Power League 64 (Japan)</description>
-		<release name="Power League 64 (Japan)" region="JPN"/>
-		<rom name="Power League 64 (Japan).z64" size="8388608" crc="aec21c28" md5="8cc73c373016070647030dde492fdc8c" sha1="1e0d939c8e278de21c42fa33495e446ed03c027e"/>
+		<rom name="Power League 64 (Japan).n64" />
+		<release name="Power League 64 (Japan)" region="JPN" />
+		<rom name="Power League 64 (Japan).z64" size="8388608" crc="aec21c28" md5="8cc73c373016070647030dde492fdc8c" sha1="1e0d939c8e278de21c42fa33495e446ed03c027e" />
 	</game>
 	<game name="Power Rangers - Lightspeed Rescue (Europe)">
 		<description>Power Rangers - Lightspeed Rescue (Europe)</description>
-		<release name="Power Rangers - Lightspeed Rescue (Europe)" region="EUR"/>
-		<rom name="Power Rangers - Lightspeed Rescue (Europe).z64" size="12582912" crc="36ee5ca8" md5="92bb1bc5e6466f1944943d34d25f2daf" sha1="c7fec2a9d57f656b8d0b4404c8797c46136fd971"/>
+		<rom name="Power Rangers - Lightspeed Rescue (Europe).n64" />
+		<release name="Power Rangers - Lightspeed Rescue (Europe)" region="EUR" />
+		<rom name="Power Rangers - Lightspeed Rescue (Europe).z64" size="12582912" crc="36ee5ca8" md5="92bb1bc5e6466f1944943d34d25f2daf" sha1="c7fec2a9d57f656b8d0b4404c8797c46136fd971" />
 	</game>
 	<game name="Power Rangers - Lightspeed Rescue (USA)" cloneof="Power Rangers - Lightspeed Rescue (Europe)">
 		<description>Power Rangers - Lightspeed Rescue (USA)</description>
-		<release name="Power Rangers - Lightspeed Rescue (USA)" region="USA"/>
-		<rom name="Power Rangers - Lightspeed Rescue (USA).z64" size="12582912" crc="a5033311" md5="91d74621ddef6d37fb845b3bc7059a38" sha1="9c0b970dfa344a8cdea9b775d7f95acec2ccf79f"/>
+		<rom name="Power Rangers - Lightspeed Rescue (USA).n64" />
+		<release name="Power Rangers - Lightspeed Rescue (USA)" region="USA" />
+		<rom name="Power Rangers - Lightspeed Rescue (USA).z64" size="12582912" crc="a5033311" md5="91d74621ddef6d37fb845b3bc7059a38" sha1="9c0b970dfa344a8cdea9b775d7f95acec2ccf79f" />
 	</game>
 	<game name="Powerpuff Girls, The - Chemical X-Traction (USA)">
 		<description>Powerpuff Girls, The - Chemical X-Traction (USA)</description>
-		<release name="Powerpuff Girls, The - Chemical X-Traction (USA)" region="USA"/>
-		<rom name="Powerpuff Girls, The - Chemical X-Traction (USA).z64" size="8388608" crc="9514da0a" md5="2991bb68eca54813d6b834adbbbacc4c" sha1="88e2032997cb884af31a7380fabac0d0a5360892"/>
+		<rom name="Powerpuff Girls, The - Chemical X-Traction (USA).n64" />
+		<release name="Powerpuff Girls, The - Chemical X-Traction (USA)" region="USA" />
+		<rom name="Powerpuff Girls, The - Chemical X-Traction (USA).z64" size="8388608" crc="9514da0a" md5="2991bb68eca54813d6b834adbbbacc4c" sha1="88e2032997cb884af31a7380fabac0d0a5360892" />
 	</game>
 	<game name="Premier Manager 64 (Europe)">
 		<description>Premier Manager 64 (Europe)</description>
-		<release name="Premier Manager 64 (Europe)" region="EUR"/>
-		<rom name="Premier Manager 64 (Europe).z64" size="16777216" crc="81cda888" md5="25bafc84ba4d87854dc44df3ef8764ea" sha1="6affb5b00b1862e233e4d909dc6e4201f9945579"/>
+		<rom name="Premier Manager 64 (Europe).n64" />
+		<release name="Premier Manager 64 (Europe)" region="EUR" />
+		<rom name="Premier Manager 64 (Europe).z64" size="16777216" crc="81cda888" md5="25bafc84ba4d87854dc44df3ef8764ea" sha1="6affb5b00b1862e233e4d909dc6e4201f9945579" />
 	</game>
 	<game name="Pro Mahjong Kiwame 64 (Japan) (Rev 1)">
 		<description>Pro Mahjong Kiwame 64 (Japan) (Rev 1)</description>
-		<release name="Pro Mahjong Kiwame 64 (Japan) (Rev 1)" region="JPN"/>
-		<rom name="Pro Mahjong Kiwame 64 (Japan) (Rev 1).z64" size="8388608" crc="b9be7b90" md5="b42f62483f7ca2aac5af911175463db8" sha1="2e0f0ae69eb98a079baab365f99af7ae56099edc" status="verified"/>
+		<rom name="Pro Mahjong Kiwame 64 (Japan) (Rev 1).n64" />
+		<release name="Pro Mahjong Kiwame 64 (Japan) (Rev 1)" region="JPN" />
+		<rom name="Pro Mahjong Kiwame 64 (Japan) (Rev 1).z64" size="8388608" crc="b9be7b90" md5="b42f62483f7ca2aac5af911175463db8" sha1="2e0f0ae69eb98a079baab365f99af7ae56099edc" status="verified" />
 	</game>
 	<game name="Pro Mahjong Kiwame 64 (Japan)" cloneof="Pro Mahjong Kiwame 64 (Japan) (Rev 1)">
 		<description>Pro Mahjong Kiwame 64 (Japan)</description>
-		<rom name="Pro Mahjong Kiwame 64 (Japan).z64" size="8388608" crc="1f5907f9" md5="7995d76f4ce236b0f0289f47ae523d32" sha1="b5be6c3b49ad37c0dd1d6e7dacbcbe03653859d9"/>
+		<rom name="Pro Mahjong Kiwame 64 (Japan).n64" />
+		<rom name="Pro Mahjong Kiwame 64 (Japan).z64" size="8388608" crc="1f5907f9" md5="7995d76f4ce236b0f0289f47ae523d32" sha1="b5be6c3b49ad37c0dd1d6e7dacbcbe03653859d9" />
 	</game>
 	<game name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)">
 		<description>Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)</description>
-		<release name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)" region="JPN"/>
-		<rom name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan).z64" size="8388608" crc="35461699" md5="f1a2e4dd22adf4f90da4bddca37d5f18" sha1="25bc862bfabdc972459e8ec2f4173bd5d638eff3"/>
+		<rom name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan).n64" />
+		<release name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan)" region="JPN" />
+		<rom name="Pro Mahjong Tsuwamono 64 - Jansou Battle ni Chousen (Japan).z64" size="8388608" crc="35461699" md5="f1a2e4dd22adf4f90da4bddca37d5f18" sha1="25bc862bfabdc972459e8ec2f4173bd5d638eff3" />
 	</game>
 	<game name="Puyo Puyo Sun 64 (Japan)">
 		<description>Puyo Puyo Sun 64 (Japan)</description>
-		<release name="Puyo Puyo Sun 64 (Japan)" region="JPN"/>
-		<rom name="Puyo Puyo Sun 64 (Japan).z64" size="8388608" crc="355ff9de" md5="faaa2094b04dca4c287af9334d22529d" sha1="cf79ec32e7e78b2cad15b5b7dd763f578648b6c6" status="verified"/>
+		<rom name="Puyo Puyo Sun 64 (Japan).n64" />
+		<release name="Puyo Puyo Sun 64 (Japan)" region="JPN" />
+		<rom name="Puyo Puyo Sun 64 (Japan).z64" size="8388608" crc="355ff9de" md5="faaa2094b04dca4c287af9334d22529d" sha1="cf79ec32e7e78b2cad15b5b7dd763f578648b6c6" status="verified" />
 	</game>
 	<game name="Puyo Puyoon Party (Japan)">
 		<description>Puyo Puyoon Party (Japan)</description>
-		<release name="Puyo Puyoon Party (Japan)" region="JPN"/>
-		<rom name="Puyo Puyoon Party (Japan).z64" size="12582912" crc="d59d2794" md5="22b86ab3f320a607899a0516c90a24d0" sha1="d5553182ecda2eba6076e7b04b900ef78b700fc5"/>
+		<rom name="Puyo Puyoon Party (Japan).n64" />
+		<release name="Puyo Puyoon Party (Japan)" region="JPN" />
+		<rom name="Puyo Puyoon Party (Japan).z64" size="12582912" crc="d59d2794" md5="22b86ab3f320a607899a0516c90a24d0" sha1="d5553182ecda2eba6076e7b04b900ef78b700fc5" />
 	</game>
 	<game name="Quake (Europe)">
 		<description>Quake (Europe)</description>
-		<release name="Quake (Europe)" region="EUR"/>
-		<rom name="Quake (Europe).z64" size="12582912" crc="28c10844" md5="592ce7718efdd1ff2f077c9b2b5275fb" sha1="c1b4fc22a1699be0bc8cea170ac4f8b6bf8f41d1" status="verified"/>
+		<rom name="Quake (Europe).n64" />
+		<release name="Quake (Europe)" region="EUR" />
+		<rom name="Quake (Europe).z64" size="12582912" crc="28c10844" md5="592ce7718efdd1ff2f077c9b2b5275fb" sha1="c1b4fc22a1699be0bc8cea170ac4f8b6bf8f41d1" status="verified" />
 	</game>
 	<game name="Quake (USA)" cloneof="Quake (Europe)">
 		<description>Quake (USA)</description>
-		<release name="Quake (USA)" region="USA"/>
-		<rom name="Quake (USA).z64" size="12582912" crc="761f39d1" md5="097605021951024c3ecb2d502c0c2a9f" sha1="25a7fe0342490d3c23328040bb34f8748995537a"/>
+		<rom name="Quake (USA).n64" />
+		<release name="Quake (USA)" region="USA" />
+		<rom name="Quake (USA).z64" size="12582912" crc="761f39d1" md5="097605021951024c3ecb2d502c0c2a9f" sha1="25a7fe0342490d3c23328040bb34f8748995537a" />
 	</game>
 	<game name="Quake II (Europe)">
 		<description>Quake II (Europe)</description>
-		<release name="Quake II (Europe)" region="EUR"/>
-		<rom name="Quake II (Europe).z64" size="12582912" crc="82beca21" md5="673d4ba4f41a0fe23650f06af53eec50" sha1="f99cc966965e8fa0beb9fd768c646e6686e19916"/>
+		<rom name="Quake II (Europe).n64" />
+		<release name="Quake II (Europe)" region="EUR" />
+		<rom name="Quake II (Europe).z64" size="12582912" crc="82beca21" md5="673d4ba4f41a0fe23650f06af53eec50" sha1="f99cc966965e8fa0beb9fd768c646e6686e19916" />
 	</game>
 	<game name="Quake II (USA)" cloneof="Quake II (Europe)">
 		<description>Quake II (USA)</description>
-		<release name="Quake II (USA)" region="USA"/>
-		<rom name="Quake II (USA).z64" size="12582912" crc="e6b34387" md5="cc93c30c633ff461c29b54ceabefd701" sha1="2edb00e602e7c2813a5d6a04dfec80487627237a"/>
+		<rom name="Quake II (USA).n64" />
+		<release name="Quake II (USA)" region="USA" />
+		<rom name="Quake II (USA).z64" size="12582912" crc="e6b34387" md5="cc93c30c633ff461c29b54ceabefd701" sha1="2edb00e602e7c2813a5d6a04dfec80487627237a" />
 	</game>
 	<game name="Rakugakids (Europe)">
 		<description>Rakugakids (Europe)</description>
-		<release name="Rakugakids (Europe)" region="EUR"/>
-		<rom name="Rakugakids (Europe).z64" size="12582912" crc="483129aa" md5="167a3502f06cf0eef56758533f3d0e52" sha1="a2846cb316dc980dd0040ca95c20abfc8ccce212"/>
+		<rom name="Rakugakids (Europe).n64" />
+		<release name="Rakugakids (Europe)" region="EUR" />
+		<rom name="Rakugakids (Europe).z64" size="12582912" crc="483129aa" md5="167a3502f06cf0eef56758533f3d0e52" sha1="a2846cb316dc980dd0040ca95c20abfc8ccce212" />
 	</game>
 	<game name="Rakugakids (Japan)" cloneof="Rakugakids (Europe)">
 		<description>Rakugakids (Japan)</description>
-		<release name="Rakugakids (Japan)" region="JPN"/>
-		<rom name="Rakugakids (Japan).z64" size="12582912" crc="b9e53b06" md5="813ad5c00bad7c4d41f8558cecedae51" sha1="43596236cc1a4a4b671d0586fb42518a009427a5"/>
+		<rom name="Rakugakids (Japan).n64" />
+		<release name="Rakugakids (Japan)" region="JPN" />
+		<rom name="Rakugakids (Japan).z64" size="12582912" crc="b9e53b06" md5="813ad5c00bad7c4d41f8558cecedae51" sha1="43596236cc1a4a4b671d0586fb42518a009427a5" />
 	</game>
 	<game name="Rally Challenge 2000 (USA)">
 		<description>Rally Challenge 2000 (USA)</description>
-		<release name="Rally Challenge 2000 (USA)" region="USA"/>
-		<rom name="Rally Challenge 2000 (USA).z64" size="12582912" crc="3edec7b0" md5="0458bc47cd771d8bc66b0ceae6895724" sha1="d42fd8de45755cd70a4d4c252cc1873410db9f3e"/>
+		<rom name="Rally Challenge 2000 (USA).n64" />
+		<release name="Rally Challenge 2000 (USA)" region="USA" />
+		<rom name="Rally Challenge 2000 (USA).z64" size="12582912" crc="3edec7b0" md5="0458bc47cd771d8bc66b0ceae6895724" sha1="d42fd8de45755cd70a4d4c252cc1873410db9f3e" />
 	</game>
 	<game name="Rally '99 (Japan)" cloneof="Rally Challenge 2000 (USA)">
 		<description>Rally '99 (Japan)</description>
-		<release name="Rally '99 (Japan)" region="JPN"/>
-		<rom name="Rally '99 (Japan).z64" size="8388608" crc="ffa625fe" md5="0630226f63561a05916edcfbc8d96c04" sha1="8d3659925433b9d4c37d06abd2e1c4662aa80e1f"/>
+		<rom name="Rally '99 (Japan).n64" />
+		<release name="Rally '99 (Japan)" region="JPN" />
+		<rom name="Rally '99 (Japan).z64" size="8388608" crc="ffa625fe" md5="0630226f63561a05916edcfbc8d96c04" sha1="8d3659925433b9d4c37d06abd2e1c4662aa80e1f" />
 	</game>
 	<game name="Rampage - World Tour (Europe)">
 		<description>Rampage - World Tour (Europe)</description>
-		<release name="Rampage - World Tour (Europe)" region="EUR"/>
-		<rom name="Rampage - World Tour (Europe).z64" size="12582912" crc="cdc458ec" md5="08e02f52e0547686a9bfac7cbb03c129" sha1="c8db2a3669b08050f42af47bae9fd5146b8c87bb"/>
+		<rom name="Rampage - World Tour (Europe).n64" />
+		<release name="Rampage - World Tour (Europe)" region="EUR" />
+		<rom name="Rampage - World Tour (Europe).z64" size="12582912" crc="cdc458ec" md5="08e02f52e0547686a9bfac7cbb03c129" sha1="c8db2a3669b08050f42af47bae9fd5146b8c87bb" />
 	</game>
 	<game name="Rampage - World Tour (USA)" cloneof="Rampage - World Tour (Europe)">
 		<description>Rampage - World Tour (USA)</description>
-		<release name="Rampage - World Tour (USA)" region="USA"/>
-		<rom name="Rampage - World Tour (USA).z64" size="12582912" crc="211119dd" md5="4645672a0cf00ada9b5e37cfde8b024e" sha1="7a6c8758e67fd3da99e3420983c0d6df83e41c6b"/>
+		<rom name="Rampage - World Tour (USA).n64" />
+		<release name="Rampage - World Tour (USA)" region="USA" />
+		<rom name="Rampage - World Tour (USA).z64" size="12582912" crc="211119dd" md5="4645672a0cf00ada9b5e37cfde8b024e" sha1="7a6c8758e67fd3da99e3420983c0d6df83e41c6b" />
 	</game>
 	<game name="Rampage 2 - Universal Tour (Europe)">
 		<description>Rampage 2 - Universal Tour (Europe)</description>
-		<release name="Rampage 2 - Universal Tour (Europe)" region="EUR"/>
-		<rom name="Rampage 2 - Universal Tour (Europe).z64" size="12582912" crc="fa6e097b" md5="1492806f12d33c3ea0edb6848d43b1cc" sha1="0c18a10807a5f910ce7337812770b4fe18994a60"/>
+		<rom name="Rampage 2 - Universal Tour (Europe).n64" />
+		<release name="Rampage 2 - Universal Tour (Europe)" region="EUR" />
+		<rom name="Rampage 2 - Universal Tour (Europe).z64" size="12582912" crc="fa6e097b" md5="1492806f12d33c3ea0edb6848d43b1cc" sha1="0c18a10807a5f910ce7337812770b4fe18994a60" />
 	</game>
 	<game name="Rampage 2 - Universal Tour (USA)" cloneof="Rampage 2 - Universal Tour (Europe)">
 		<description>Rampage 2 - Universal Tour (USA)</description>
-		<release name="Rampage 2 - Universal Tour (USA)" region="USA"/>
-		<rom name="Rampage 2 - Universal Tour (USA).z64" size="12582912" crc="7614ee0d" md5="8113d0ea2008402d4631f241f625d16b" sha1="36d1b741f6ea896b05ab7ceeac8b78684cbdac6b"/>
+		<rom name="Rampage 2 - Universal Tour (USA).n64" />
+		<release name="Rampage 2 - Universal Tour (USA)" region="USA" />
+		<rom name="Rampage 2 - Universal Tour (USA).z64" size="12582912" crc="7614ee0d" md5="8113d0ea2008402d4631f241f625d16b" sha1="36d1b741f6ea896b05ab7ceeac8b78684cbdac6b" />
 	</game>
 	<game name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Rat Attack (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="dd4fa798" md5="bc66239c12ae8696926e50c2b6ed9c49" sha1="b27e328f7600b7a2e175e4a36d8c85073eaf4d0e"/>
+		<rom name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Rat Attack (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="dd4fa798" md5="bc66239c12ae8696926e50c2b6ed9c49" sha1="b27e328f7600b7a2e175e4a36d8c85073eaf4d0e" />
 	</game>
 	<game name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl)" cloneof="Rat Attack (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Rat Attack! (USA) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl)" region="USA"/>
-		<rom name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="2315fea7" md5="f661889fdf65ddcd212e9fb53b2c8f50" sha1="0682b6745832984f43652c0589e4ecf37f937790"/>
+		<rom name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl)" region="USA" />
+		<rom name="Rat Attack! (USA) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="2315fea7" md5="f661889fdf65ddcd212e9fb53b2c8f50" sha1="0682b6745832984f43652c0589e4ecf37f937790" />
 	</game>
 	<game name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)">
 		<description>Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="169a5037" md5="5dbbfd5ace8222fa8fe51be113453c13" sha1="619ab27ea1645399439ad324566361d3e7ff020e"/>
+		<rom name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It).z64" size="33554432" crc="169a5037" md5="5dbbfd5ace8222fa8fe51be113453c13" sha1="619ab27ea1645399439ad324566361d3e7ff020e" />
 	</game>
 	<game name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)" cloneof="Rayman 2 - The Great Escape (Europe) (En,Fr,De,Es,It)">
 		<description>Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)</description>
-		<release name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)" region="USA"/>
-		<rom name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It).z64" size="33554432" crc="02bb4409" md5="03aa4d09fde77eed9b95be68e603d233" sha1="50558356b059ad3fbaf5fe95380512b9dceaaf52"/>
+		<rom name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It).n64" />
+		<release name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It)" region="USA" />
+		<rom name="Rayman 2 - The Great Escape (USA) (En,Fr,De,Es,It).z64" size="33554432" crc="02bb4409" md5="03aa4d09fde77eed9b95be68e603d233" sha1="50558356b059ad3fbaf5fe95380512b9dceaaf52" />
 	</game>
 	<game name="Razor Freestyle Scooter (USA)">
 		<description>Razor Freestyle Scooter (USA)</description>
-		<release name="Razor Freestyle Scooter (USA)" region="USA"/>
-		<rom name="Razor Freestyle Scooter (USA).z64" size="8388608" crc="927ce621" md5="406b08987ab92d73d72b597ec6b11bd9" sha1="d107e8d28a262a60ba50de4c227343ebc3587784"/>
+		<rom name="Razor Freestyle Scooter (USA).n64" />
+		<release name="Razor Freestyle Scooter (USA)" region="USA" />
+		<rom name="Razor Freestyle Scooter (USA).z64" size="8388608" crc="927ce621" md5="406b08987ab92d73d72b597ec6b11bd9" sha1="d107e8d28a262a60ba50de4c227343ebc3587784" />
 	</game>
 	<game name="Re-Volt (Europe) (En,Fr,De,Es)">
 		<description>Re-Volt (Europe) (En,Fr,De,Es)</description>
-		<release name="Re-Volt (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Re-Volt (Europe) (En,Fr,De,Es).z64" size="12582912" crc="81d13a11" md5="faa64abb0d222fcc0c6e2515d3805d9f" sha1="5ed3cd3888fec080d44ffe345dd50d75e471ff8f"/>
+		<rom name="Re-Volt (Europe) (En,Fr,De,Es).n64" />
+		<release name="Re-Volt (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Re-Volt (Europe) (En,Fr,De,Es).z64" size="12582912" crc="81d13a11" md5="faa64abb0d222fcc0c6e2515d3805d9f" sha1="5ed3cd3888fec080d44ffe345dd50d75e471ff8f" />
 	</game>
 	<game name="Re-Volt (USA)" cloneof="Re-Volt (Europe) (En,Fr,De,Es)">
 		<description>Re-Volt (USA)</description>
-		<release name="Re-Volt (USA)" region="USA"/>
-		<rom name="Re-Volt (USA).z64" size="12582912" crc="fc0c86d0" md5="3fc4d3187435443455f8355b2d3f8934" sha1="667fdc39112599bd904f5e7d8d692973e554bd88"/>
+		<rom name="Re-Volt (USA).n64" />
+		<release name="Re-Volt (USA)" region="USA" />
+		<rom name="Re-Volt (USA).z64" size="12582912" crc="fc0c86d0" md5="3fc4d3187435443455f8355b2d3f8934" sha1="667fdc39112599bd904f5e7d8d692973e554bd88" />
 	</game>
 	<game name="Ready 2 Rumble Boxing (Europe) (En,Fr,De)">
 		<description>Ready 2 Rumble Boxing (Europe) (En,Fr,De)</description>
-		<release name="Ready 2 Rumble Boxing (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Ready 2 Rumble Boxing (Europe) (En,Fr,De).z64" size="33554432" crc="a69df7b3" md5="adc95ae01855fa305b13f8b22427e597" sha1="e18477d858c623a834f24dc2717d0ef340e63364"/>
+		<rom name="Ready 2 Rumble Boxing (Europe) (En,Fr,De).n64" />
+		<release name="Ready 2 Rumble Boxing (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Ready 2 Rumble Boxing (Europe) (En,Fr,De).z64" size="33554432" crc="a69df7b3" md5="adc95ae01855fa305b13f8b22427e597" sha1="e18477d858c623a834f24dc2717d0ef340e63364" />
 	</game>
 	<game name="Ready 2 Rumble Boxing (USA)" cloneof="Ready 2 Rumble Boxing (Europe) (En,Fr,De)">
 		<description>Ready 2 Rumble Boxing (USA)</description>
-		<release name="Ready 2 Rumble Boxing (USA)" region="USA"/>
-		<rom name="Ready 2 Rumble Boxing (USA).z64" size="33554432" crc="2a554048" md5="a42f6f14f7ea10abeb3b55ffd42eb572" sha1="e60fedd535a72fda5c424b846421bbdad17c6caa"/>
+		<rom name="Ready 2 Rumble Boxing (USA).n64" />
+		<release name="Ready 2 Rumble Boxing (USA)" region="USA" />
+		<rom name="Ready 2 Rumble Boxing (USA).z64" size="33554432" crc="2a554048" md5="a42f6f14f7ea10abeb3b55ffd42eb572" sha1="e60fedd535a72fda5c424b846421bbdad17c6caa" />
 	</game>
 	<game name="Ready 2 Rumble Boxing - Round 2 (USA)">
 		<description>Ready 2 Rumble Boxing - Round 2 (USA)</description>
-		<release name="Ready 2 Rumble Boxing - Round 2 (USA)" region="USA"/>
-		<rom name="Ready 2 Rumble Boxing - Round 2 (USA).z64" size="33554432" crc="052a0e04" md5="df4446a2b55c4d8d67e9c0c19e0fd9fb" sha1="42ad558c20dda72e9383323960cd1fd591122052"/>
+		<rom name="Ready 2 Rumble Boxing - Round 2 (USA).n64" />
+		<release name="Ready 2 Rumble Boxing - Round 2 (USA)" region="USA" />
+		<rom name="Ready 2 Rumble Boxing - Round 2 (USA).z64" size="33554432" crc="052a0e04" md5="df4446a2b55c4d8d67e9c0c19e0fd9fb" sha1="42ad558c20dda72e9383323960cd1fd591122052" />
 	</game>
 	<game name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual)">
 		<description>Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual)</description>
-		<release name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual)" region="CHN"/>
-		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual).z64" size="294912" crc="007f3759" md5="3abc2d34ad3ce623f4ed8f126d30cc80" sha1="85fd084f9b34c5f2b90f5fdb73847e47df9f5667"/>
+		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual).n64" />
+		<release name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual)" region="CHN" />
+		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue) (Manual).z64" size="294912" crc="007f3759" md5="3abc2d34ad3ce623f4ed8f126d30cc80" sha1="85fd084f9b34c5f2b90f5fdb73847e47df9f5667" />
 	</game>
 	<game name="Resident Evil 2 (Europe) (En,Fr)">
 		<description>Resident Evil 2 (Europe) (En,Fr)</description>
-		<release name="Resident Evil 2 (Europe) (En,Fr)" region="EUR"/>
-		<rom name="Resident Evil 2 (Europe) (En,Fr).z64" size="67108864" crc="7c8ee011" md5="b04f298721223a22e1150cebc712ee6a" sha1="d54561791bc41f1b743f8abe769a6e8cbf435326" status="verified"/>
+		<rom name="Resident Evil 2 (Europe) (En,Fr).n64" />
+		<release name="Resident Evil 2 (Europe) (En,Fr)" region="EUR" />
+		<rom name="Resident Evil 2 (Europe) (En,Fr).z64" size="67108864" crc="7c8ee011" md5="b04f298721223a22e1150cebc712ee6a" sha1="d54561791bc41f1b743f8abe769a6e8cbf435326" status="verified" />
 	</game>
 	<game name="Biohazard 2 (Japan)" cloneof="Resident Evil 2 (Europe) (En,Fr)">
 		<description>Biohazard 2 (Japan)</description>
-		<release name="Biohazard 2 (Japan)" region="JPN"/>
-		<rom name="Biohazard 2 (Japan).z64" size="67108864" crc="4f9d569f" md5="f77d70959222276491222f31ebff3bf1" sha1="7492139f237c547ef32955c7cc6b9a5e6dcaa55d"/>
+		<rom name="Biohazard 2 (Japan).n64" />
+		<release name="Biohazard 2 (Japan)" region="JPN" />
+		<rom name="Biohazard 2 (Japan).z64" size="67108864" crc="4f9d569f" md5="f77d70959222276491222f31ebff3bf1" sha1="7492139f237c547ef32955c7cc6b9a5e6dcaa55d" />
 	</game>
 	<game name="Resident Evil 2 (USA) (Rev 1)" cloneof="Resident Evil 2 (Europe) (En,Fr)">
 		<description>Resident Evil 2 (USA) (Rev 1)</description>
-		<release name="Resident Evil 2 (USA) (Rev 1)" region="USA"/>
-		<rom name="Resident Evil 2 (USA) (Rev 1).z64" size="67108864" crc="848fbc0d" md5="1add2c0217662b307cdfd876b35fbf7a" sha1="62ec19bead748c12d38f6c5a7ab0831edbd3d44b"/>
+		<rom name="Resident Evil 2 (USA) (Rev 1).n64" />
+		<release name="Resident Evil 2 (USA) (Rev 1)" region="USA" />
+		<rom name="Resident Evil 2 (USA) (Rev 1).z64" size="67108864" crc="848fbc0d" md5="1add2c0217662b307cdfd876b35fbf7a" sha1="62ec19bead748c12d38f6c5a7ab0831edbd3d44b" />
 	</game>
 	<game name="Resident Evil 2 (USA)" cloneof="Resident Evil 2 (Europe) (En,Fr)">
 		<description>Resident Evil 2 (USA)</description>
-		<rom name="Resident Evil 2 (USA).z64" size="67108864" crc="832ea1da" md5="dd21150cbc21c05420304599ec57411c" sha1="93187c4145cad272a255c17657cd9a1011b3fb3a"/>
+		<rom name="Resident Evil 2 (USA).n64" />
+		<rom name="Resident Evil 2 (USA).z64" size="67108864" crc="832ea1da" md5="dd21150cbc21c05420304599ec57411c" sha1="93187c4145cad272a255c17657cd9a1011b3fb3a" />
 	</game>
 	<game name="Road Rash 64 (Europe)">
 		<description>Road Rash 64 (Europe)</description>
-		<release name="Road Rash 64 (Europe)" region="EUR"/>
-		<rom name="Road Rash 64 (Europe).z64" size="33554432" crc="3c664a7b" md5="ad922dae446a301e1aafe1dfbad75a2e" sha1="816824cb5dc62ee54dc52c0ebb9b2564ecb88133"/>
+		<rom name="Road Rash 64 (Europe).n64" />
+		<release name="Road Rash 64 (Europe)" region="EUR" />
+		<rom name="Road Rash 64 (Europe).z64" size="33554432" crc="3c664a7b" md5="ad922dae446a301e1aafe1dfbad75a2e" sha1="816824cb5dc62ee54dc52c0ebb9b2564ecb88133" />
 	</game>
 	<game name="Road Rash 64 (USA)" cloneof="Road Rash 64 (Europe)">
 		<description>Road Rash 64 (USA)</description>
-		<release name="Road Rash 64 (USA)" region="USA"/>
-		<rom name="Road Rash 64 (USA).z64" size="33554432" crc="600b3988" md5="28c2373f6d831eec81f6146a809e701b" sha1="87727a298f583ec8325f5655088ff21e37b335b2"/>
+		<rom name="Road Rash 64 (USA).n64" />
+		<release name="Road Rash 64 (USA)" region="USA" />
+		<rom name="Road Rash 64 (USA).z64" size="33554432" crc="600b3988" md5="28c2373f6d831eec81f6146a809e701b" sha1="87727a298f583ec8325f5655088ff21e37b335b2" />
 	</game>
 	<game name="Road Rash 64 (Europe) (Beta) (1999-10-12)" cloneof="Road Rash 64 (Europe)">
 		<description>Road Rash 64 (Europe) (Beta) (1999-10-12)</description>
-		<rom name="Road Rash 64 (Europe) (Beta) (1999-10-12).z64" size="33554432" crc="4fb98385" md5="436f93c0d8b1650bc308ccf344c08c93" sha1="615fed220a13096bb6fc4c5d7902c66fc5a044d7"/>
+		<rom name="Road Rash 64 (Europe) (Beta) (1999-10-12).n64" />
+		<rom name="Road Rash 64 (Europe) (Beta) (1999-10-12).z64" size="33554432" crc="4fb98385" md5="436f93c0d8b1650bc308ccf344c08c93" sha1="615fed220a13096bb6fc4c5d7902c66fc5a044d7" />
 	</game>
 	<game name="Roadsters (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Roadsters (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Roadsters (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Roadsters (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="997ed5af" md5="41f67b5c8bb8daeffd989123846fc063" sha1="2ad3bccd29dc879a873c926af03002e36582525a"/>
+		<rom name="Roadsters (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Roadsters (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Roadsters (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="997ed5af" md5="41f67b5c8bb8daeffd989123846fc063" sha1="2ad3bccd29dc879a873c926af03002e36582525a" />
 	</game>
 	<game name="Roadsters (USA) (En,Fr,Es)" cloneof="Roadsters (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Roadsters (USA) (En,Fr,Es)</description>
-		<release name="Roadsters (USA) (En,Fr,Es)" region="USA"/>
-		<rom name="Roadsters (USA) (En,Fr,Es).z64" size="12582912" crc="e4337b92" md5="d3644b398c090528e0ed9eb3c140366e" sha1="d896ffcba44696bdb7e2048841f287ea5951ad2a"/>
+		<rom name="Roadsters (USA) (En,Fr,Es).n64" />
+		<release name="Roadsters (USA) (En,Fr,Es)" region="USA" />
+		<rom name="Roadsters (USA) (En,Fr,Es).z64" size="12582912" crc="e4337b92" md5="d3644b398c090528e0ed9eb3c140366e" sha1="d896ffcba44696bdb7e2048841f287ea5951ad2a" />
 	</game>
 	<game name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)">
 		<description>Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)</description>
-		<release name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)" region="JPN"/>
-		<rom name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan).z64" size="33554432" crc="3b0f8061" md5="444f70a655ac89ca900f6fafaf926b16" sha1="9bc6130916d8a1d8bcec5f38fbbff066444838cd"/>
+		<rom name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan).n64" />
+		<release name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan)" region="JPN" />
+		<rom name="Robot Poncots 64 - 7tsu no Umi no Caramel (Japan).z64" size="33554432" crc="3b0f8061" md5="444f70a655ac89ca900f6fafaf926b16" sha1="9bc6130916d8a1d8bcec5f38fbbff066444838cd" />
 	</game>
 	<game name="Robotech - Crystal Dreams (USA) (Proto 2)">
 		<description>Robotech - Crystal Dreams (USA) (Proto 2)</description>
-		<release name="Robotech - Crystal Dreams (USA) (Proto 2)" region="USA"/>
-		<rom name="Robotech - Crystal Dreams (USA) (Proto 2).z64" size="16777216" crc="f9a7904e" md5="b39592c6c9a3121258bdb62485956880" sha1="8051c03135447a92b21aface5b00111c3b4af773"/>
+		<rom name="Robotech - Crystal Dreams (USA) (Proto 2).n64" />
+		<release name="Robotech - Crystal Dreams (USA) (Proto 2)" region="USA" />
+		<rom name="Robotech - Crystal Dreams (USA) (Proto 2).z64" size="16777216" crc="f9a7904e" md5="b39592c6c9a3121258bdb62485956880" sha1="8051c03135447a92b21aface5b00111c3b4af773" />
 	</game>
 	<game name="Robotech - Crystal Dreams (USA) (Proto 1)" cloneof="Robotech - Crystal Dreams (USA) (Proto 2)">
 		<description>Robotech - Crystal Dreams (USA) (Proto 1)</description>
-		<rom name="Robotech - Crystal Dreams (USA) (Proto 1).z64" size="16777216" crc="baa8646d" md5="e40ba4761ce977f3fb02151354812d99" sha1="6fde818ae618a92eb9008769d9459b2eaf927246"/>
+		<rom name="Robotech - Crystal Dreams (USA) (Proto 1).n64" />
+		<rom name="Robotech - Crystal Dreams (USA) (Proto 1).z64" size="16777216" crc="baa8646d" md5="e40ba4761ce977f3fb02151354812d99" sha1="6fde818ae618a92eb9008769d9459b2eaf927246" />
 	</game>
 	<game name="Robotron 64 (Europe)">
 		<description>Robotron 64 (Europe)</description>
-		<release name="Robotron 64 (Europe)" region="EUR"/>
-		<rom name="Robotron 64 (Europe).z64" size="8388608" crc="23bf4956" md5="2abcd1ad41b3356fbc1018ecb121283e" sha1="d86a7ed2f203ba9df0ce5b18d9e4e2e2d9b62a3f"/>
+		<rom name="Robotron 64 (Europe).n64" />
+		<release name="Robotron 64 (Europe)" region="EUR" />
+		<rom name="Robotron 64 (Europe).z64" size="8388608" crc="23bf4956" md5="2abcd1ad41b3356fbc1018ecb121283e" sha1="d86a7ed2f203ba9df0ce5b18d9e4e2e2d9b62a3f" />
 	</game>
 	<game name="Robotron 64 (USA)" cloneof="Robotron 64 (Europe)">
 		<description>Robotron 64 (USA)</description>
-		<release name="Robotron 64 (USA)" region="USA"/>
-		<rom name="Robotron 64 (USA).z64" size="8388608" crc="b2cbae58" md5="5698757883a6f46fe5b4c9b6e780b480" sha1="44d158bc2aeefb111a620b61e043b2703e6c5808"/>
+		<rom name="Robotron 64 (USA).n64" />
+		<release name="Robotron 64 (USA)" region="USA" />
+		<rom name="Robotron 64 (USA).z64" size="8388608" crc="b2cbae58" md5="5698757883a6f46fe5b4c9b6e780b480" sha1="44d158bc2aeefb111a620b61e043b2703e6c5808" />
 	</game>
 	<game name="Rocket - Robot on Wheels (Europe) (En,Fr,De)">
 		<description>Rocket - Robot on Wheels (Europe) (En,Fr,De)</description>
-		<release name="Rocket - Robot on Wheels (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Rocket - Robot on Wheels (Europe) (En,Fr,De).z64" size="12582912" crc="7de5d20d" md5="427c5457d4a29a222811f0caa9cca7b9" sha1="a1aa086f0826bee4be71c16bc67468b8d8a49065"/>
+		<rom name="Rocket - Robot on Wheels (Europe) (En,Fr,De).n64" />
+		<release name="Rocket - Robot on Wheels (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Rocket - Robot on Wheels (Europe) (En,Fr,De).z64" size="12582912" crc="7de5d20d" md5="427c5457d4a29a222811f0caa9cca7b9" sha1="a1aa086f0826bee4be71c16bc67468b8d8a49065" />
 	</game>
 	<game name="Rocket - Robot on Wheels (USA)" cloneof="Rocket - Robot on Wheels (Europe) (En,Fr,De)">
 		<description>Rocket - Robot on Wheels (USA)</description>
-		<release name="Rocket - Robot on Wheels (USA)" region="USA"/>
-		<rom name="Rocket - Robot on Wheels (USA).z64" size="12582912" crc="e0399f23" md5="c2907eb2f9a350793317ece878a3b8e3" sha1="622d71a44da0b81ea68092cac9198c66154a4f4a"/>
+		<rom name="Rocket - Robot on Wheels (USA).n64" />
+		<release name="Rocket - Robot on Wheels (USA)" region="USA" />
+		<rom name="Rocket - Robot on Wheels (USA).z64" size="12582912" crc="e0399f23" md5="c2907eb2f9a350793317ece878a3b8e3" sha1="622d71a44da0b81ea68092cac9198c66154a4f4a" />
 	</game>
 	<game name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29)" cloneof="Rocket - Robot on Wheels (Europe) (En,Fr,De)">
 		<description>Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29)</description>
-		<rom name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29).z64" size="25165824" crc="7d766772" md5="c33561d58dc04cee752a3a4bd1fb4797" sha1="0786e5be0ea6522a1e9f1a9052dacaf01169298e"/>
+		<rom name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29).n64" />
+		<rom name="Rocket - Robot on Wheels (Europe) (Beta) (1999-09-29).z64" size="25165824" crc="7d766772" md5="c33561d58dc04cee752a3a4bd1fb4797" sha1="0786e5be0ea6522a1e9f1a9052dacaf01169298e" />
 	</game>
 	<game name="RR64 - Ridge Racer 64 (Europe)">
 		<description>RR64 - Ridge Racer 64 (Europe)</description>
-		<release name="RR64 - Ridge Racer 64 (Europe)" region="EUR"/>
-		<rom name="RR64 - Ridge Racer 64 (Europe).z64" size="33554432" crc="dd9ae3a8" md5="4561840840760ffa7b59f03a5f416a5c" sha1="faa21c8e0282d21eac2d1b35b020f40381e18fc4" status="verified"/>
+		<rom name="RR64 - Ridge Racer 64 (Europe).n64" />
+		<release name="RR64 - Ridge Racer 64 (Europe)" region="EUR" />
+		<rom name="RR64 - Ridge Racer 64 (Europe).z64" size="33554432" crc="dd9ae3a8" md5="4561840840760ffa7b59f03a5f416a5c" sha1="faa21c8e0282d21eac2d1b35b020f40381e18fc4" status="verified" />
 	</game>
 	<game name="RR64 - Ridge Racer 64 (USA)" cloneof="RR64 - Ridge Racer 64 (Europe)">
 		<description>RR64 - Ridge Racer 64 (USA)</description>
-		<release name="RR64 - Ridge Racer 64 (USA)" region="USA"/>
-		<rom name="RR64 - Ridge Racer 64 (USA).z64" size="33554432" crc="3c2c2d1c" md5="990f97d56456fc23e52bd263e709e21e" sha1="5f079cd9827b24d12af4961482a0fcc679e53042"/>
+		<rom name="RR64 - Ridge Racer 64 (USA).n64" />
+		<release name="RR64 - Ridge Racer 64 (USA)" region="USA" />
+		<rom name="RR64 - Ridge Racer 64 (USA).z64" size="33554432" crc="3c2c2d1c" md5="990f97d56456fc23e52bd263e709e21e" sha1="5f079cd9827b24d12af4961482a0fcc679e53042" />
 	</game>
 	<game name="Rugrats - Treasure Hunt (Europe)">
 		<description>Rugrats - Treasure Hunt (Europe)</description>
-		<release name="Rugrats - Treasure Hunt (Europe)" region="EUR"/>
-		<rom name="Rugrats - Treasure Hunt (Europe).z64" size="16777216" crc="3338b7c8" md5="55185016031cdc73c0fd471527c35706" sha1="5ff0b82077559dd4c206a7a7d13eabeabc82e9c4"/>
+		<rom name="Rugrats - Treasure Hunt (Europe).n64" />
+		<release name="Rugrats - Treasure Hunt (Europe)" region="EUR" />
+		<rom name="Rugrats - Treasure Hunt (Europe).z64" size="16777216" crc="3338b7c8" md5="55185016031cdc73c0fd471527c35706" sha1="5ff0b82077559dd4c206a7a7d13eabeabc82e9c4" />
 	</game>
 	<game name="Razmoket, Les - La Chasse aux Tresors (France)" cloneof="Rugrats - Treasure Hunt (Europe)">
 		<description>Razmoket, Les - La Chasse aux Tresors (France)</description>
-		<release name="Razmoket, Les - La Chasse aux Tresors (France)" region="FRA"/>
-		<rom name="Razmoket, Les - La Chasse aux Tresors (France).z64" size="16777216" crc="66766469" md5="55685d6324efde5bc9d26c98706b0b8a" sha1="69c06b2d31bc6bc66cd028705d81024f21a7654c"/>
+		<rom name="Razmoket, Les - La Chasse aux Tresors (France).n64" />
+		<release name="Razmoket, Les - La Chasse aux Tresors (France)" region="FRA" />
+		<rom name="Razmoket, Les - La Chasse aux Tresors (France).z64" size="16777216" crc="66766469" md5="55685d6324efde5bc9d26c98706b0b8a" sha1="69c06b2d31bc6bc66cd028705d81024f21a7654c" />
 	</game>
 	<game name="Rugrats - Die grosse Schatzsuche (Germany)" cloneof="Rugrats - Treasure Hunt (Europe)">
 		<description>Rugrats - Die grosse Schatzsuche (Germany)</description>
-		<release name="Rugrats - Die grosse Schatzsuche (Germany)" region="GER"/>
-		<rom name="Rugrats - Die grosse Schatzsuche (Germany).z64" size="16777216" crc="23aed3a2" md5="dec4598a39728c28cd0ceba45a173ce1" sha1="32caba1042cabbf366852d629d3fee1a5186bce3"/>
+		<rom name="Rugrats - Die grosse Schatzsuche (Germany).n64" />
+		<release name="Rugrats - Die grosse Schatzsuche (Germany)" region="GER" />
+		<rom name="Rugrats - Die grosse Schatzsuche (Germany).z64" size="16777216" crc="23aed3a2" md5="dec4598a39728c28cd0ceba45a173ce1" sha1="32caba1042cabbf366852d629d3fee1a5186bce3" />
 	</game>
 	<game name="Rugrats - Scavenger Hunt (USA)" cloneof="Rugrats - Treasure Hunt (Europe)">
 		<description>Rugrats - Scavenger Hunt (USA)</description>
-		<release name="Rugrats - Scavenger Hunt (USA)" region="USA"/>
-		<rom name="Rugrats - Scavenger Hunt (USA).z64" size="16777216" crc="a87faf82" md5="8c432235a57d34bc4a9b8b290e21e01e" sha1="fb2a62f1625630d6f0beb5fd00a32e12155d50e8"/>
+		<rom name="Rugrats - Scavenger Hunt (USA).n64" />
+		<release name="Rugrats - Scavenger Hunt (USA)" region="USA" />
+		<rom name="Rugrats - Scavenger Hunt (USA).z64" size="16777216" crc="a87faf82" md5="8c432235a57d34bc4a9b8b290e21e01e" sha1="fb2a62f1625630d6f0beb5fd00a32e12155d50e8" />
 	</game>
 	<game name="Rugrats in Paris - The Movie (Europe)">
 		<description>Rugrats in Paris - The Movie (Europe)</description>
-		<release name="Rugrats in Paris - The Movie (Europe)" region="EUR"/>
-		<rom name="Rugrats in Paris - The Movie (Europe).z64" size="16777216" crc="cd74b07e" md5="229089089661f517c863242d6bb77746" sha1="fdda27e7c418728391a5ec53f62fdb5e1b21a0df"/>
+		<rom name="Rugrats in Paris - The Movie (Europe).n64" />
+		<release name="Rugrats in Paris - The Movie (Europe)" region="EUR" />
+		<rom name="Rugrats in Paris - The Movie (Europe).z64" size="16777216" crc="cd74b07e" md5="229089089661f517c863242d6bb77746" sha1="fdda27e7c418728391a5ec53f62fdb5e1b21a0df" />
 	</game>
 	<game name="Rugrats in Paris - The Movie (USA)" cloneof="Rugrats in Paris - The Movie (Europe)">
 		<description>Rugrats in Paris - The Movie (USA)</description>
-		<release name="Rugrats in Paris - The Movie (USA)" region="USA"/>
-		<rom name="Rugrats in Paris - The Movie (USA).z64" size="16777216" crc="a9cc2419" md5="207efe58c7c221dbdfff285ab80126c1" sha1="7a80199973c42b08490da1f6255b5f17569ba15e"/>
+		<rom name="Rugrats in Paris - The Movie (USA).n64" />
+		<release name="Rugrats in Paris - The Movie (USA)" region="USA" />
+		<rom name="Rugrats in Paris - The Movie (USA).z64" size="16777216" crc="a9cc2419" md5="207efe58c7c221dbdfff285ab80126c1" sha1="7a80199973c42b08490da1f6255b5f17569ba15e" />
 	</game>
 	<game name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="30f21f89" md5="681df5a32e857e77194106b35304d6b5" sha1="090a027612140e90ffbbd7c48dec77005f7b0a69"/>
+		<rom name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="30f21f89" md5="681df5a32e857e77194106b35304d6b5" sha1="090a027612140e90ffbbd7c48dec77005f7b0a69" />
 	</game>
 	<game name="Rush 2 - Extreme Racing USA (USA)" cloneof="Rush 2 - Extreme Racing USA (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Rush 2 - Extreme Racing USA (USA)</description>
-		<release name="Rush 2 - Extreme Racing USA (USA)" region="USA"/>
-		<rom name="Rush 2 - Extreme Racing USA (USA).z64" size="12582912" crc="9eb14ea8" md5="6a925ab624ee3b343231d799733ba898" sha1="01b0a31b1accc18061e8c85f6c5edf0dbd79f097"/>
+		<rom name="Rush 2 - Extreme Racing USA (USA).n64" />
+		<release name="Rush 2 - Extreme Racing USA (USA)" region="USA" />
+		<rom name="Rush 2 - Extreme Racing USA (USA).z64" size="12582912" crc="9eb14ea8" md5="6a925ab624ee3b343231d799733ba898" sha1="01b0a31b1accc18061e8c85f6c5edf0dbd79f097" />
 	</game>
 	<game name="S.C.A.R.S. (Europe) (En,Fr,De)">
 		<description>S.C.A.R.S. (Europe) (En,Fr,De)</description>
-		<release name="S.C.A.R.S. (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="S.C.A.R.S. (Europe) (En,Fr,De).z64" size="8388608" crc="4e37b6f2" md5="7ed3f10bc32cf76f172d8c31d15a2799" sha1="8b4ebad8b7f50381ba2e16d0c475332837bb5780"/>
+		<rom name="S.C.A.R.S. (Europe) (En,Fr,De).n64" />
+		<release name="S.C.A.R.S. (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="S.C.A.R.S. (Europe) (En,Fr,De).z64" size="8388608" crc="4e37b6f2" md5="7ed3f10bc32cf76f172d8c31d15a2799" sha1="8b4ebad8b7f50381ba2e16d0c475332837bb5780" />
 	</game>
 	<game name="S.C.A.R.S. (USA)" cloneof="S.C.A.R.S. (Europe) (En,Fr,De)">
 		<description>S.C.A.R.S. (USA)</description>
-		<release name="S.C.A.R.S. (USA)" region="USA"/>
-		<rom name="S.C.A.R.S. (USA).z64" size="8388608" crc="22916735" md5="d0aa9d20a4b85fe514d2a3150d0133ea" sha1="1e87e7bc5b7bc877abc790ebff122ed6e2be828e"/>
+		<rom name="S.C.A.R.S. (USA).n64" />
+		<release name="S.C.A.R.S. (USA)" region="USA" />
+		<rom name="S.C.A.R.S. (USA).z64" size="8388608" crc="22916735" md5="d0aa9d20a4b85fe514d2a3150d0133ea" sha1="1e87e7bc5b7bc877abc790ebff122ed6e2be828e" />
 	</game>
 	<game name="Saikyou Habu Shougi (Japan)">
 		<description>Saikyou Habu Shougi (Japan)</description>
-		<release name="Saikyou Habu Shougi (Japan)" region="JPN"/>
-		<rom name="Saikyou Habu Shougi (Japan).z64" size="8388608" crc="01794d62" md5="c4e47228706bc724d7fbd811231d20c9" sha1="b7c977fcd8224595e84714c3fa84221374e1838e"/>
+		<rom name="Saikyou Habu Shougi (Japan).n64" />
+		<release name="Saikyou Habu Shougi (Japan)" region="JPN" />
+		<rom name="Saikyou Habu Shougi (Japan).z64" size="8388608" crc="01794d62" md5="c4e47228706bc724d7fbd811231d20c9" sha1="b7c977fcd8224595e84714c3fa84221374e1838e" />
 	</game>
 	<game name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)">
 		<description>San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)</description>
-		<release name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De).z64" size="8388608" crc="e064962a" md5="81b1122ee15f7b50a341ae62e9c5716b" sha1="bc8d37e3a3b9edb4c8465ed7e477c6434c31b47d"/>
+		<rom name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De).n64" />
+		<release name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De).z64" size="8388608" crc="e064962a" md5="81b1122ee15f7b50a341ae62e9c5716b" sha1="bc8d37e3a3b9edb4c8465ed7e477c6434c31b47d" />
 	</game>
 	<game name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De)" cloneof="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)">
 		<description>San Francisco Rush - Extreme Racing (USA) (En,Fr,De)</description>
-		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De).z64" size="8388608" crc="3e20070b" md5="f015fc28e1d62a36b4ebf4c79ca8f285" sha1="cc62539cb30b180c3c7e0aa927786ed061d8d9ab"/>
+		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De).n64" />
+		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De).z64" size="8388608" crc="3e20070b" md5="f015fc28e1d62a36b4ebf4c79ca8f285" sha1="cc62539cb30b180c3c7e0aa927786ed061d8d9ab" />
 	</game>
 	<game name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1)" cloneof="San Francisco Rush - Extreme Racing (Europe) (En,Fr,De)">
 		<description>San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1)</description>
-		<release name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1)" region="USA"/>
-		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1).z64" size="8388608" crc="886c5753" md5="5b127e6b090a0b3f68a114d4d89323d4" sha1="8ac2dc63afde2da90811ce1a3a951b8c0b19a0e7"/>
+		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1).n64" />
+		<release name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1)" region="USA" />
+		<rom name="San Francisco Rush - Extreme Racing (USA) (En,Fr,De) (Rev 1).z64" size="8388608" crc="886c5753" md5="5b127e6b090a0b3f68a114d4d89323d4" sha1="8ac2dc63afde2da90811ce1a3a951b8c0b19a0e7" />
 	</game>
 	<game name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="e63b86c5" md5="02b16ac23998f78f09af6513f4acb664" sha1="61373d4758eca3fa831beac27b4d4c250845f80c"/>
+		<rom name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="e63b86c5" md5="02b16ac23998f78f09af6513f4acb664" sha1="61373d4758eca3fa831beac27b4d4c250845f80c" />
 	</game>
 	<game name="San Francisco Rush 2049 (USA)" cloneof="San Francisco Rush 2049 (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>San Francisco Rush 2049 (USA)</description>
-		<release name="San Francisco Rush 2049 (USA)" region="USA"/>
-		<rom name="San Francisco Rush 2049 (USA).z64" size="12582912" crc="10941439" md5="af5be0adff51a8e9c6d771282c295810" sha1="3f99351d7bb61656614bdb2aa1a90cfe55d1922c"/>
+		<rom name="San Francisco Rush 2049 (USA).n64" />
+		<release name="San Francisco Rush 2049 (USA)" region="USA" />
+		<rom name="San Francisco Rush 2049 (USA).z64" size="12582912" crc="10941439" md5="af5be0adff51a8e9c6d771282c295810" sha1="3f99351d7bb61656614bdb2aa1a90cfe55d1922c" />
 	</game>
 	<game name="Scooby-Doo! - Classic Creep Capers (Europe)">
 		<description>Scooby-Doo! - Classic Creep Capers (Europe)</description>
-		<release name="Scooby-Doo! - Classic Creep Capers (Europe)" region="EUR"/>
-		<rom name="Scooby-Doo! - Classic Creep Capers (Europe).z64" size="16777216" crc="0d737e6f" md5="3b6dd7b60437234895500beff28df6d6" sha1="fa2d39392750e160f2c41733777c64d8df1127af"/>
+		<rom name="Scooby-Doo! - Classic Creep Capers (Europe).n64" />
+		<release name="Scooby-Doo! - Classic Creep Capers (Europe)" region="EUR" />
+		<rom name="Scooby-Doo! - Classic Creep Capers (Europe).z64" size="16777216" crc="0d737e6f" md5="3b6dd7b60437234895500beff28df6d6" sha1="fa2d39392750e160f2c41733777c64d8df1127af" />
 	</game>
 	<game name="Scooby-Doo! - Classic Creep Capers (USA)" cloneof="Scooby-Doo! - Classic Creep Capers (Europe)">
 		<description>Scooby-Doo! - Classic Creep Capers (USA)</description>
-		<rom name="Scooby-Doo! - Classic Creep Capers (USA).z64" size="16777216" crc="39068228" md5="16cc6db10a56331b56f374b4fb254d5e" sha1="fa22bd1216094124c84987414dde1b50af90d928"/>
+		<rom name="Scooby-Doo! - Classic Creep Capers (USA).n64" />
+		<rom name="Scooby-Doo! - Classic Creep Capers (USA).z64" size="16777216" crc="39068228" md5="16cc6db10a56331b56f374b4fb254d5e" sha1="fa22bd1216094124c84987414dde1b50af90d928" />
 	</game>
 	<game name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1)" cloneof="Scooby-Doo! - Classic Creep Capers (Europe)">
 		<description>Scooby-Doo! - Classic Creep Capers (USA) (Rev 1)</description>
-		<release name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1)" region="USA"/>
-		<rom name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1).z64" size="16777216" crc="cdf86f5e" md5="01cd9938dae5dcdd4b264ae7f26c6d4d" sha1="44dc4f2a148e56fe8088805cb5a860dbc3a638e2"/>
+		<rom name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1).n64" />
+		<release name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1)" region="USA" />
+		<rom name="Scooby-Doo! - Classic Creep Capers (USA) (Rev 1).z64" size="16777216" crc="cdf86f5e" md5="01cd9938dae5dcdd4b264ae7f26c6d4d" sha1="44dc4f2a148e56fe8088805cb5a860dbc3a638e2" />
 	</game>
 	<game name="SD Hiryuu no Ken Densetsu (Japan)">
 		<description>SD Hiryuu no Ken Densetsu (Japan)</description>
-		<release name="SD Hiryuu no Ken Densetsu (Japan)" region="JPN"/>
-		<rom name="SD Hiryuu no Ken Densetsu (Japan).z64" size="12582912" crc="cc083e34" md5="637a7ea2a39f20c5b20834187230d89d" sha1="79cfb5a29b2cbd4f35966f209385b389233cf8cf"/>
+		<rom name="SD Hiryuu no Ken Densetsu (Japan).n64" />
+		<release name="SD Hiryuu no Ken Densetsu (Japan)" region="JPN" />
+		<rom name="SD Hiryuu no Ken Densetsu (Japan).z64" size="12582912" crc="cc083e34" md5="637a7ea2a39f20c5b20834187230d89d" sha1="79cfb5a29b2cbd4f35966f209385b389233cf8cf" />
 	</game>
 	<game name="Sesame Street - Elmo's Letter Adventure (USA)">
 		<description>Sesame Street - Elmo's Letter Adventure (USA)</description>
-		<release name="Sesame Street - Elmo's Letter Adventure (USA)" region="USA"/>
-		<rom name="Sesame Street - Elmo's Letter Adventure (USA).z64" size="8388608" crc="92c3ba6f" md5="15df97a59b2354b130dec3fb86bba513" sha1="97777ca06f4e8aff8f1e95033cc8d3833be40f76"/>
+		<rom name="Sesame Street - Elmo's Letter Adventure (USA).n64" />
+		<release name="Sesame Street - Elmo's Letter Adventure (USA)" region="USA" />
+		<rom name="Sesame Street - Elmo's Letter Adventure (USA).z64" size="8388608" crc="92c3ba6f" md5="15df97a59b2354b130dec3fb86bba513" sha1="97777ca06f4e8aff8f1e95033cc8d3833be40f76" />
 	</game>
 	<game name="Sesame Street - Elmo's Number Journey (USA)">
 		<description>Sesame Street - Elmo's Number Journey (USA)</description>
-		<release name="Sesame Street - Elmo's Number Journey (USA)" region="USA"/>
-		<rom name="Sesame Street - Elmo's Number Journey (USA).z64" size="8388608" crc="ea3b92d8" md5="f733453ed26afa0aca8d3eb3b5b6d8ea" sha1="7195ea96d9fe5de065af61f70d55c92c8ee905e6"/>
+		<rom name="Sesame Street - Elmo's Number Journey (USA).n64" />
+		<release name="Sesame Street - Elmo's Number Journey (USA)" region="USA" />
+		<rom name="Sesame Street - Elmo's Number Journey (USA).z64" size="8388608" crc="ea3b92d8" md5="f733453ed26afa0aca8d3eb3b5b6d8ea" sha1="7195ea96d9fe5de065af61f70d55c92c8ee905e6" />
 	</game>
 	<game name="Shadow Man (Europe) (En,Es,It)">
 		<description>Shadow Man (Europe) (En,Es,It)</description>
-		<release name="Shadow Man (Europe) (En,Es,It)" region="EUR"/>
-		<rom name="Shadow Man (Europe) (En,Es,It).z64" size="33554432" crc="8d230306" md5="a485a6e9e30b7d55d23d8dd043770c64" sha1="39ece3f37c1f54af4274a9733419eb693eac1740"/>
+		<rom name="Shadow Man (Europe) (En,Es,It).n64" />
+		<release name="Shadow Man (Europe) (En,Es,It)" region="EUR" />
+		<rom name="Shadow Man (Europe) (En,Es,It).z64" size="33554432" crc="8d230306" md5="a485a6e9e30b7d55d23d8dd043770c64" sha1="39ece3f37c1f54af4274a9733419eb693eac1740" />
 	</game>
 	<game name="Shadow Man (France)" cloneof="Shadow Man (Europe) (En,Es,It)">
 		<description>Shadow Man (France)</description>
-		<release name="Shadow Man (France)" region="FRA"/>
-		<rom name="Shadow Man (France).z64" size="33554432" crc="6812d3a7" md5="235511bbdb21af5a767bdb7502a80f06" sha1="1f0b03c80c6449de78ee8403cfa84fe8cf759341"/>
+		<rom name="Shadow Man (France).n64" />
+		<release name="Shadow Man (France)" region="FRA" />
+		<rom name="Shadow Man (France).z64" size="33554432" crc="6812d3a7" md5="235511bbdb21af5a767bdb7502a80f06" sha1="1f0b03c80c6449de78ee8403cfa84fe8cf759341" />
 	</game>
 	<game name="Shadow Man (Germany)" cloneof="Shadow Man (Europe) (En,Es,It)">
 		<description>Shadow Man (Germany)</description>
-		<release name="Shadow Man (Germany)" region="GER"/>
-		<rom name="Shadow Man (Germany).z64" size="33554432" crc="eaf6add1" md5="af40ef12ce923ff1c26e76cc9d9b9ed9" sha1="8768f0ec0b7a0b4f5ff0da6f4d790edef5e3fe9c"/>
+		<rom name="Shadow Man (Germany).n64" />
+		<release name="Shadow Man (Germany)" region="GER" />
+		<rom name="Shadow Man (Germany).z64" size="33554432" crc="eaf6add1" md5="af40ef12ce923ff1c26e76cc9d9b9ed9" sha1="8768f0ec0b7a0b4f5ff0da6f4d790edef5e3fe9c" />
 	</game>
 	<game name="Shadow Man (USA)" cloneof="Shadow Man (Europe) (En,Es,It)">
 		<description>Shadow Man (USA)</description>
-		<release name="Shadow Man (USA)" region="USA"/>
-		<rom name="Shadow Man (USA).z64" size="33554432" crc="5e20cc63" md5="b457298b87b85bbf950f24867daa9475" sha1="cfb99dd949fdb2b2a0002ef595ab1813fe865b2c"/>
+		<rom name="Shadow Man (USA).n64" />
+		<release name="Shadow Man (USA)" region="USA" />
+		<rom name="Shadow Man (USA).z64" size="33554432" crc="5e20cc63" md5="b457298b87b85bbf950f24867daa9475" sha1="cfb99dd949fdb2b2a0002ef595ab1813fe865b2c" />
 	</game>
 	<game name="Shadow Man (Brazil)" cloneof="Shadow Man (Europe) (En,Es,It)">
 		<description>Shadow Man (Brazil)</description>
-		<release name="Shadow Man (Brazil)" region="BRA"/>
-		<rom name="Shadow Man (Brazil).z64" size="33554432" crc="61e6642c" md5="fe2605193736a128ad65db1c9835a130" sha1="93b2f3423c0af3510e36785622a6dde425dd136c"/>
+		<rom name="Shadow Man (Brazil).n64" />
+		<release name="Shadow Man (Brazil)" region="BRA" />
+		<rom name="Shadow Man (Brazil).z64" size="33554432" crc="61e6642c" md5="fe2605193736a128ad65db1c9835a130" sha1="93b2f3423c0af3510e36785622a6dde425dd136c" />
 	</game>
 	<game name="Shadowgate 64 - Trials of the Four Towers (Europe)">
 		<description>Shadowgate 64 - Trials of the Four Towers (Europe)</description>
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe)" region="EUR"/>
-		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe).z64" size="16777216" crc="ff7d7df0" md5="e8955c3b743fddfe403e52e769e9853f" sha1="f2844b3421779a997c96231d25275da4e2d1018b"/>
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe).n64" />
+		<release name="Shadowgate 64 - Trials of the Four Towers (Europe)" region="EUR" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe).z64" size="16777216" crc="ff7d7df0" md5="e8955c3b743fddfe403e52e769e9853f" sha1="f2844b3421779a997c96231d25275da4e2d1018b" />
 	</game>
 	<game name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" cloneof="Shadowgate 64 - Trials of the Four Towers (Europe)">
 		<description>Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)</description>
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" region="ITA"/>
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" region="SPA"/>
-		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It).z64" size="16777216" crc="87f00472" md5="a06e757cf1930b29fa4c0b5c9f31335f" sha1="9f1a413f686032dda73be3312f452991a4e29ec9"/>
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It).n64" />
+		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" region="ITA" />
+		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It)" region="SPA" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Es,It).z64" size="16777216" crc="87f00472" md5="a06e757cf1930b29fa4c0b5c9f31335f" sha1="9f1a413f686032dda73be3312f452991a4e29ec9" />
 	</game>
 	<game name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" cloneof="Shadowgate 64 - Trials of the Four Towers (Europe)">
 		<description>Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)</description>
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" region="FRA"/>
-		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" region="GER"/>
-		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl).z64" size="16777216" crc="eedc0bea" md5="11169a32d449ec3a8903ca8a9d69a6aa" sha1="31de2e29dce21341e1958b32a7d8b1b03fc56e3b"/>
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl).n64" />
+		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" region="FRA" />
+		<release name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl)" region="GER" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Europe) (Fr,De,Nl).z64" size="16777216" crc="eedc0bea" md5="11169a32d449ec3a8903ca8a9d69a6aa" sha1="31de2e29dce21341e1958b32a7d8b1b03fc56e3b" />
 	</game>
 	<game name="Shadowgate 64 - Trials of the Four Towers (Japan)" cloneof="Shadowgate 64 - Trials of the Four Towers (Europe)">
 		<description>Shadowgate 64 - Trials of the Four Towers (Japan)</description>
-		<release name="Shadowgate 64 - Trials of the Four Towers (Japan)" region="JPN"/>
-		<rom name="Shadowgate 64 - Trials of the Four Towers (Japan).z64" size="16777216" crc="9f74a58c" md5="1960a3879fadf2c5eff5beb47e0e1441" sha1="706524aff9bd84972d4e095afd0317d5bacc525f"/>
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Japan).n64" />
+		<release name="Shadowgate 64 - Trials of the Four Towers (Japan)" region="JPN" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (Japan).z64" size="16777216" crc="9f74a58c" md5="1960a3879fadf2c5eff5beb47e0e1441" sha1="706524aff9bd84972d4e095afd0317d5bacc525f" />
 	</game>
 	<game name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)" cloneof="Shadowgate 64 - Trials of the Four Towers (Europe)">
 		<description>Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)</description>
-		<release name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)" region="USA"/>
-		<rom name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es).z64" size="16777216" crc="69983cc3" md5="407a1a18bd7dbe0485329296c3f84eb8" sha1="4397729f8143ea9a39f319e1f31f2e0b84335a24"/>
+		<rom name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es).n64" />
+		<release name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es)" region="USA" />
+		<rom name="Shadowgate 64 - Trials of the Four Towers (USA) (En,Es).z64" size="16777216" crc="69983cc3" md5="407a1a18bd7dbe0485329296c3f84eb8" sha1="4397729f8143ea9a39f319e1f31f2e0b84335a24" />
 	</game>
 	<game name="Shen You Mario (China) (v6) (iQue) (Manual)">
 		<description>Shen You Mario (China) (v6) (iQue) (Manual)</description>
-		<release name="Shen You Mario (China) (v6) (iQue) (Manual)" region="CHN"/>
-		<rom name="Shen You Mario (China) (v6) (iQue) (Manual).z64" size="409600" crc="a5b65a64" md5="b4bd31b13e474df29922150e1ef3f328" sha1="a7f90ffbbffa26919e23d24057bcb504ef8a8aa0"/>
+		<rom name="Shen You Mario (China) (v6) (iQue) (Manual).n64" />
+		<release name="Shen You Mario (China) (v6) (iQue) (Manual)" region="CHN" />
+		<rom name="Shen You Mario (China) (v6) (iQue) (Manual).z64" size="409600" crc="a5b65a64" md5="b4bd31b13e474df29922150e1ef3f328" sha1="a7f90ffbbffa26919e23d24057bcb504ef8a8aa0" />
 	</game>
 	<game name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)">
 		<description>Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)</description>
-		<release name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)" region="JPN"/>
-		<rom name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan).z64" size="12582912" crc="e892ed43" md5="13d9514a4d208dc6c7b0c833f68114d2" sha1="8e87dd6baf0d8d27e60c3257b145ef439b17b7a0"/>
+		<rom name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan).n64" />
+		<release name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan)" region="JPN" />
+		<rom name="Shin Nihon Pro Wrestling Toukon Road - Brave Spirits (Japan).z64" size="12582912" crc="e892ed43" md5="13d9514a4d208dc6c7b0c833f68114d2" sha1="8e87dd6baf0d8d27e60c3257b145ef439b17b7a0" />
 	</game>
 	<game name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)">
 		<description>Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)</description>
-		<release name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)" region="JPN"/>
-		<rom name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan).z64" size="33554432" crc="deac787f" md5="113044b16b75f98792bf9c20c6b6282b" sha1="bdfa3c47264196bd91d0487d3c9b3531bdace8ea"/>
+		<rom name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan).n64" />
+		<release name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan)" region="JPN" />
+		<rom name="Shin Nihon Pro Wrestling Toukon Road 2 - The Next Generation (Japan).z64" size="33554432" crc="deac787f" md5="113044b16b75f98792bf9c20c6b6282b" sha1="bdfa3c47264196bd91d0487d3c9b3531bdace8ea" />
 	</game>
 	<game name="Shuishang Motuo (China) (v4) (iQue) (Manual)">
 		<description>Shuishang Motuo (China) (v4) (iQue) (Manual)</description>
-		<release name="Shuishang Motuo (China) (v4) (iQue) (Manual)" region="CHN"/>
-		<rom name="Shuishang Motuo (China) (v4) (iQue) (Manual).z64" size="491520" crc="3ef9368e" md5="926b1495565435da0af29bb660532da3" sha1="fc2d8b6a2b64104681940ad2557703df44bb9e97"/>
+		<rom name="Shuishang Motuo (China) (v4) (iQue) (Manual).n64" />
+		<release name="Shuishang Motuo (China) (v4) (iQue) (Manual)" region="CHN" />
+		<rom name="Shuishang Motuo (China) (v4) (iQue) (Manual).z64" size="491520" crc="3ef9368e" md5="926b1495565435da0af29bb660532da3" sha1="fc2d8b6a2b64104681940ad2557703df44bb9e97" />
 	</game>
 	<game name="Shuishang Motuo (China) (v2) (iQue) (Manual)" cloneof="Shuishang Motuo (China) (v4) (iQue) (Manual)">
 		<description>Shuishang Motuo (China) (v2) (iQue) (Manual)</description>
-		<rom name="Shuishang Motuo (China) (v2) (iQue) (Manual).z64" size="311296" crc="b7547f54" md5="a66fee7af89d58b24a25c346a0e90172" sha1="536ed6c8f1ef5a66581efa3c4ae43a2fb7d6dc58"/>
+		<rom name="Shuishang Motuo (China) (v2) (iQue) (Manual).n64" />
+		<rom name="Shuishang Motuo (China) (v2) (iQue) (Manual).z64" size="311296" crc="b7547f54" md5="a66fee7af89d58b24a25c346a0e90172" sha1="536ed6c8f1ef5a66581efa3c4ae43a2fb7d6dc58" />
 	</game>
 	<game name="SimCity 2000 (Japan)">
 		<description>SimCity 2000 (Japan)</description>
-		<release name="SimCity 2000 (Japan)" region="JPN"/>
-		<rom name="SimCity 2000 (Japan).z64" size="12582912" crc="57767e45" md5="244bea64ea209990e9c69a830b507135" sha1="f728bd9990b9674533a04cd2fe275236b5cab32f"/>
+		<rom name="SimCity 2000 (Japan).n64" />
+		<release name="SimCity 2000 (Japan)" region="JPN" />
+		<rom name="SimCity 2000 (Japan).z64" size="12582912" crc="57767e45" md5="244bea64ea209990e9c69a830b507135" sha1="f728bd9990b9674533a04cd2fe275236b5cab32f" />
 	</game>
 	<game name="Snowboard Kids (Europe)">
 		<description>Snowboard Kids (Europe)</description>
-		<release name="Snowboard Kids (Europe)" region="EUR"/>
-		<rom name="Snowboard Kids (Europe).z64" size="8388608" crc="5619a70d" md5="ab4382e583ae139eedbafce5fa87e4c8" sha1="b26802748f4cc15f44492bcc6941a487e75bbca6" status="verified"/>
+		<rom name="Snowboard Kids (Europe).n64" />
+		<release name="Snowboard Kids (Europe)" region="EUR" />
+		<rom name="Snowboard Kids (Europe).z64" size="8388608" crc="5619a70d" md5="ab4382e583ae139eedbafce5fa87e4c8" sha1="b26802748f4cc15f44492bcc6941a487e75bbca6" status="verified" />
 	</game>
 	<game name="Snobo Kids (Japan)" cloneof="Snowboard Kids (Europe)">
 		<description>Snobo Kids (Japan)</description>
-		<release name="Snobo Kids (Japan)" region="JPN"/>
-		<rom name="Snobo Kids (Japan).z64" size="8388608" crc="213bf381" md5="b8d4b92e66a312708626b3216de07a3a" sha1="96480c8fa7285d9e850f6ba002e56bcb7ada9796"/>
+		<rom name="Snobo Kids (Japan).n64" />
+		<release name="Snobo Kids (Japan)" region="JPN" />
+		<rom name="Snobo Kids (Japan).z64" size="8388608" crc="213bf381" md5="b8d4b92e66a312708626b3216de07a3a" sha1="96480c8fa7285d9e850f6ba002e56bcb7ada9796" />
 	</game>
 	<game name="Snowboard Kids (USA)" cloneof="Snowboard Kids (Europe)">
 		<description>Snowboard Kids (USA)</description>
-		<release name="Snowboard Kids (USA)" region="USA"/>
-		<rom name="Snowboard Kids (USA).z64" size="8388608" crc="020fb906" md5="eb31f4f9c1fe26a3a663f74e9790516e" sha1="1583bacc9046a360df8ea4d536942155247e154c"/>
+		<rom name="Snowboard Kids (USA).n64" />
+		<release name="Snowboard Kids (USA)" region="USA" />
+		<rom name="Snowboard Kids (USA).z64" size="8388608" crc="020fb906" md5="eb31f4f9c1fe26a3a663f74e9790516e" sha1="1583bacc9046a360df8ea4d536942155247e154c" />
 	</game>
 	<game name="Snowboard Kids 2 (USA)">
 		<description>Snowboard Kids 2 (USA)</description>
-		<release name="Snowboard Kids 2 (USA)" region="USA"/>
-		<rom name="Snowboard Kids 2 (USA).z64" size="16777216" crc="d0dc8a8e" md5="08e1152e9d9742e9bbf6c224b6958f2d" sha1="5ce896fd64276948bc2b8cccd8cd51c25a9f32aa"/>
+		<rom name="Snowboard Kids 2 (USA).n64" />
+		<release name="Snowboard Kids 2 (USA)" region="USA" />
+		<rom name="Snowboard Kids 2 (USA).z64" size="16777216" crc="d0dc8a8e" md5="08e1152e9d9742e9bbf6c224b6958f2d" sha1="5ce896fd64276948bc2b8cccd8cd51c25a9f32aa" />
 	</game>
 	<game name="Chou Snobo Kids (Japan)" cloneof="Snowboard Kids 2 (USA)">
 		<description>Chou Snobo Kids (Japan)</description>
-		<release name="Chou Snobo Kids (Japan)" region="JPN"/>
-		<rom name="Chou Snobo Kids (Japan).z64" size="16777216" crc="dd4e84e4" md5="9181b35a758ef17d1e2dc595df55ee3c" sha1="a411b2fc46d6953b32897f99ffc5146f385dfd5b"/>
+		<rom name="Chou Snobo Kids (Japan).n64" />
+		<release name="Chou Snobo Kids (Japan)" region="JPN" />
+		<rom name="Chou Snobo Kids (Japan).z64" size="16777216" crc="dd4e84e4" md5="9181b35a758ef17d1e2dc595df55ee3c" sha1="a411b2fc46d6953b32897f99ffc5146f385dfd5b" />
 	</game>
 	<game name="Snowboard Kids 2 (Australia)" cloneof="Snowboard Kids 2 (USA)">
 		<description>Snowboard Kids 2 (Australia)</description>
-		<release name="Snowboard Kids 2 (Australia)" region="AUS"/>
-		<rom name="Snowboard Kids 2 (Australia).z64" size="16777216" crc="3a0b6214" md5="47b5e3955d54f969941533f26691ab38" sha1="e807f0fa1d6fde619a83f0926b2294123f34501c"/>
+		<rom name="Snowboard Kids 2 (Australia).n64" />
+		<release name="Snowboard Kids 2 (Australia)" region="AUS" />
+		<rom name="Snowboard Kids 2 (Australia).z64" size="16777216" crc="3a0b6214" md5="47b5e3955d54f969941533f26691ab38" sha1="e807f0fa1d6fde619a83f0926b2294123f34501c" />
 	</game>
 	<game name="South Park (Europe) (En,Fr,Es)">
 		<description>South Park (Europe) (En,Fr,Es)</description>
-		<release name="South Park (Europe) (En,Fr,Es)" region="EUR"/>
-		<rom name="South Park (Europe) (En,Fr,Es).z64" size="16777216" crc="b2c3e123" md5="40cc2085a5c12456bef830b047068326" sha1="c70c9fd6ebf1ae9f79155f9384ab1c4b29dc6882"/>
+		<rom name="South Park (Europe) (En,Fr,Es).n64" />
+		<release name="South Park (Europe) (En,Fr,Es)" region="EUR" />
+		<rom name="South Park (Europe) (En,Fr,Es).z64" size="16777216" crc="b2c3e123" md5="40cc2085a5c12456bef830b047068326" sha1="c70c9fd6ebf1ae9f79155f9384ab1c4b29dc6882" />
 	</game>
 	<game name="South Park (Germany)" cloneof="South Park (Europe) (En,Fr,Es)">
 		<description>South Park (Germany)</description>
-		<release name="South Park (Germany)" region="GER"/>
-		<rom name="South Park (Germany).z64" size="16777216" crc="5711e197" md5="2c94a246e701d667ba807dab6c9771e2" sha1="3260db8fbc90370603fc07ab2e48e02c029573fb"/>
+		<rom name="South Park (Germany).n64" />
+		<release name="South Park (Germany)" region="GER" />
+		<rom name="South Park (Germany).z64" size="16777216" crc="5711e197" md5="2c94a246e701d667ba807dab6c9771e2" sha1="3260db8fbc90370603fc07ab2e48e02c029573fb" />
 	</game>
 	<game name="South Park (USA)" cloneof="South Park (Europe) (En,Fr,Es)">
 		<description>South Park (USA)</description>
-		<release name="South Park (USA)" region="USA"/>
-		<rom name="South Park (USA).z64" size="16777216" crc="7d666b9e" md5="1730119b0455ef89c4e495dec8e950a5" sha1="42d7350d1f9040c5546f481c4d650b99a23aadbc"/>
+		<rom name="South Park (USA).n64" />
+		<release name="South Park (USA)" region="USA" />
+		<rom name="South Park (USA).z64" size="16777216" crc="7d666b9e" md5="1730119b0455ef89c4e495dec8e950a5" sha1="42d7350d1f9040c5546f481c4d650b99a23aadbc" />
 	</game>
 	<game name="South Park (Brazil)" cloneof="South Park (Europe) (En,Fr,Es)">
 		<description>South Park (Brazil)</description>
-		<release name="South Park (Brazil)" region="BRA"/>
-		<rom name="South Park (Brazil).z64" size="16777216" crc="235caec6" md5="d313af5f8af4d19f732a1a2c4d4d66bb" sha1="26623418f8c6f271ba36b68eaecb18db19563b2b"/>
+		<rom name="South Park (Brazil).n64" />
+		<release name="South Park (Brazil)" region="BRA" />
+		<rom name="South Park (Brazil).z64" size="16777216" crc="235caec6" md5="d313af5f8af4d19f732a1a2c4d4d66bb" sha1="26623418f8c6f271ba36b68eaecb18db19563b2b" />
 	</game>
 	<game name="South Park - Chef's Luv Shack (Europe)">
 		<description>South Park - Chef's Luv Shack (Europe)</description>
-		<release name="South Park - Chef's Luv Shack (Europe)" region="EUR"/>
-		<rom name="South Park - Chef's Luv Shack (Europe).z64" size="16777216" crc="ac1628eb" md5="f1ae48b778c8431a50c37eb1ed96b120" sha1="5aeec40c04ae9f7bc286f38e5250712c5fead191"/>
+		<rom name="South Park - Chef's Luv Shack (Europe).n64" />
+		<release name="South Park - Chef's Luv Shack (Europe)" region="EUR" />
+		<rom name="South Park - Chef's Luv Shack (Europe).z64" size="16777216" crc="ac1628eb" md5="f1ae48b778c8431a50c37eb1ed96b120" sha1="5aeec40c04ae9f7bc286f38e5250712c5fead191" />
 	</game>
 	<game name="South Park - Chef's Luv Shack (USA)" cloneof="South Park - Chef's Luv Shack (Europe)">
 		<description>South Park - Chef's Luv Shack (USA)</description>
-		<release name="South Park - Chef's Luv Shack (USA)" region="USA"/>
-		<rom name="South Park - Chef's Luv Shack (USA).z64" size="16777216" crc="6b6b1d09" md5="6af573eb055648a8542aa82d9524fb2f" sha1="0344b569e8410a860cd54165bc33130e80760896"/>
+		<rom name="South Park - Chef's Luv Shack (USA).n64" />
+		<release name="South Park - Chef's Luv Shack (USA)" region="USA" />
+		<rom name="South Park - Chef's Luv Shack (USA).z64" size="16777216" crc="6b6b1d09" md5="6af573eb055648a8542aa82d9524fb2f" sha1="0344b569e8410a860cd54165bc33130e80760896" />
 	</game>
 	<game name="South Park Rally (Europe)">
 		<description>South Park Rally (Europe)</description>
-		<release name="South Park Rally (Europe)" region="EUR"/>
-		<rom name="South Park Rally (Europe).z64" size="16777216" crc="296e3525" md5="c33fa02791077a71b0afe1cfed47c180" sha1="e16b5b16e41c66fefb3bc82bd6a82f9ef4d709fd"/>
+		<rom name="South Park Rally (Europe).n64" />
+		<release name="South Park Rally (Europe)" region="EUR" />
+		<rom name="South Park Rally (Europe).z64" size="16777216" crc="296e3525" md5="c33fa02791077a71b0afe1cfed47c180" sha1="e16b5b16e41c66fefb3bc82bd6a82f9ef4d709fd" />
 	</game>
 	<game name="South Park Rally (USA)" cloneof="South Park Rally (Europe)">
 		<description>South Park Rally (USA)</description>
-		<release name="South Park Rally (USA)" region="USA"/>
-		<rom name="South Park Rally (USA).z64" size="16777216" crc="ccdd322a" md5="1c494719032ff99382b167c43fb11762" sha1="e0b9e2358b09d430a100a14a6cb19e30b55faea2"/>
+		<rom name="South Park Rally (USA).n64" />
+		<release name="South Park Rally (USA)" region="USA" />
+		<rom name="South Park Rally (USA).z64" size="16777216" crc="ccdd322a" md5="1c494719032ff99382b167c43fb11762" sha1="e0b9e2358b09d430a100a14a6cb19e30b55faea2" />
 	</game>
 	<game name="South Park Rally (Europe) (Beta)" cloneof="South Park Rally (Europe)">
 		<description>South Park Rally (Europe) (Beta)</description>
-		<rom name="South Park Rally (Europe) (Beta).z64" size="16777216" crc="1c535592" md5="cdee4b0529b33405a293d51cb3765c57" sha1="0a12d66e1014e55f216c8693774494c85915103b"/>
+		<rom name="South Park Rally (Europe) (Beta).n64" />
+		<rom name="South Park Rally (Europe) (Beta).z64" size="16777216" crc="1c535592" md5="cdee4b0529b33405a293d51cb3765c57" sha1="0a12d66e1014e55f216c8693774494c85915103b" />
 	</game>
 	<game name="Space Invaders (USA)">
 		<description>Space Invaders (USA)</description>
-		<release name="Space Invaders (USA)" region="USA"/>
-		<rom name="Space Invaders (USA).z64" size="8388608" crc="60f7ff8e" md5="c72417e0f8f043f9f11851633c4b1a57" sha1="6850205eace572ae1aa31100320ad8df1b8db37e"/>
+		<rom name="Space Invaders (USA).n64" />
+		<release name="Space Invaders (USA)" region="USA" />
+		<rom name="Space Invaders (USA).z64" size="8388608" crc="60f7ff8e" md5="c72417e0f8f043f9f11851633c4b1a57" sha1="6850205eace572ae1aa31100320ad8df1b8db37e" />
 	</game>
 	<game name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)">
 		<description>SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)</description>
-		<release name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)" region="EUR"/>
-		<rom name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt).z64" size="8388608" crc="63042e36" md5="fca7afcadcf5e5545a62919ba94dad18" sha1="23710541bb3394072740b0f0236a7cb1a7d41531"/>
+		<rom name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt).n64" />
+		<release name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)" region="EUR" />
+		<rom name="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt).z64" size="8388608" crc="63042e36" md5="fca7afcadcf5e5545a62919ba94dad18" sha1="23710541bb3394072740b0f0236a7cb1a7d41531" />
 	</game>
 	<game name="SpaceStation Silicon Valley (Japan) (Proto)" cloneof="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)">
 		<description>SpaceStation Silicon Valley (Japan) (Proto)</description>
-		<rom name="SpaceStation Silicon Valley (Japan) (Proto).z64" size="8388608" crc="dcec9f8a" md5="e66ed1cc4ab95d0872bb2ebc49b206c4" sha1="7320f08474c011fc7781093bf1a6818c37ce51e2"/>
+		<rom name="SpaceStation Silicon Valley (Japan) (Proto).n64" />
+		<rom name="SpaceStation Silicon Valley (Japan) (Proto).z64" size="8388608" crc="dcec9f8a" md5="e66ed1cc4ab95d0872bb2ebc49b206c4" sha1="7320f08474c011fc7781093bf1a6818c37ce51e2" />
 	</game>
 	<game name="SpaceStation Silicon Valley (USA)" cloneof="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)">
 		<description>SpaceStation Silicon Valley (USA)</description>
-		<rom name="SpaceStation Silicon Valley (USA).z64" size="8388608" crc="a606e8ae" md5="868b37d1b66d1d994e2bad4e218bf129" sha1="e5e09205aa743a9e5043a42df72adc379c746b0b"/>
+		<rom name="SpaceStation Silicon Valley (USA).n64" />
+		<rom name="SpaceStation Silicon Valley (USA).z64" size="8388608" crc="a606e8ae" md5="868b37d1b66d1d994e2bad4e218bf129" sha1="e5e09205aa743a9e5043a42df72adc379c746b0b" />
 	</game>
 	<game name="SpaceStation Silicon Valley (USA) (Rev 1)" cloneof="SpaceStation Silicon Valley (Europe) (En,Fr,De,Es,It,Nl,Pt)">
 		<description>SpaceStation Silicon Valley (USA) (Rev 1)</description>
-		<release name="SpaceStation Silicon Valley (USA) (Rev 1)" region="USA"/>
-		<rom name="SpaceStation Silicon Valley (USA) (Rev 1).z64" size="8388608" crc="e32d9e7b" md5="f1f1c5e2b895db63348bc738c0cdc645" sha1="c968bba6a90db9ecbd957e910684a80726b0497d" status="verified"/>
+		<rom name="SpaceStation Silicon Valley (USA) (Rev 1).n64" />
+		<release name="SpaceStation Silicon Valley (USA) (Rev 1)" region="USA" />
+		<rom name="SpaceStation Silicon Valley (USA) (Rev 1).z64" size="8388608" crc="e32d9e7b" md5="f1f1c5e2b895db63348bc738c0cdc645" sha1="c968bba6a90db9ecbd957e910684a80726b0497d" status="verified" />
 	</game>
 	<game name="Spider-Man (USA)">
 		<description>Spider-Man (USA)</description>
-		<release name="Spider-Man (USA)" region="USA"/>
-		<rom name="Spider-Man (USA).z64" size="33554432" crc="696cc2a4" md5="7f1991b8861e7e532ec21ecf2af82191" sha1="382c9c5d4e416444c4f6f9f4f6a5914d679fedf1"/>
+		<rom name="Spider-Man (USA).n64" />
+		<release name="Spider-Man (USA)" region="USA" />
+		<rom name="Spider-Man (USA).z64" size="33554432" crc="696cc2a4" md5="7f1991b8861e7e532ec21ecf2af82191" sha1="382c9c5d4e416444c4f6f9f4f6a5914d679fedf1" />
 	</game>
 	<game name="Star Soldier - Vanishing Earth (USA)">
 		<description>Star Soldier - Vanishing Earth (USA)</description>
-		<release name="Star Soldier - Vanishing Earth (USA)" region="USA"/>
-		<rom name="Star Soldier - Vanishing Earth (USA).z64" size="12582912" crc="ea650def" md5="ee045a2e9f924cd8fd00018b50e46650" sha1="14dfd0172567b47c819b3e61d1ce13281e0ffed6" status="verified"/>
+		<rom name="Star Soldier - Vanishing Earth (USA).n64" />
+		<release name="Star Soldier - Vanishing Earth (USA)" region="USA" />
+		<rom name="Star Soldier - Vanishing Earth (USA).z64" size="12582912" crc="ea650def" md5="ee045a2e9f924cd8fd00018b50e46650" sha1="14dfd0172567b47c819b3e61d1ce13281e0ffed6" status="verified" />
 	</game>
 	<game name="Star Soldier - Vanishing Earth (Japan)" cloneof="Star Soldier - Vanishing Earth (USA)">
 		<description>Star Soldier - Vanishing Earth (Japan)</description>
-		<release name="Star Soldier - Vanishing Earth (Japan)" region="JPN"/>
-		<rom name="Star Soldier - Vanishing Earth (Japan).z64" size="12582912" crc="7ee5f51d" md5="14a21928be46c18ba04161305e89f5de" sha1="0b34bddd00c49530e0ef47330a05dc70ebe5f8b7"/>
+		<rom name="Star Soldier - Vanishing Earth (Japan).n64" />
+		<release name="Star Soldier - Vanishing Earth (Japan)" region="JPN" />
+		<rom name="Star Soldier - Vanishing Earth (Japan).z64" size="12582912" crc="7ee5f51d" md5="14a21928be46c18ba04161305e89f5de" sha1="0b34bddd00c49530e0ef47330a05dc70ebe5f8b7" />
 	</game>
 	<game name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
 		<description>Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)</description>
-		<release name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)" region="EUR"/>
-		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1).z64" size="16777216" crc="c88e5638" md5="a9dd498e6a28f55311ce4ef057e164b8" sha1="66a70566d267532272b15abc0be20e2a1074ae45"/>
+		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1).n64" />
+		<release name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)" region="EUR" />
+		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1).z64" size="16777216" crc="c88e5638" md5="a9dd498e6a28f55311ce4ef057e164b8" sha1="66a70566d267532272b15abc0be20e2a1074ae45" />
 	</game>
 	<game name="Star Wars - Rogue Squadron (Europe) (En,Fr,De)" cloneof="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
 		<description>Star Wars - Rogue Squadron (Europe) (En,Fr,De)</description>
-		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De).z64" size="16777216" crc="6289645f" md5="7f919d2e35cbe561e139ae8fe93aca86" sha1="da91a86f1f566dc66a2ae1292aa581bfc4f9cdfd" status="verified"/>
+		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De).n64" />
+		<rom name="Star Wars - Rogue Squadron (Europe) (En,Fr,De).z64" size="16777216" crc="6289645f" md5="7f919d2e35cbe561e139ae8fe93aca86" sha1="da91a86f1f566dc66a2ae1292aa581bfc4f9cdfd" status="verified" />
 	</game>
 	<game name="Star Wars - Rogue Squadron (USA)" cloneof="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
 		<description>Star Wars - Rogue Squadron (USA)</description>
-		<rom name="Star Wars - Rogue Squadron (USA).z64" size="16777216" crc="83c225cc" md5="47cac4e2a6309458342f21a9018ffbf0" sha1="ed42eed1ee2db646ff7ef94ba8c5421d164a4f0d"/>
+		<rom name="Star Wars - Rogue Squadron (USA).n64" />
+		<rom name="Star Wars - Rogue Squadron (USA).z64" size="16777216" crc="83c225cc" md5="47cac4e2a6309458342f21a9018ffbf0" sha1="ed42eed1ee2db646ff7ef94ba8c5421d164a4f0d" />
 	</game>
 	<game name="Star Wars - Rogue Squadron (USA) (Rev 1)" cloneof="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
 		<description>Star Wars - Rogue Squadron (USA) (Rev 1)</description>
-		<release name="Star Wars - Rogue Squadron (USA) (Rev 1)" region="USA"/>
-		<rom name="Star Wars - Rogue Squadron (USA) (Rev 1).z64" size="16777216" crc="65a8fba0" md5="2e458d7cc355d7918493b0e0362c9a20" sha1="c12e1c6fb47a67da463c50b705ec682ec24ae80d"/>
+		<rom name="Star Wars - Rogue Squadron (USA) (Rev 1).n64" />
+		<release name="Star Wars - Rogue Squadron (USA) (Rev 1)" region="USA" />
+		<rom name="Star Wars - Rogue Squadron (USA) (Rev 1).z64" size="16777216" crc="65a8fba0" md5="2e458d7cc355d7918493b0e0362c9a20" sha1="c12e1c6fb47a67da463c50b705ec682ec24ae80d" />
 	</game>
 	<game name="Star Wars - Shutsugeki! Rogue Chuutai (Japan)" cloneof="Star Wars - Rogue Squadron (Europe) (En,Fr,De) (Rev 1)">
 		<description>Star Wars - Shutsugeki! Rogue Chuutai (Japan)</description>
-		<release name="Star Wars - Shutsugeki! Rogue Chuutai (Japan)" region="JPN"/>
-		<rom name="Star Wars - Shutsugeki! Rogue Chuutai (Japan).z64" size="16777216" crc="ee7643b6" md5="8603b180e70b2a72ef77d46c2bec2234" sha1="d8bddb9727264c14bf3bc20b2fe983fb86eada32"/>
+		<rom name="Star Wars - Shutsugeki! Rogue Chuutai (Japan).n64" />
+		<release name="Star Wars - Shutsugeki! Rogue Chuutai (Japan)" region="JPN" />
+		<rom name="Star Wars - Shutsugeki! Rogue Chuutai (Japan).z64" size="16777216" crc="ee7643b6" md5="8603b180e70b2a72ef77d46c2bec2234" sha1="d8bddb9727264c14bf3bc20b2fe983fb86eada32" />
 	</game>
 	<game name="Star Wars - Shadows of the Empire (Europe)">
 		<description>Star Wars - Shadows of the Empire (Europe)</description>
-		<release name="Star Wars - Shadows of the Empire (Europe)" region="EUR"/>
-		<rom name="Star Wars - Shadows of the Empire (Europe).z64" size="12582912" crc="f0a191bf" md5="591cf8e672c9cc0fe9c871cc56dcc854" sha1="e014f60bea29bbc7fbd7f3ba4fcc6bdd228c8fe5" status="verified"/>
+		<rom name="Star Wars - Shadows of the Empire (Europe).n64" />
+		<release name="Star Wars - Shadows of the Empire (Europe)" region="EUR" />
+		<rom name="Star Wars - Shadows of the Empire (Europe).z64" size="12582912" crc="f0a191bf" md5="591cf8e672c9cc0fe9c871cc56dcc854" sha1="e014f60bea29bbc7fbd7f3ba4fcc6bdd228c8fe5" status="verified" />
 	</game>
 	<game name="Star Wars - Shadows of the Empire (USA)" cloneof="Star Wars - Shadows of the Empire (Europe)">
 		<description>Star Wars - Shadows of the Empire (USA)</description>
-		<rom name="Star Wars - Shadows of the Empire (USA).z64" size="12582912" crc="3c0837b3" md5="5cce8ad5f86e8a373a7525dc4c7e6705" sha1="271c285f6e5069133ab27a2a8324d4651591e35d"/>
+		<rom name="Star Wars - Shadows of the Empire (USA).n64" />
+		<rom name="Star Wars - Shadows of the Empire (USA).z64" size="12582912" crc="3c0837b3" md5="5cce8ad5f86e8a373a7525dc4c7e6705" sha1="271c285f6e5069133ab27a2a8324d4651591e35d" />
 	</game>
 	<game name="Star Wars - Shadows of the Empire (USA) (Rev 1)" cloneof="Star Wars - Shadows of the Empire (Europe)">
 		<description>Star Wars - Shadows of the Empire (USA) (Rev 1)</description>
-		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 1).z64" size="12582912" crc="b0540688" md5="fa635e837275d28fd5a24d5675ba42c8" sha1="ded8f972d1e1d662614b1ec79822d649a8ce5430"/>
+		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 1).n64" />
+		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 1).z64" size="12582912" crc="b0540688" md5="fa635e837275d28fd5a24d5675ba42c8" sha1="ded8f972d1e1d662614b1ec79822d649a8ce5430" />
 	</game>
 	<game name="Star Wars - Shadows of the Empire (USA) (Rev 2)" cloneof="Star Wars - Shadows of the Empire (Europe)">
 		<description>Star Wars - Shadows of the Empire (USA) (Rev 2)</description>
-		<release name="Star Wars - Shadows of the Empire (USA) (Rev 2)" region="USA"/>
-		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 2).z64" size="12582912" crc="e8727549" md5="c7b40352aad8d863d88d51672f9a0087" sha1="9ab85626c27372ee614b7c5301c2c4eb187fd9f6"/>
+		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 2).n64" />
+		<release name="Star Wars - Shadows of the Empire (USA) (Rev 2)" region="USA" />
+		<rom name="Star Wars - Shadows of the Empire (USA) (Rev 2).z64" size="12582912" crc="e8727549" md5="c7b40352aad8d863d88d51672f9a0087" sha1="9ab85626c27372ee614b7c5301c2c4eb187fd9f6" />
 	</game>
 	<game name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15)" cloneof="Star Wars - Shadows of the Empire (Europe)">
 		<description>Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15)</description>
-		<rom name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15).z64" size="12582912" crc="28368603" md5="4076973cfda277fc876e9f066cc73deb" sha1="0f642f17693adf1b97121a61bbeca37df59bb55a"/>
+		<rom name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15).n64" />
+		<rom name="Star Wars - Shadows of the Empire (USA) (Beta) (1996-10-15).z64" size="12582912" crc="28368603" md5="4076973cfda277fc876e9f066cc73deb" sha1="0f642f17693adf1b97121a61bbeca37df59bb55a" />
 	</game>
 	<game name="Star Wars - Teikoku no Kage (Japan)" cloneof="Star Wars - Shadows of the Empire (Europe)">
 		<description>Star Wars - Teikoku no Kage (Japan)</description>
-		<release name="Star Wars - Teikoku no Kage (Japan)" region="JPN"/>
-		<rom name="Star Wars - Teikoku no Kage (Japan).z64" size="12582912" crc="7ce71426" md5="5b6b6b0c8c9a40286dcf61706b6a05cb" sha1="93ed6f1497ede2239f9d75b4a39204b6c9dd9ffd"/>
+		<rom name="Star Wars - Teikoku no Kage (Japan).n64" />
+		<release name="Star Wars - Teikoku no Kage (Japan)" region="JPN" />
+		<rom name="Star Wars - Teikoku no Kage (Japan).z64" size="12582912" crc="7ce71426" md5="5b6b6b0c8c9a40286dcf61706b6a05cb" sha1="93ed6f1497ede2239f9d75b4a39204b6c9dd9ffd" />
 	</game>
 	<game name="Star Wars Episode I - Battle for Naboo (Europe)">
 		<description>Star Wars Episode I - Battle for Naboo (Europe)</description>
-		<release name="Star Wars Episode I - Battle for Naboo (Europe)" region="EUR"/>
-		<rom name="Star Wars Episode I - Battle for Naboo (Europe).z64" size="33554432" crc="029104fd" md5="0bd1f7bb9f4b02520e4e9285c809f099" sha1="c949856a6cb0b59a2d171c8ad2e8d913cca23022"/>
+		<rom name="Star Wars Episode I - Battle for Naboo (Europe).n64" />
+		<release name="Star Wars Episode I - Battle for Naboo (Europe)" region="EUR" />
+		<rom name="Star Wars Episode I - Battle for Naboo (Europe).z64" size="33554432" crc="029104fd" md5="0bd1f7bb9f4b02520e4e9285c809f099" sha1="c949856a6cb0b59a2d171c8ad2e8d913cca23022" />
 	</game>
 	<game name="Star Wars Episode I - Battle for Naboo (USA)" cloneof="Star Wars Episode I - Battle for Naboo (Europe)">
 		<description>Star Wars Episode I - Battle for Naboo (USA)</description>
-		<release name="Star Wars Episode I - Battle for Naboo (USA)" region="USA"/>
-		<rom name="Star Wars Episode I - Battle for Naboo (USA).z64" size="33554432" crc="99dee3c0" md5="3cb88b934572e7520f35e5458798775b" sha1="e4441a6eeb67861408c2e009baae8aad4df34021"/>
+		<rom name="Star Wars Episode I - Battle for Naboo (USA).n64" />
+		<release name="Star Wars Episode I - Battle for Naboo (USA)" region="USA" />
+		<rom name="Star Wars Episode I - Battle for Naboo (USA).z64" size="33554432" crc="99dee3c0" md5="3cb88b934572e7520f35e5458798775b" sha1="e4441a6eeb67861408c2e009baae8aad4df34021" />
 	</game>
 	<game name="Star Wars Episode I - Racer (Europe) (En,Fr,De)">
 		<description>Star Wars Episode I - Racer (Europe) (En,Fr,De)</description>
-		<release name="Star Wars Episode I - Racer (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Star Wars Episode I - Racer (Europe) (En,Fr,De).z64" size="33554432" crc="e0f46629" md5="6ef9fed309f28bd59b605f128869aa00" sha1="899a8245da017289c88e97327fdcd6694b770a25" status="verified"/>
+		<rom name="Star Wars Episode I - Racer (Europe) (En,Fr,De).n64" />
+		<release name="Star Wars Episode I - Racer (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Star Wars Episode I - Racer (Europe) (En,Fr,De).z64" size="33554432" crc="e0f46629" md5="6ef9fed309f28bd59b605f128869aa00" sha1="899a8245da017289c88e97327fdcd6694b770a25" status="verified" />
 	</game>
 	<game name="Star Wars Episode I - Racer (Japan)" cloneof="Star Wars Episode I - Racer (Europe) (En,Fr,De)">
 		<description>Star Wars Episode I - Racer (Japan)</description>
-		<release name="Star Wars Episode I - Racer (Japan)" region="JPN"/>
-		<rom name="Star Wars Episode I - Racer (Japan).z64" size="33554432" crc="97c155c5" md5="7579ab0e79b1011479b88f2bf39d48e0" sha1="9577ccd2d069d0e7e306cf21ddb0e4765a308072"/>
+		<rom name="Star Wars Episode I - Racer (Japan).n64" />
+		<release name="Star Wars Episode I - Racer (Japan)" region="JPN" />
+		<rom name="Star Wars Episode I - Racer (Japan).z64" size="33554432" crc="97c155c5" md5="7579ab0e79b1011479b88f2bf39d48e0" sha1="9577ccd2d069d0e7e306cf21ddb0e4765a308072" />
 	</game>
 	<game name="Star Wars Episode I - Racer (USA)" cloneof="Star Wars Episode I - Racer (Europe) (En,Fr,De)">
 		<description>Star Wars Episode I - Racer (USA)</description>
-		<release name="Star Wars Episode I - Racer (USA)" region="USA"/>
-		<rom name="Star Wars Episode I - Racer (USA).z64" size="33554432" crc="c53c1035" md5="1ee8800a4003e7f9688c5a35f929d01b" sha1="3542d5597c8a56ea8f5c63bceae97a24c4c08d58"/>
+		<rom name="Star Wars Episode I - Racer (USA).n64" />
+		<release name="Star Wars Episode I - Racer (USA)" region="USA" />
+		<rom name="Star Wars Episode I - Racer (USA).z64" size="33554432" crc="c53c1035" md5="1ee8800a4003e7f9688c5a35f929d01b" sha1="3542d5597c8a56ea8f5c63bceae97a24c4c08d58" />
 	</game>
 	<game name="StarCraft 64 (USA)">
 		<description>StarCraft 64 (USA)</description>
-		<release name="StarCraft 64 (USA)" region="USA"/>
-		<rom name="StarCraft 64 (USA).z64" size="33554432" crc="4e4c7ec9" md5="559f71b861f639b6376d891e3023414b" sha1="a36d91b5aac7bb95df0d7de5f9814f5270e25c2b"/>
+		<rom name="StarCraft 64 (USA).n64" />
+		<release name="StarCraft 64 (USA)" region="USA" />
+		<rom name="StarCraft 64 (USA).z64" size="33554432" crc="4e4c7ec9" md5="559f71b861f639b6376d891e3023414b" sha1="a36d91b5aac7bb95df0d7de5f9814f5270e25c2b" />
 	</game>
 	<game name="StarCraft 64 (Australia)" cloneof="StarCraft 64 (USA)">
 		<description>StarCraft 64 (Australia)</description>
-		<release name="StarCraft 64 (Australia)" region="AUS"/>
-		<rom name="StarCraft 64 (Australia).z64" size="33554432" crc="2639dae2" md5="72b60fac5ee257fa387b43c57632d50c" sha1="bd8ab8994be02368c844234006e5c11509ce2894" status="verified"/>
+		<rom name="StarCraft 64 (Australia).n64" />
+		<release name="StarCraft 64 (Australia)" region="AUS" />
+		<rom name="StarCraft 64 (Australia).z64" size="33554432" crc="2639dae2" md5="72b60fac5ee257fa387b43c57632d50c" sha1="bd8ab8994be02368c844234006e5c11509ce2894" status="verified" />
 	</game>
 	<game name="StarCraft 64 (USA) (Beta)" cloneof="StarCraft 64 (USA)">
 		<description>StarCraft 64 (USA) (Beta)</description>
-		<rom name="StarCraft 64 (USA) (Beta).z64" size="33554432" crc="b0e1654f" md5="3eb732a8d004263ad8eb0da59a29582a" sha1="472573d057e42653b7413861319b9f7342f2467d"/>
+		<rom name="StarCraft 64 (USA) (Beta).n64" />
+		<rom name="StarCraft 64 (USA) (Beta).z64" size="33554432" crc="b0e1654f" md5="3eb732a8d004263ad8eb0da59a29582a" sha1="472573d057e42653b7413861319b9f7342f2467d" />
 	</game>
 	<game name="StarCraft 64 (Germany) (Proto)" cloneof="StarCraft 64 (USA)">
 		<description>StarCraft 64 (Germany) (Proto)</description>
-		<rom name="StarCraft 64 (Germany) (Proto).z64" size="33554432" crc="2b1c9fe4" md5="356a5d3d59e0adef6efae6096fc20f77" sha1="bc585da421caba45f5eb87caa6d7a138a09e9b43"/>
+		<rom name="StarCraft 64 (Germany) (Proto).n64" />
+		<rom name="StarCraft 64 (Germany) (Proto).z64" size="33554432" crc="2b1c9fe4" md5="356a5d3d59e0adef6efae6096fc20f77" sha1="bc585da421caba45f5eb87caa6d7a138a09e9b43" />
 	</game>
 	<game name="Starshot - Space Circus Fever (Europe) (En,Fr,De)">
 		<description>Starshot - Space Circus Fever (Europe) (En,Fr,De)</description>
-		<release name="Starshot - Space Circus Fever (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Starshot - Space Circus Fever (Europe) (En,Fr,De).z64" size="12582912" crc="056d2218" md5="a9c393aa232b32798adf378f4318f99f" sha1="b92818c5ff6be02bec77edcbe278d06785d00c78" status="verified"/>
+		<rom name="Starshot - Space Circus Fever (Europe) (En,Fr,De).n64" />
+		<release name="Starshot - Space Circus Fever (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Starshot - Space Circus Fever (Europe) (En,Fr,De).z64" size="12582912" crc="056d2218" md5="a9c393aa232b32798adf378f4318f99f" sha1="b92818c5ff6be02bec77edcbe278d06785d00c78" status="verified" />
 	</game>
 	<game name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" cloneof="Starshot - Space Circus Fever (Europe) (En,Fr,De)">
 		<description>Starshot - Space Circus Fever (USA) (En,Fr,Es)</description>
-		<release name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" region="SPA"/>
-		<release name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" region="USA"/>
-		<rom name="Starshot - Space Circus Fever (USA) (En,Fr,Es).z64" size="12582912" crc="7720e5f3" md5="42af1992978229bbb5f560571708e25e" sha1="7def46651f55745d5bbd633c9002bdbffc53a5e0"/>
+		<rom name="Starshot - Space Circus Fever (USA) (En,Fr,Es).n64" />
+		<release name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" region="SPA" />
+		<release name="Starshot - Space Circus Fever (USA) (En,Fr,Es)" region="USA" />
+		<rom name="Starshot - Space Circus Fever (USA) (En,Fr,Es).z64" size="12582912" crc="7720e5f3" md5="42af1992978229bbb5f560571708e25e" sha1="7def46651f55745d5bbd633c9002bdbffc53a5e0" />
 	</game>
 	<game name="Stunt Racer 64 (USA)">
 		<description>Stunt Racer 64 (USA)</description>
-		<release name="Stunt Racer 64 (USA)" region="USA"/>
-		<rom name="Stunt Racer 64 (USA).z64" size="12582912" crc="3438b1af" md5="e8b666a429fedb2a1a1228cd450cd4fc" sha1="8570fa1f3e4cf7e62dc49da181353e4f301503b7"/>
+		<rom name="Stunt Racer 64 (USA).n64" />
+		<release name="Stunt Racer 64 (USA)" region="USA" />
+		<rom name="Stunt Racer 64 (USA).z64" size="12582912" crc="3438b1af" md5="e8b666a429fedb2a1a1228cd450cd4fc" sha1="8570fa1f3e4cf7e62dc49da181353e4f301503b7" />
 	</game>
 	<game name="Super B-Daman - Battle Phoenix 64 (Japan)">
 		<description>Super B-Daman - Battle Phoenix 64 (Japan)</description>
-		<release name="Super B-Daman - Battle Phoenix 64 (Japan)" region="JPN"/>
-		<rom name="Super B-Daman - Battle Phoenix 64 (Japan).z64" size="12582912" crc="5006dc88" md5="b3c1d4b9ec7dcd2922e681dbbc393915" sha1="d443fb2e2e3980fcb90e5bba4138922477ea9037"/>
+		<rom name="Super B-Daman - Battle Phoenix 64 (Japan).n64" />
+		<release name="Super B-Daman - Battle Phoenix 64 (Japan)" region="JPN" />
+		<rom name="Super B-Daman - Battle Phoenix 64 (Japan).z64" size="12582912" crc="5006dc88" md5="b3c1d4b9ec7dcd2922e681dbbc393915" sha1="d443fb2e2e3980fcb90e5bba4138922477ea9037" />
 	</game>
 	<game name="Super Bowling (USA)">
 		<description>Super Bowling (USA)</description>
-		<release name="Super Bowling (USA)" region="USA"/>
-		<rom name="Super Bowling (USA).z64" size="8388608" crc="f6ccd04a" md5="fa3a043997a3acdf17337385b126bc04" sha1="56937a9e9536af55ebed06480413265848c4a04a"/>
+		<rom name="Super Bowling (USA).n64" />
+		<release name="Super Bowling (USA)" region="USA" />
+		<rom name="Super Bowling (USA).z64" size="8388608" crc="f6ccd04a" md5="fa3a043997a3acdf17337385b126bc04" sha1="56937a9e9536af55ebed06480413265848c4a04a" />
 	</game>
 	<game name="Super Bowling (Japan)" cloneof="Super Bowling (USA)">
 		<description>Super Bowling (Japan)</description>
-		<release name="Super Bowling (Japan)" region="JPN"/>
-		<rom name="Super Bowling (Japan).z64" size="8388608" crc="ba2d8b2e" md5="09c5b4d19364efe48bb818087734978e" sha1="faa5ffdffec1fa56125130becb6e150032c6923e"/>
+		<rom name="Super Bowling (Japan).n64" />
+		<release name="Super Bowling (Japan)" region="JPN" />
+		<rom name="Super Bowling (Japan).z64" size="8388608" crc="ba2d8b2e" md5="09c5b4d19364efe48bb818087734978e" sha1="faa5ffdffec1fa56125130becb6e150032c6923e" />
 	</game>
 	<game name="Super Mario 64 (Europe) (En,Fr,De)">
 		<description>Super Mario 64 (Europe) (En,Fr,De)</description>
-		<release name="Super Mario 64 (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Super Mario 64 (Europe) (En,Fr,De).z64" size="8388608" crc="03048de6" md5="45676429ef6b90e65b517129b700308e" sha1="4ac5721683d0e0b6bbb561b58a71740845dceea9" status="verified"/>
+		<rom name="Super Mario 64 (Europe) (En,Fr,De).n64" />
+		<release name="Super Mario 64 (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Super Mario 64 (Europe) (En,Fr,De).z64" size="8388608" crc="03048de6" md5="45676429ef6b90e65b517129b700308e" sha1="4ac5721683d0e0b6bbb561b58a71740845dceea9" status="verified" />
 	</game>
 	<game name="Shen You Mario (China) (iQue)" cloneof="Super Mario 64 (Europe) (En,Fr,De)">
 		<description>Shen You Mario (China) (iQue)</description>
-		<rom name="Shen You Mario (China) (iQue).z64" size="8060928" crc="08b48ca1" md5="29047fba820695bd14c5bd7aa1aa4400" sha1="2e1db2780985a1f068077dc0444b685f39cd90ec"/>
+		<rom name="Shen You Mario (China) (iQue).n64" />
+		<rom name="Shen You Mario (China) (iQue).z64" size="8060928" crc="08b48ca1" md5="29047fba820695bd14c5bd7aa1aa4400" sha1="2e1db2780985a1f068077dc0444b685f39cd90ec" />
 	</game>
 	<game name="Super Mario 64 (Japan)" cloneof="Super Mario 64 (Europe) (En,Fr,De)">
 		<description>Super Mario 64 (Japan)</description>
-		<rom name="Super Mario 64 (Japan).z64" size="8388608" crc="dd801954" md5="85d61f5525af708c9f1e84dce6dc10e9" sha1="8a20a5c83d6ceb0f0506cfc9fa20d8f438cafe51" status="verified"/>
+		<rom name="Super Mario 64 (Japan).n64" />
+		<rom name="Super Mario 64 (Japan).z64" size="8388608" crc="dd801954" md5="85d61f5525af708c9f1e84dce6dc10e9" sha1="8a20a5c83d6ceb0f0506cfc9fa20d8f438cafe51" status="verified" />
 	</game>
 	<game name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition)" cloneof="Super Mario 64 (Europe) (En,Fr,De)">
 		<description>Super Mario 64 (Japan) (Rev 3) (Shindou Edition)</description>
-		<release name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition)" region="JPN"/>
-		<rom name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition).z64" size="8388608" crc="a1e15117" md5="2d727c3278aa232d94f2fb45aec4d303" sha1="3f319ae697533a255a1003d09202379d78d5a2e0" status="verified"/>
+		<rom name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition).n64" />
+		<release name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition)" region="JPN" />
+		<rom name="Super Mario 64 (Japan) (Rev 3) (Shindou Edition).z64" size="8388608" crc="a1e15117" md5="2d727c3278aa232d94f2fb45aec4d303" sha1="3f319ae697533a255a1003d09202379d78d5a2e0" status="verified" />
 	</game>
 	<game name="Super Mario 64 (USA)" cloneof="Super Mario 64 (Europe) (En,Fr,De)">
 		<description>Super Mario 64 (USA)</description>
-		<release name="Super Mario 64 (USA)" region="USA"/>
-		<rom name="Super Mario 64 (USA).z64" size="8388608" crc="3ce60709" md5="20b854b239203baf6c961b850a4a51a2" sha1="9bef1128717f958171a4afac3ed78ee2bb4e86ce" status="verified"/>
+		<rom name="Super Mario 64 (USA).n64" />
+		<release name="Super Mario 64 (USA)" region="USA" />
+		<rom name="Super Mario 64 (USA).z64" size="8388608" crc="3ce60709" md5="20b854b239203baf6c961b850a4a51a2" sha1="9bef1128717f958171a4afac3ed78ee2bb4e86ce" status="verified" />
 	</game>
 	<game name="Super Robot Spirits (Japan)">
 		<description>Super Robot Spirits (Japan)</description>
-		<release name="Super Robot Spirits (Japan)" region="JPN"/>
-		<rom name="Super Robot Spirits (Japan).z64" size="16777216" crc="8c9216c1" md5="3ec3f83eab22702e146c467eb1db45fa" sha1="3bf62a1a48716708a5831ce47fb8c1a41dc365e6"/>
+		<rom name="Super Robot Spirits (Japan).n64" />
+		<release name="Super Robot Spirits (Japan)" region="JPN" />
+		<rom name="Super Robot Spirits (Japan).z64" size="16777216" crc="8c9216c1" md5="3ec3f83eab22702e146c467eb1db45fa" sha1="3bf62a1a48716708a5831ce47fb8c1a41dc365e6" />
 	</game>
 	<game name="Super Robot Taisen 64 (Japan)">
 		<description>Super Robot Taisen 64 (Japan)</description>
-		<release name="Super Robot Taisen 64 (Japan)" region="JPN"/>
-		<rom name="Super Robot Taisen 64 (Japan).z64" size="33554432" crc="85df2771" md5="3f4b73963abc91cee59c416063efd4ae" sha1="9883aef6e20a46e110560c505999f3e21a1897de"/>
+		<rom name="Super Robot Taisen 64 (Japan).n64" />
+		<release name="Super Robot Taisen 64 (Japan)" region="JPN" />
+		<rom name="Super Robot Taisen 64 (Japan).z64" size="33554432" crc="85df2771" md5="3f4b73963abc91cee59c416063efd4ae" sha1="9883aef6e20a46e110560c505999f3e21a1897de" />
 	</game>
 	<game name="Super Smash Bros. (Europe) (En,Fr,De)">
 		<description>Super Smash Bros. (Europe) (En,Fr,De)</description>
-		<release name="Super Smash Bros. (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Super Smash Bros. (Europe) (En,Fr,De).z64" size="33554432" crc="45a91cb1" md5="5e54c6c563b09c107f86fb33e914ef81" sha1="6ee8a41fef66280ce3e3f0984d00b96079442fb9" status="verified"/>
+		<rom name="Super Smash Bros. (Europe) (En,Fr,De).n64" />
+		<release name="Super Smash Bros. (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Super Smash Bros. (Europe) (En,Fr,De).z64" size="33554432" crc="45a91cb1" md5="5e54c6c563b09c107f86fb33e914ef81" sha1="6ee8a41fef66280ce3e3f0984d00b96079442fb9" status="verified" />
 	</game>
 	<game name="Nintendo All-Star! Dairantou Smash Brothers (Japan)" cloneof="Super Smash Bros. (Europe) (En,Fr,De)">
 		<description>Nintendo All-Star! Dairantou Smash Brothers (Japan)</description>
-		<release name="Nintendo All-Star! Dairantou Smash Brothers (Japan)" region="JPN"/>
-		<rom name="Nintendo All-Star! Dairantou Smash Brothers (Japan).z64" size="16777216" crc="04c9d3b1" md5="66db457b130d31a286a23d6e4dd9726e" sha1="4b71f0e01878696733eefa9c80d11c147ecb4984" status="verified"/>
+		<rom name="Nintendo All-Star! Dairantou Smash Brothers (Japan).n64" />
+		<release name="Nintendo All-Star! Dairantou Smash Brothers (Japan)" region="JPN" />
+		<rom name="Nintendo All-Star! Dairantou Smash Brothers (Japan).z64" size="16777216" crc="04c9d3b1" md5="66db457b130d31a286a23d6e4dd9726e" sha1="4b71f0e01878696733eefa9c80d11c147ecb4984" status="verified" />
 	</game>
 	<game name="Rentiantang Mingxing - Daluan Dou (China) (iQue)" cloneof="Super Smash Bros. (Europe) (En,Fr,De)">
 		<description>Rentiantang Mingxing - Daluan Dou (China) (iQue)</description>
-		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue).z64" size="16793600" crc="d86e2edf" md5="7b815846ec91e6c4a8b8baa0ce4078f0" sha1="926dfad9daede0ddd088d3006bbd1d02ca6222a4"/>
+		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue).n64" />
+		<rom name="Rentiantang Mingxing - Daluan Dou (China) (iQue).z64" size="16793600" crc="d86e2edf" md5="7b815846ec91e6c4a8b8baa0ce4078f0" sha1="926dfad9daede0ddd088d3006bbd1d02ca6222a4" />
 	</game>
 	<game name="Super Smash Bros. (Australia)" cloneof="Super Smash Bros. (Europe) (En,Fr,De)">
 		<description>Super Smash Bros. (Australia)</description>
-		<release name="Super Smash Bros. (Australia)" region="AUS"/>
-		<rom name="Super Smash Bros. (Australia).z64" size="16777216" crc="e96779fa" md5="694dea68dbf1c3f06ff0476acf2169e6" sha1="a9bf83fe73361e8d042c33ed48b3851d7d46712c"/>
+		<rom name="Super Smash Bros. (Australia).n64" />
+		<release name="Super Smash Bros. (Australia)" region="AUS" />
+		<rom name="Super Smash Bros. (Australia).z64" size="16777216" crc="e96779fa" md5="694dea68dbf1c3f06ff0476acf2169e6" sha1="a9bf83fe73361e8d042c33ed48b3851d7d46712c" />
 	</game>
 	<game name="Super Smash Bros. (USA)" cloneof="Super Smash Bros. (Europe) (En,Fr,De)">
 		<description>Super Smash Bros. (USA)</description>
-		<release name="Super Smash Bros. (USA)" region="USA"/>
-		<rom name="Super Smash Bros. (USA).z64" size="16777216" crc="eb97929e" md5="f7c52568a31aadf26e14dc2b6416b2ed" sha1="e2929e10fccc0aa84e5776227e798abc07cedabf" status="verified"/>
+		<rom name="Super Smash Bros. (USA).n64" />
+		<release name="Super Smash Bros. (USA)" region="USA" />
+		<rom name="Super Smash Bros. (USA).z64" size="16777216" crc="eb97929e" md5="f7c52568a31aadf26e14dc2b6416b2ed" sha1="e2929e10fccc0aa84e5776227e798abc07cedabf" status="verified" />
 	</game>
 	<game name="Supercross 2000 (Europe) (En,Fr,De)">
 		<description>Supercross 2000 (Europe) (En,Fr,De)</description>
-		<release name="Supercross 2000 (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Supercross 2000 (Europe) (En,Fr,De).z64" size="16777216" crc="cb5482ec" md5="6d58a01ef7a7a7c779d2a66315992c5f" sha1="3fa3f859048a65e1e810ed7be98ada0a0b4e49ad"/>
+		<rom name="Supercross 2000 (Europe) (En,Fr,De).n64" />
+		<release name="Supercross 2000 (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Supercross 2000 (Europe) (En,Fr,De).z64" size="16777216" crc="cb5482ec" md5="6d58a01ef7a7a7c779d2a66315992c5f" sha1="3fa3f859048a65e1e810ed7be98ada0a0b4e49ad" />
 	</game>
 	<game name="Supercross 2000 (USA)" cloneof="Supercross 2000 (Europe) (En,Fr,De)">
 		<description>Supercross 2000 (USA)</description>
-		<release name="Supercross 2000 (USA)" region="USA"/>
-		<rom name="Supercross 2000 (USA).z64" size="16777216" crc="094e2a48" md5="60347200a1a7cabc0d849ee69ec51df7" sha1="8d726c2ef6bc74b0d516067ffd92da00efa07993"/>
+		<rom name="Supercross 2000 (USA).n64" />
+		<release name="Supercross 2000 (USA)" region="USA" />
+		<rom name="Supercross 2000 (USA).z64" size="16777216" crc="094e2a48" md5="60347200a1a7cabc0d849ee69ec51df7" sha1="8d726c2ef6bc74b0d516067ffd92da00efa07993" />
 	</game>
 	<game name="Superman (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Superman (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Superman (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Superman (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="bca4ff8c" md5="5ab39f2d7a144e1ba243df059560e878" sha1="326378f4c05ca48b69d29ca1c72ab8e19b6ee10d"/>
+		<rom name="Superman (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Superman (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Superman (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="bca4ff8c" md5="5ab39f2d7a144e1ba243df059560e878" sha1="326378f4c05ca48b69d29ca1c72ab8e19b6ee10d" />
 	</game>
 	<game name="Superman (USA) (Beta) (1998-09-06)" cloneof="Superman (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Superman (USA) (Beta) (1998-09-06)</description>
-		<rom name="Superman (USA) (Beta) (1998-09-06).z64" size="33554432" crc="a0897826" md5="19c9491dd517603be2fa3020c2f2deb2" sha1="9eccd95652cf6ba95f2dc78c44a26fc0832dfe35"/>
+		<rom name="Superman (USA) (Beta) (1998-09-06).n64" />
+		<rom name="Superman (USA) (Beta) (1998-09-06).z64" size="33554432" crc="a0897826" md5="19c9491dd517603be2fa3020c2f2deb2" sha1="9eccd95652cf6ba95f2dc78c44a26fc0832dfe35" />
 	</game>
 	<game name="Superman - The New Superman Aventures (USA) (En,Fr,Es)" cloneof="Superman (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Superman - The New Superman Aventures (USA) (En,Fr,Es)</description>
-		<release name="Superman - The New Superman Aventures (USA) (En,Fr,Es)" region="USA"/>
-		<rom name="Superman - The New Superman Aventures (USA) (En,Fr,Es).z64" size="8388608" crc="437e3677" md5="3f64b4f72e61225ef3ae93976c9bfc7c" sha1="c271db752610c9581e1ba1e9125ea8ecdb56f74f"/>
+		<rom name="Superman - The New Superman Aventures (USA) (En,Fr,Es).n64" />
+		<release name="Superman - The New Superman Aventures (USA) (En,Fr,Es)" region="USA" />
+		<rom name="Superman - The New Superman Aventures (USA) (En,Fr,Es).z64" size="8388608" crc="437e3677" md5="3f64b4f72e61225ef3ae93976c9bfc7c" sha1="c271db752610c9581e1ba1e9125ea8ecdb56f74f" />
 	</game>
 	<game name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)">
 		<description>Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)</description>
-		<release name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)" region="JPN"/>
-		<rom name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan).z64" size="8388608" crc="4cd21372" md5="26f4ca20f7b9c88199ac046c57e282b4" sha1="fb905ac5887de6c3670f73f9c92efbacd55b6816"/>
+		<rom name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan).n64" />
+		<release name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan)" region="JPN" />
+		<rom name="Susume! Taisen Puzzle Dama - Toukon! Marutama Chou (Japan).z64" size="8388608" crc="4cd21372" md5="26f4ca20f7b9c88199ac046c57e282b4" sha1="fb905ac5887de6c3670f73f9c92efbacd55b6816" />
 	</game>
 	<game name="Sydney 2000 (Europe) (Proto)">
 		<description>Sydney 2000 (Europe) (Proto)</description>
-		<release name="Sydney 2000 (Europe) (Proto)" region="EUR"/>
-		<rom name="Sydney 2000 (Europe) (Proto).z64" size="33554432" crc="db7b31b9" md5="fc32007ba03ff2510020e979c7bdad4f" sha1="ecc18f53e0ca563b3d5fa6876768ef2f94d35e36"/>
+		<rom name="Sydney 2000 (Europe) (Proto).n64" />
+		<release name="Sydney 2000 (Europe) (Proto)" region="EUR" />
+		<rom name="Sydney 2000 (Europe) (Proto).z64" size="33554432" crc="db7b31b9" md5="fc32007ba03ff2510020e979c7bdad4f" sha1="ecc18f53e0ca563b3d5fa6876768ef2f94d35e36" />
 	</game>
 	<game name="Sydney 2000 (USA) (Proto)" cloneof="Sydney 2000 (Europe) (Proto)">
 		<description>Sydney 2000 (USA) (Proto)</description>
-		<release name="Sydney 2000 (USA) (Proto)" region="USA"/>
-		<rom name="Sydney 2000 (USA) (Proto).z64" size="33554432" crc="5b6673aa" md5="2eea8d20bef26f88a5e82fdd39f87e75" sha1="711c79790a713e65cc2ecb4857f35898b8e92985"/>
+		<rom name="Sydney 2000 (USA) (Proto).n64" />
+		<release name="Sydney 2000 (USA) (Proto)" region="USA" />
+		<rom name="Sydney 2000 (USA) (Proto).z64" size="33554432" crc="5b6673aa" md5="2eea8d20bef26f88a5e82fdd39f87e75" sha1="711c79790a713e65cc2ecb4857f35898b8e92985" />
 	</game>
 	<game name="Tarzan (Europe)">
 		<description>Tarzan (Europe)</description>
-		<release name="Tarzan (Europe)" region="EUR"/>
-		<rom name="Tarzan (Europe).z64" size="16777216" crc="7737ed9e" md5="bd1de2fc1cf31096423563a40ecbf933" sha1="7623aceecd244f4352a7d9346a607ac183b32cd6"/>
+		<rom name="Tarzan (Europe).n64" />
+		<release name="Tarzan (Europe)" region="EUR" />
+		<rom name="Tarzan (Europe).z64" size="16777216" crc="7737ed9e" md5="bd1de2fc1cf31096423563a40ecbf933" sha1="7623aceecd244f4352a7d9346a607ac183b32cd6" />
 	</game>
 	<game name="Tarzan (France)" cloneof="Tarzan (Europe)">
 		<description>Tarzan (France)</description>
-		<release name="Tarzan (France)" region="FRA"/>
-		<rom name="Tarzan (France).z64" size="16777216" crc="99c7649d" md5="5d82e903f65341487ddc11af80ad607a" sha1="1cf1f0f8217ba4e1691427f97ef62b15dc02a1c3"/>
+		<rom name="Tarzan (France).n64" />
+		<release name="Tarzan (France)" region="FRA" />
+		<rom name="Tarzan (France).z64" size="16777216" crc="99c7649d" md5="5d82e903f65341487ddc11af80ad607a" sha1="1cf1f0f8217ba4e1691427f97ef62b15dc02a1c3" />
 	</game>
 	<game name="Tarzan (Germany)" cloneof="Tarzan (Europe)">
 		<description>Tarzan (Germany)</description>
-		<release name="Tarzan (Germany)" region="GER"/>
-		<rom name="Tarzan (Germany).z64" size="16777216" crc="0b0954c5" md5="df3cdd959e8c63b45f557fc197ce0e63" sha1="4fc7ded9601a78db964ed5b1a585bb716f6d636c"/>
+		<rom name="Tarzan (Germany).n64" />
+		<release name="Tarzan (Germany)" region="GER" />
+		<rom name="Tarzan (Germany).z64" size="16777216" crc="0b0954c5" md5="df3cdd959e8c63b45f557fc197ce0e63" sha1="4fc7ded9601a78db964ed5b1a585bb716f6d636c" />
 	</game>
 	<game name="Tarzan (USA)" cloneof="Tarzan (Europe)">
 		<description>Tarzan (USA)</description>
-		<release name="Tarzan (USA)" region="USA"/>
-		<rom name="Tarzan (USA).z64" size="16777216" crc="c38ca641" md5="eae7e0ee5328ed9f13b9cf9990189928" sha1="44c63a89e1e8f9eeee0aa4b45442822feb3cc579"/>
+		<rom name="Tarzan (USA).n64" />
+		<release name="Tarzan (USA)" region="USA" />
+		<rom name="Tarzan (USA).z64" size="16777216" crc="c38ca641" md5="eae7e0ee5328ed9f13b9cf9990189928" sha1="44c63a89e1e8f9eeee0aa4b45442822feb3cc579" />
 	</game>
 	<game name="Taz Express (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Taz Express (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Taz Express (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Taz Express (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="0712c306" md5="192b715e8bc5972a4986df21dc8bf357" sha1="e1d8121986652ed180505af21456c180c8b29fab"/>
+		<rom name="Taz Express (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Taz Express (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Taz Express (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="0712c306" md5="192b715e8bc5972a4986df21dc8bf357" sha1="e1d8121986652ed180505af21456c180c8b29fab" />
 	</game>
 	<game name="Taz Express (USA) (Proto) (2000-05-15)" cloneof="Taz Express (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Taz Express (USA) (Proto) (2000-05-15)</description>
-		<release name="Taz Express (USA) (Proto) (2000-05-15)" region="USA"/>
-		<rom name="Taz Express (USA) (Proto) (2000-05-15).z64" size="33554432" crc="dde7cfbd" md5="7a94f94485bd28f0d6d67257050b26d4" sha1="674f73fe81e9121751add1e24991993b8dde1b9b"/>
+		<rom name="Taz Express (USA) (Proto) (2000-05-15).n64" />
+		<release name="Taz Express (USA) (Proto) (2000-05-15)" region="USA" />
+		<rom name="Taz Express (USA) (Proto) (2000-05-15).z64" size="33554432" crc="dde7cfbd" md5="7a94f94485bd28f0d6d67257050b26d4" sha1="674f73fe81e9121751add1e24991993b8dde1b9b" />
 	</game>
 	<game name="Tetris 64 (Japan) (En)">
 		<description>Tetris 64 (Japan) (En)</description>
-		<release name="Tetris 64 (Japan) (En)" region="JPN"/>
-		<rom name="Tetris 64 (Japan) (En).z64" size="8388608" crc="f128cd17" md5="7c8efcf4fba28f9f5b5ea10a71283bf3" sha1="ea9a3ba1384e15e0af996b43fe3e56db889002de"/>
+		<rom name="Tetris 64 (Japan) (En).n64" />
+		<release name="Tetris 64 (Japan) (En)" region="JPN" />
+		<rom name="Tetris 64 (Japan) (En).z64" size="8388608" crc="f128cd17" md5="7c8efcf4fba28f9f5b5ea10a71283bf3" sha1="ea9a3ba1384e15e0af996b43fe3e56db889002de" />
 	</game>
 	<game name="Tetrisphere (Europe)">
 		<description>Tetrisphere (Europe)</description>
-		<release name="Tetrisphere (Europe)" region="EUR"/>
-		<rom name="Tetrisphere (Europe).z64" size="8388608" crc="7cb31b0f" md5="765a330d5ce2dbe7120c6c8e18a1487d" sha1="a730d8dd3b00c22f8fa4c6e74299e5cc2bbb8207"/>
+		<rom name="Tetrisphere (Europe).n64" />
+		<release name="Tetrisphere (Europe)" region="EUR" />
+		<rom name="Tetrisphere (Europe).z64" size="8388608" crc="7cb31b0f" md5="765a330d5ce2dbe7120c6c8e18a1487d" sha1="a730d8dd3b00c22f8fa4c6e74299e5cc2bbb8207" />
 	</game>
 	<game name="Tetrisphere (USA)" cloneof="Tetrisphere (Europe)">
 		<description>Tetrisphere (USA)</description>
-		<release name="Tetrisphere (USA)" region="USA"/>
-		<rom name="Tetrisphere (USA).z64" size="8388608" crc="70a3a5ce" md5="3f88078e2d9dbf6c9372f6373cf9ae09" sha1="32adaa274ceed246aeee9f53592d642a121f3bdb"/>
+		<rom name="Tetrisphere (USA).n64" />
+		<release name="Tetrisphere (USA)" region="USA" />
+		<rom name="Tetrisphere (USA).z64" size="8388608" crc="70a3a5ce" md5="3f88078e2d9dbf6c9372f6373cf9ae09" sha1="32adaa274ceed246aeee9f53592d642a121f3bdb" />
 	</game>
 	<game name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)">
 		<description>Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)</description>
-		<release name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)" region="EUR"/>
-		<rom name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da).z64" size="16777216" crc="d82d5736" md5="a09663b596f348d28af846a51375eb81" sha1="53944f6c63b2e971abf756efeccab24fa0b96e78"/>
+		<rom name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da).n64" />
+		<release name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)" region="EUR" />
+		<rom name="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da).z64" size="16777216" crc="d82d5736" md5="a09663b596f348d28af846a51375eb81" sha1="53944f6c63b2e971abf756efeccab24fa0b96e78" />
 	</game>
 	<game name="Tigger's Honey Hunt (USA)" cloneof="Tigger's Honey Hunt (Europe) (En,Fr,De,Es,It,Nl,Da)">
 		<description>Tigger's Honey Hunt (USA)</description>
-		<release name="Tigger's Honey Hunt (USA)" region="USA"/>
-		<rom name="Tigger's Honey Hunt (USA).z64" size="16777216" crc="68c2ac8f" md5="f8636514b5b0edebf376c3111d24417a" sha1="98db3a0f9025893107e9fb1bb8d0b6bc0ef3e280"/>
+		<rom name="Tigger's Honey Hunt (USA).n64" />
+		<release name="Tigger's Honey Hunt (USA)" region="USA" />
+		<rom name="Tigger's Honey Hunt (USA).z64" size="16777216" crc="68c2ac8f" md5="f8636514b5b0edebf376c3111d24417a" sha1="98db3a0f9025893107e9fb1bb8d0b6bc0ef3e280" />
 	</game>
 	<game name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="9ea8a3b8" md5="46be5d00682fcc1f7fc0fba507e8e5c1" sha1="96c874c4556b4872269e41339a1cbac53cc5b052"/>
+		<rom name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="9ea8a3b8" md5="46be5d00682fcc1f7fc0fba507e8e5c1" sha1="96c874c4556b4872269e41339a1cbac53cc5b052" />
 	</game>
 	<game name="Tom and Jerry in Fists of Furry (USA)" cloneof="Tom and Jerry in Fists of Furry (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Tom and Jerry in Fists of Furry (USA)</description>
-		<release name="Tom and Jerry in Fists of Furry (USA)" region="USA"/>
-		<rom name="Tom and Jerry in Fists of Furry (USA).z64" size="12582912" crc="6d685b83" md5="a63a9af85be8bb47c1741b8a37115354" sha1="d8980a34ece4a8933d439d0378e0cff8f03994a7"/>
+		<rom name="Tom and Jerry in Fists of Furry (USA).n64" />
+		<release name="Tom and Jerry in Fists of Furry (USA)" region="USA" />
+		<rom name="Tom and Jerry in Fists of Furry (USA).z64" size="12582912" crc="6d685b83" md5="a63a9af85be8bb47c1741b8a37115354" sha1="d8980a34ece4a8933d439d0378e0cff8f03994a7" />
 	</game>
 	<game name="Tom Clancy's Rainbow Six (Europe)">
 		<description>Tom Clancy's Rainbow Six (Europe)</description>
-		<release name="Tom Clancy's Rainbow Six (Europe)" region="EUR"/>
-		<rom name="Tom Clancy's Rainbow Six (Europe).z64" size="16777216" crc="4b71e083" md5="1b991cf41c70ff2c92ffbefacabe8d03" sha1="64105f5c17ba7e2e0350f20e18addcc0a4766bd8"/>
+		<rom name="Tom Clancy's Rainbow Six (Europe).n64" />
+		<release name="Tom Clancy's Rainbow Six (Europe)" region="EUR" />
+		<rom name="Tom Clancy's Rainbow Six (Europe).z64" size="16777216" crc="4b71e083" md5="1b991cf41c70ff2c92ffbefacabe8d03" sha1="64105f5c17ba7e2e0350f20e18addcc0a4766bd8" />
 	</game>
 	<game name="Tom Clancy's Rainbow Six (France)" cloneof="Tom Clancy's Rainbow Six (Europe)">
 		<description>Tom Clancy's Rainbow Six (France)</description>
-		<release name="Tom Clancy's Rainbow Six (France)" region="FRA"/>
-		<rom name="Tom Clancy's Rainbow Six (France).z64" size="16777216" crc="bbf7b6a8" md5="15e4c1b4f3f459d4caa7f7e2cf0c95da" sha1="ec38196491aeee7ad2fb4a0a7f139c0839e864c6"/>
+		<rom name="Tom Clancy's Rainbow Six (France).n64" />
+		<release name="Tom Clancy's Rainbow Six (France)" region="FRA" />
+		<rom name="Tom Clancy's Rainbow Six (France).z64" size="16777216" crc="bbf7b6a8" md5="15e4c1b4f3f459d4caa7f7e2cf0c95da" sha1="ec38196491aeee7ad2fb4a0a7f139c0839e864c6" />
 	</game>
 	<game name="Tom Clancy's Rainbow Six (Germany)" cloneof="Tom Clancy's Rainbow Six (Europe)">
 		<description>Tom Clancy's Rainbow Six (Germany)</description>
-		<release name="Tom Clancy's Rainbow Six (Germany)" region="GER"/>
-		<rom name="Tom Clancy's Rainbow Six (Germany).z64" size="16777216" crc="5d73e788" md5="fdc76a53b1056d3e50ea6a3e295fe4d1" sha1="e41c7b71284976ea5d51b42593973a1d3ce58508"/>
+		<rom name="Tom Clancy's Rainbow Six (Germany).n64" />
+		<release name="Tom Clancy's Rainbow Six (Germany)" region="GER" />
+		<rom name="Tom Clancy's Rainbow Six (Germany).z64" size="16777216" crc="5d73e788" md5="fdc76a53b1056d3e50ea6a3e295fe4d1" sha1="e41c7b71284976ea5d51b42593973a1d3ce58508" />
 	</game>
 	<game name="Tom Clancy's Rainbow Six (USA)" cloneof="Tom Clancy's Rainbow Six (Europe)">
 		<description>Tom Clancy's Rainbow Six (USA)</description>
-		<release name="Tom Clancy's Rainbow Six (USA)" region="USA"/>
-		<rom name="Tom Clancy's Rainbow Six (USA).z64" size="16777216" crc="53b0cc13" md5="80f3b1abd9fb9ae73997489db185a74d" sha1="f785674c670c01e31c77b3034525d43fd6703b9a"/>
+		<rom name="Tom Clancy's Rainbow Six (USA).n64" />
+		<release name="Tom Clancy's Rainbow Six (USA)" region="USA" />
+		<rom name="Tom Clancy's Rainbow Six (USA).z64" size="16777216" crc="53b0cc13" md5="80f3b1abd9fb9ae73997489db185a74d" sha1="f785674c670c01e31c77b3034525d43fd6703b9a" />
 	</game>
 	<game name="Tommy Thunder (USA) (Proto) (1997-10-01)">
 		<description>Tommy Thunder (USA) (Proto) (1997-10-01)</description>
-		<release name="Tommy Thunder (USA) (Proto) (1997-10-01)" region="USA"/>
-		<rom name="Tommy Thunder (USA) (Proto) (1997-10-01).z64" size="8388608" crc="66734854" md5="99f95ad4a3b0c78b6f58a0fc3ad22db6" sha1="287fd68b5de520ade240889bc0133777fed5c671"/>
+		<rom name="Tommy Thunder (USA) (Proto) (1997-10-01).n64" />
+		<release name="Tommy Thunder (USA) (Proto) (1997-10-01)" region="USA" />
+		<rom name="Tommy Thunder (USA) (Proto) (1997-10-01).z64" size="8388608" crc="66734854" md5="99f95ad4a3b0c78b6f58a0fc3ad22db6" sha1="287fd68b5de520ade240889bc0133777fed5c671" />
 	</game>
 	<game name="Tonic Trouble (Europe) (En,Fr,De,Es,It)">
 		<description>Tonic Trouble (Europe) (En,Fr,De,Es,It)</description>
-		<release name="Tonic Trouble (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="Tonic Trouble (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="b4322403" md5="3d3573a855835a98de29d598c35590e0" sha1="81909104362baeb7ae3793c08c3d138e96105bbf"/>
+		<rom name="Tonic Trouble (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="Tonic Trouble (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="Tonic Trouble (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="b4322403" md5="3d3573a855835a98de29d598c35590e0" sha1="81909104362baeb7ae3793c08c3d138e96105bbf" />
 	</game>
 	<game name="Tonic Trouble (USA) (Rev 1)" cloneof="Tonic Trouble (Europe) (En,Fr,De,Es,It)">
 		<description>Tonic Trouble (USA) (Rev 1)</description>
-		<release name="Tonic Trouble (USA) (Rev 1)" region="USA"/>
-		<rom name="Tonic Trouble (USA) (Rev 1).z64" size="16777216" crc="1c04ba12" md5="7d3e935156844de0002db875e1076a5c" sha1="38f9837159d6aa69ca656d8005eccf099c129537"/>
+		<rom name="Tonic Trouble (USA) (Rev 1).n64" />
+		<release name="Tonic Trouble (USA) (Rev 1)" region="USA" />
+		<rom name="Tonic Trouble (USA) (Rev 1).z64" size="16777216" crc="1c04ba12" md5="7d3e935156844de0002db875e1076a5c" sha1="38f9837159d6aa69ca656d8005eccf099c129537" />
 	</game>
 	<game name="Tony Hawk's Pro Skater 2 (Europe)">
 		<description>Tony Hawk's Pro Skater 2 (Europe)</description>
-		<release name="Tony Hawk's Pro Skater 2 (Europe)" region="EUR"/>
-		<rom name="Tony Hawk's Pro Skater 2 (Europe).z64" size="16777216" crc="a1207132" md5="6be030475c4db52f273ef8a02b4dafa8" sha1="803672c1ffa7860536d8b35dca8b59f637f4165e"/>
+		<rom name="Tony Hawk's Pro Skater 2 (Europe).n64" />
+		<release name="Tony Hawk's Pro Skater 2 (Europe)" region="EUR" />
+		<rom name="Tony Hawk's Pro Skater 2 (Europe).z64" size="16777216" crc="a1207132" md5="6be030475c4db52f273ef8a02b4dafa8" sha1="803672c1ffa7860536d8b35dca8b59f637f4165e" />
 	</game>
 	<game name="Tony Hawk's Pro Skater 2 (USA)" cloneof="Tony Hawk's Pro Skater 2 (Europe)">
 		<description>Tony Hawk's Pro Skater 2 (USA)</description>
-		<release name="Tony Hawk's Pro Skater 2 (USA)" region="USA"/>
-		<rom name="Tony Hawk's Pro Skater 2 (USA).z64" size="16777216" crc="80aa83f3" md5="29974692808c112b306fbd259273dc96" sha1="458ac754cd8e08c46f4c5c9204192ecde84a179d"/>
+		<rom name="Tony Hawk's Pro Skater 2 (USA).n64" />
+		<release name="Tony Hawk's Pro Skater 2 (USA)" region="USA" />
+		<rom name="Tony Hawk's Pro Skater 2 (USA).z64" size="16777216" crc="80aa83f3" md5="29974692808c112b306fbd259273dc96" sha1="458ac754cd8e08c46f4c5c9204192ecde84a179d" />
 	</game>
 	<game name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20)" cloneof="Tony Hawk's Pro Skater 2 (Europe)">
 		<description>Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20)</description>
-		<rom name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20).z64" size="33554432" crc="98d0d335" md5="317a4e89618b8b7955632c5f70177690" sha1="fab693f9da784837d10a3281d16ec5a1d3d733c9"/>
+		<rom name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20).n64" />
+		<rom name="Tony Hawk's Pro Skater 2 (USA) (Beta) (2001-04-20).z64" size="33554432" crc="98d0d335" md5="317a4e89618b8b7955632c5f70177690" sha1="fab693f9da784837d10a3281d16ec5a1d3d733c9" />
 	</game>
 	<game name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04)" cloneof="Tony Hawk's Pro Skater 2 (Europe)">
 		<description>Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04)</description>
-		<rom name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04).z64" size="33554432" crc="bcf178c5" md5="6440a67e2c27bd9adedfc60939c2bf1b" sha1="134289253ccccbcabbf52660f28a49449c399ede"/>
+		<rom name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04).n64" />
+		<rom name="Tony Hawk's Pro Skater 2 (USA) (v012) (Beta) (2001-06-04).z64" size="33554432" crc="bcf178c5" md5="6440a67e2c27bd9adedfc60939c2bf1b" sha1="134289253ccccbcabbf52660f28a49449c399ede" />
 	</game>
 	<game name="Tony Hawk's Pro Skater 3 (USA)">
 		<description>Tony Hawk's Pro Skater 3 (USA)</description>
-		<release name="Tony Hawk's Pro Skater 3 (USA)" region="USA"/>
-		<rom name="Tony Hawk's Pro Skater 3 (USA).z64" size="16777216" crc="62a8ce7d" md5="9d4891bf26881c4541171b0235015fd4" sha1="7b9438120c67214afaea09f4b106c54ef8f366c5"/>
+		<rom name="Tony Hawk's Pro Skater 3 (USA).n64" />
+		<release name="Tony Hawk's Pro Skater 3 (USA)" region="USA" />
+		<rom name="Tony Hawk's Pro Skater 3 (USA).z64" size="16777216" crc="62a8ce7d" md5="9d4891bf26881c4541171b0235015fd4" sha1="7b9438120c67214afaea09f4b106c54ef8f366c5" />
 	</game>
 	<game name="Tony Hawk's Skateboarding (Europe)">
 		<description>Tony Hawk's Skateboarding (Europe)</description>
-		<release name="Tony Hawk's Skateboarding (Europe)" region="EUR"/>
-		<rom name="Tony Hawk's Skateboarding (Europe).z64" size="12582912" crc="39e4f766" md5="c9e9c4a18b1540c6b4111331d7c663b8" sha1="c321cd05eec58765467878ac8015784535280e3c" status="verified"/>
+		<rom name="Tony Hawk's Skateboarding (Europe).n64" />
+		<release name="Tony Hawk's Skateboarding (Europe)" region="EUR" />
+		<rom name="Tony Hawk's Skateboarding (Europe).z64" size="12582912" crc="39e4f766" md5="c9e9c4a18b1540c6b4111331d7c663b8" sha1="c321cd05eec58765467878ac8015784535280e3c" status="verified" />
 	</game>
 	<game name="Tony Hawk's Pro Skater (USA)" cloneof="Tony Hawk's Skateboarding (Europe)">
 		<description>Tony Hawk's Pro Skater (USA)</description>
-		<rom name="Tony Hawk's Pro Skater (USA).z64" size="12582912" crc="f5c1b64f" md5="5ed7e392198a5fa56ee37ea9e93a8d50" sha1="fc1b4dec85e6874fa7321edc24f5a1e78600d9d0"/>
+		<rom name="Tony Hawk's Pro Skater (USA).n64" />
+		<rom name="Tony Hawk's Pro Skater (USA).z64" size="12582912" crc="f5c1b64f" md5="5ed7e392198a5fa56ee37ea9e93a8d50" sha1="fc1b4dec85e6874fa7321edc24f5a1e78600d9d0" />
 	</game>
 	<game name="Tony Hawk's Pro Skater (USA) (Rev 1)" cloneof="Tony Hawk's Skateboarding (Europe)">
 		<description>Tony Hawk's Pro Skater (USA) (Rev 1)</description>
-		<release name="Tony Hawk's Pro Skater (USA) (Rev 1)" region="USA"/>
-		<rom name="Tony Hawk's Pro Skater (USA) (Rev 1).z64" size="12582912" crc="6182a092" md5="aff424a1883dc7bb92c7b2ebe9342f85" sha1="4900b6c92fb8df1765e91e891dccc525bb102fe1"/>
+		<rom name="Tony Hawk's Pro Skater (USA) (Rev 1).n64" />
+		<release name="Tony Hawk's Pro Skater (USA) (Rev 1)" region="USA" />
+		<rom name="Tony Hawk's Pro Skater (USA) (Rev 1).z64" size="12582912" crc="6182a092" md5="aff424a1883dc7bb92c7b2ebe9342f85" sha1="4900b6c92fb8df1765e91e891dccc525bb102fe1" />
 	</game>
 	<game name="Tony Hawk's Pro Skater (USA) (Beta)" cloneof="Tony Hawk's Skateboarding (Europe)">
 		<description>Tony Hawk's Pro Skater (USA) (Beta)</description>
-		<rom name="Tony Hawk's Pro Skater (USA) (Beta).z64" size="25165824" crc="f50204da" md5="035c0700406197104d977c379e410cb7" sha1="839be141af2f5cd717b264c8167c72cebd87ef29"/>
+		<rom name="Tony Hawk's Pro Skater (USA) (Beta).n64" />
+		<rom name="Tony Hawk's Pro Skater (USA) (Beta).z64" size="25165824" crc="f50204da" md5="035c0700406197104d977c379e410cb7" sha1="839be141af2f5cd717b264c8167c72cebd87ef29" />
 	</game>
 	<game name="Toon Panic (Japan) (Proto)">
 		<description>Toon Panic (Japan) (Proto)</description>
-		<release name="Toon Panic (Japan) (Proto)" region="JPN"/>
-		<rom name="Toon Panic (Japan) (Proto).z64" size="12582912" crc="cf396c4e" md5="b6fd2a048d1f4f324cebc97ba09872bb" sha1="c0da7fe28d05fab82f79703fdf9d807b9d7ee70e"/>
+		<rom name="Toon Panic (Japan) (Proto).n64" />
+		<release name="Toon Panic (Japan) (Proto)" region="JPN" />
+		<rom name="Toon Panic (Japan) (Proto).z64" size="12582912" crc="cf396c4e" md5="b6fd2a048d1f4f324cebc97ba09872bb" sha1="c0da7fe28d05fab82f79703fdf9d807b9d7ee70e" />
 	</game>
 	<game name="Top Gear Hyper Bike (Europe)">
 		<description>Top Gear Hyper Bike (Europe)</description>
-		<release name="Top Gear Hyper Bike (Europe)" region="EUR"/>
-		<rom name="Top Gear Hyper Bike (Europe).z64" size="16777216" crc="bae57ea7" md5="0072538ef925645db310f8e23a480b89" sha1="ff4eb866c48700fa978a5e663cda1499c8eac0b4" status="verified"/>
+		<rom name="Top Gear Hyper Bike (Europe).n64" />
+		<release name="Top Gear Hyper Bike (Europe)" region="EUR" />
+		<rom name="Top Gear Hyper Bike (Europe).z64" size="16777216" crc="bae57ea7" md5="0072538ef925645db310f8e23a480b89" sha1="ff4eb866c48700fa978a5e663cda1499c8eac0b4" status="verified" />
 	</game>
 	<game name="Top Gear Hyper Bike (Japan)" cloneof="Top Gear Hyper Bike (Europe)">
 		<description>Top Gear Hyper Bike (Japan)</description>
-		<release name="Top Gear Hyper Bike (Japan)" region="JPN"/>
-		<rom name="Top Gear Hyper Bike (Japan).z64" size="16777216" crc="09b2cda1" md5="4347174bb415ca970f2d50df2973f656" sha1="7db7337260af8f153b6291b13e655f192b59ec01"/>
+		<rom name="Top Gear Hyper Bike (Japan).n64" />
+		<release name="Top Gear Hyper Bike (Japan)" region="JPN" />
+		<rom name="Top Gear Hyper Bike (Japan).z64" size="16777216" crc="09b2cda1" md5="4347174bb415ca970f2d50df2973f656" sha1="7db7337260af8f153b6291b13e655f192b59ec01" />
 	</game>
 	<game name="Top Gear Hyper-Bike (USA)" cloneof="Top Gear Hyper Bike (Europe)">
 		<description>Top Gear Hyper-Bike (USA)</description>
-		<release name="Top Gear Hyper-Bike (USA)" region="USA"/>
-		<rom name="Top Gear Hyper-Bike (USA).z64" size="16777216" crc="6eebc26a" md5="7258f4ab367b025c95a4f476c461e717" sha1="c7593b3d0d793cf03616df02501735221624ac04"/>
+		<rom name="Top Gear Hyper-Bike (USA).n64" />
+		<release name="Top Gear Hyper-Bike (USA)" region="USA" />
+		<rom name="Top Gear Hyper-Bike (USA).z64" size="16777216" crc="6eebc26a" md5="7258f4ab367b025c95a4f476c461e717" sha1="c7593b3d0d793cf03616df02501735221624ac04" />
 	</game>
 	<game name="Top Gear Hyper-Bike (USA) (Beta)" cloneof="Top Gear Hyper Bike (Europe)">
 		<description>Top Gear Hyper-Bike (USA) (Beta)</description>
-		<rom name="Top Gear Hyper-Bike (USA) (Beta).z64" size="33554432" crc="00c0278a" md5="b60d26c2c2242bff61f76469fc272d2a" sha1="d3ae07e2c4360ec4eb06a70c6e48d848eec532dd"/>
+		<rom name="Top Gear Hyper-Bike (USA) (Beta).n64" />
+		<rom name="Top Gear Hyper-Bike (USA) (Beta).z64" size="33554432" crc="00c0278a" md5="b60d26c2c2242bff61f76469fc272d2a" sha1="d3ae07e2c4360ec4eb06a70c6e48d848eec532dd" />
 	</game>
 	<game name="Top Gear Overdrive (Europe)">
 		<description>Top Gear Overdrive (Europe)</description>
-		<release name="Top Gear Overdrive (Europe)" region="EUR"/>
-		<rom name="Top Gear Overdrive (Europe).z64" size="12582912" crc="0cc70580" md5="6c65a252f227aef18df2dd3ce04cc821" sha1="bad781b7a3fe73a0127223cd807fafbc4007dccf"/>
+		<rom name="Top Gear Overdrive (Europe).n64" />
+		<release name="Top Gear Overdrive (Europe)" region="EUR" />
+		<rom name="Top Gear Overdrive (Europe).z64" size="12582912" crc="0cc70580" md5="6c65a252f227aef18df2dd3ce04cc821" sha1="bad781b7a3fe73a0127223cd807fafbc4007dccf" />
 	</game>
 	<game name="Top Gear Overdrive (Japan)" cloneof="Top Gear Overdrive (Europe)">
 		<description>Top Gear Overdrive (Japan)</description>
-		<release name="Top Gear Overdrive (Japan)" region="JPN"/>
-		<rom name="Top Gear Overdrive (Japan).z64" size="12582912" crc="81aafc2b" md5="b5691794a851d8b603f0c741d44aa244" sha1="be62d75c7ac1067111cd213365a9583550f897f3"/>
+		<rom name="Top Gear Overdrive (Japan).n64" />
+		<release name="Top Gear Overdrive (Japan)" region="JPN" />
+		<rom name="Top Gear Overdrive (Japan).z64" size="12582912" crc="81aafc2b" md5="b5691794a851d8b603f0c741d44aa244" sha1="be62d75c7ac1067111cd213365a9583550f897f3" />
 	</game>
 	<game name="Top Gear Overdrive (USA)" cloneof="Top Gear Overdrive (Europe)">
 		<description>Top Gear Overdrive (USA)</description>
-		<release name="Top Gear Overdrive (USA)" region="USA"/>
-		<rom name="Top Gear Overdrive (USA).z64" size="12582912" crc="f3e0ff21" md5="7818696426c0a429fbfccc4efe8d5570" sha1="75ebbe451906ce68b0dd43eef9ee44416452a4f1"/>
+		<rom name="Top Gear Overdrive (USA).n64" />
+		<release name="Top Gear Overdrive (USA)" region="USA" />
+		<rom name="Top Gear Overdrive (USA).z64" size="12582912" crc="f3e0ff21" md5="7818696426c0a429fbfccc4efe8d5570" sha1="75ebbe451906ce68b0dd43eef9ee44416452a4f1" />
 	</game>
 	<game name="Top Gear Rally (Europe)">
 		<description>Top Gear Rally (Europe)</description>
-		<release name="Top Gear Rally (Europe)" region="EUR"/>
-		<rom name="Top Gear Rally (Europe).z64" size="8388608" crc="40b3bb21" md5="1698508f521280d0a80e078ec981d4ac" sha1="9fae5d98fe3464f00d59034690df90118646eb95"/>
+		<rom name="Top Gear Rally (Europe).n64" />
+		<release name="Top Gear Rally (Europe)" region="EUR" />
+		<rom name="Top Gear Rally (Europe).z64" size="8388608" crc="40b3bb21" md5="1698508f521280d0a80e078ec981d4ac" sha1="9fae5d98fe3464f00d59034690df90118646eb95" />
 	</game>
 	<game name="Top Gear Rally (Japan)" cloneof="Top Gear Rally (Europe)">
 		<description>Top Gear Rally (Japan)</description>
-		<release name="Top Gear Rally (Japan)" region="JPN"/>
-		<rom name="Top Gear Rally (Japan).z64" size="8388608" crc="c6707cd6" md5="6e0af13dcefee6a11c4d7262206d6d2d" sha1="e0415b87c5a5b69ac581e79137406bdaa79b354a"/>
+		<rom name="Top Gear Rally (Japan).n64" />
+		<release name="Top Gear Rally (Japan)" region="JPN" />
+		<rom name="Top Gear Rally (Japan).z64" size="8388608" crc="c6707cd6" md5="6e0af13dcefee6a11c4d7262206d6d2d" sha1="e0415b87c5a5b69ac581e79137406bdaa79b354a" />
 	</game>
 	<game name="Top Gear Rally (USA)" cloneof="Top Gear Rally (Europe)">
 		<description>Top Gear Rally (USA)</description>
-		<release name="Top Gear Rally (USA)" region="USA"/>
-		<rom name="Top Gear Rally (USA).z64" size="8388608" crc="137287f5" md5="6f7030284b6bc84a49e07da864526b52" sha1="bfc51f086ebdb78904dc24ad0c3a2d946e26d022"/>
+		<rom name="Top Gear Rally (USA).n64" />
+		<release name="Top Gear Rally (USA)" region="USA" />
+		<rom name="Top Gear Rally (USA).z64" size="8388608" crc="137287f5" md5="6f7030284b6bc84a49e07da864526b52" sha1="bfc51f086ebdb78904dc24ad0c3a2d946e26d022" />
 	</game>
 	<game name="Top Gear Rally (Asia) (En)" cloneof="Top Gear Rally (Europe)">
 		<description>Top Gear Rally (Asia) (En)</description>
-		<release name="Top Gear Rally (Asia) (En)" region="ASI"/>
-		<rom name="Top Gear Rally (Asia) (En).z64" size="8388608" crc="c4bc4df8" md5="50195216c8a37f9bd5b2105a40ee8d8f" sha1="7e36a98f6fafe3ff7e72d14e0fae16418458da47"/>
+		<rom name="Top Gear Rally (Asia) (En).n64" />
+		<release name="Top Gear Rally (Asia) (En)" region="ASI" />
+		<rom name="Top Gear Rally (Asia) (En).z64" size="8388608" crc="c4bc4df8" md5="50195216c8a37f9bd5b2105a40ee8d8f" sha1="7e36a98f6fafe3ff7e72d14e0fae16418458da47" />
 	</game>
 	<game name="Top Gear Rally 2 (Europe)">
 		<description>Top Gear Rally 2 (Europe)</description>
-		<release name="Top Gear Rally 2 (Europe)" region="EUR"/>
-		<rom name="Top Gear Rally 2 (Europe).z64" size="12582912" crc="cb294d39" md5="44c4566572dc0662d4299ab5b19043ae" sha1="cc140d2a8bab74109d34fda97f4da21f8c3cd083"/>
+		<rom name="Top Gear Rally 2 (Europe).n64" />
+		<release name="Top Gear Rally 2 (Europe)" region="EUR" />
+		<rom name="Top Gear Rally 2 (Europe).z64" size="12582912" crc="cb294d39" md5="44c4566572dc0662d4299ab5b19043ae" sha1="cc140d2a8bab74109d34fda97f4da21f8c3cd083" />
 	</game>
 	<game name="TG Rally 2 (Europe)" cloneof="Top Gear Rally 2 (Europe)">
 		<description>TG Rally 2 (Europe)</description>
-		<rom name="TG Rally 2 (Europe).z64" size="12582912" crc="135c8eb0" md5="acd0118ac4709db3943b3d35112c2001" sha1="46907a7bd1ceb65f48c39d9d60b56dbc75a7a2c3" status="verified"/>
+		<rom name="TG Rally 2 (Europe).n64" />
+		<rom name="TG Rally 2 (Europe).z64" size="12582912" crc="135c8eb0" md5="acd0118ac4709db3943b3d35112c2001" sha1="46907a7bd1ceb65f48c39d9d60b56dbc75a7a2c3" status="verified" />
 	</game>
 	<game name="Top Gear Rally 2 (Japan)" cloneof="Top Gear Rally 2 (Europe)">
 		<description>Top Gear Rally 2 (Japan)</description>
-		<release name="Top Gear Rally 2 (Japan)" region="JPN"/>
-		<rom name="Top Gear Rally 2 (Japan).z64" size="12582912" crc="aa136e07" md5="b10d781ec625ca45713fd34e5096c24a" sha1="d78df79985bfdc7c77f7ed0338e86e852bb3f45a"/>
+		<rom name="Top Gear Rally 2 (Japan).n64" />
+		<release name="Top Gear Rally 2 (Japan)" region="JPN" />
+		<rom name="Top Gear Rally 2 (Japan).z64" size="12582912" crc="aa136e07" md5="b10d781ec625ca45713fd34e5096c24a" sha1="d78df79985bfdc7c77f7ed0338e86e852bb3f45a" />
 	</game>
 	<game name="Top Gear Rally 2 (USA)" cloneof="Top Gear Rally 2 (Europe)">
 		<description>Top Gear Rally 2 (USA)</description>
-		<release name="Top Gear Rally 2 (USA)" region="USA"/>
-		<rom name="Top Gear Rally 2 (USA).z64" size="12582912" crc="914cf9c4" md5="1fa409fcac007ddeccc4cf439a0d8dae" sha1="fed36b2202b28fc7ff6446ecba541413660d0630"/>
+		<rom name="Top Gear Rally 2 (USA).n64" />
+		<release name="Top Gear Rally 2 (USA)" region="USA" />
+		<rom name="Top Gear Rally 2 (USA).z64" size="12582912" crc="914cf9c4" md5="1fa409fcac007ddeccc4cf439a0d8dae" sha1="fed36b2202b28fc7ff6446ecba541413660d0630" />
 	</game>
 	<game name="Top Gear Rally 2 (Europe) (Beta) (1999-08-31)" cloneof="Top Gear Rally 2 (Europe)">
 		<description>Top Gear Rally 2 (Europe) (Beta) (1999-08-31)</description>
-		<rom name="Top Gear Rally 2 (Europe) (Beta) (1999-08-31).z64" size="16777216" crc="3c77c5d6" md5="c33cd926e1e71f39f7238af7b9e0dc5c" sha1="168dd383edd88a921d25cf7eaeb18b2da29c744a"/>
+		<rom name="Top Gear Rally 2 (Europe) (Beta) (1999-08-31).n64" />
+		<rom name="Top Gear Rally 2 (Europe) (Beta) (1999-08-31).z64" size="16777216" crc="3c77c5d6" md5="c33cd926e1e71f39f7238af7b9e0dc5c" sha1="168dd383edd88a921d25cf7eaeb18b2da29c744a" />
 	</game>
 	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
 		<description>Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)</description>
-		<release name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)" region="EUR"/>
-		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).z64" size="12582912" crc="59574cb9" md5="5f2c9e5e39ab09311d96e6c751184b6b" sha1="92015e5254cbbad1bc668ecb13a4b568e5f55052"/>
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).n64" />
+		<release name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)" region="EUR" />
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe).z64" size="12582912" crc="59574cb9" md5="5f2c9e5e39ab09311d96e6c751184b6b" sha1="92015e5254cbbad1bc668ecb13a4b568e5f55052" />
 	</game>
 	<game name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
 		<description>Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)</description>
-		<release name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)" region="FRA"/>
-		<rom name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France).z64" size="12582912" crc="fb4bea9a" md5="fa0f12c15b3655f9f56888c3249b1ced" sha1="a9f97e22391313095d2c2fbaf81fb33bfa2ba7c6"/>
+		<rom name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France).n64" />
+		<release name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France)" region="FRA" />
+		<rom name="Toy Story 2 - Buzz l'Eclair a la Rescousse! (France).z64" size="12582912" crc="fb4bea9a" md5="fa0f12c15b3655f9f56888c3249b1ced" sha1="a9f97e22391313095d2c2fbaf81fb33bfa2ba7c6" />
 	</game>
 	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
 		<description>Toy Story 2 - Buzz Lightyear to the Rescue! (USA)</description>
-		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA).z64" size="12582912" crc="b9570841" md5="b44e9c2d9d2f2de3af4793b824ccf936" sha1="982ad2e1e44c6662c88a77367bc5df91c51531bf" status="verified"/>
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA).n64" />
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA).z64" size="12582912" crc="b9570841" md5="b44e9c2d9d2f2de3af4793b824ccf936" sha1="982ad2e1e44c6662c88a77367bc5df91c51531bf" status="verified" />
 	</game>
 	<game name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
 		<description>Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)</description>
-		<release name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)" region="USA"/>
-		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).z64" size="12582912" crc="c81f3321" md5="cd61a7fdbd7297733b246204e8360d83" sha1="486dbb2e6068065a7b354a21089e889de0970ec8"/>
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).n64" />
+		<release name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1)" region="USA" />
+		<rom name="Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).z64" size="12582912" crc="c81f3321" md5="cd61a7fdbd7297733b246204e8360d83" sha1="486dbb2e6068065a7b354a21089e889de0970ec8" />
 	</game>
 	<game name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
 		<description>Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany)</description>
-		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany).z64" size="12582912" crc="c5e4c89f" md5="3f40f37b0464dd065067523fb21016dd" sha1="f8fbb100227015be8629243f53d70f29a2a14315"/>
+		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany).n64" />
+		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany).z64" size="12582912" crc="c5e4c89f" md5="3f40f37b0464dd065067523fb21016dd" sha1="f8fbb100227015be8629243f53d70f29a2a14315" />
 	</game>
 	<game name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)" cloneof="Toy Story 2 - Buzz Lightyear to the Rescue! (Europe)">
 		<description>Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)</description>
-		<release name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)" region="GER"/>
-		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1).z64" size="12582912" crc="d1906de4" md5="a4a2b825797e2059b5df60d733461f34" sha1="eae83c07e2e777d8e71a5be6120aed03d7e67782"/>
+		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1).n64" />
+		<release name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1)" region="GER" />
+		<rom name="Toy Story 2 - Captain Buzz Lightyear auf Rettungsmission! (Germany) (Rev 1).z64" size="12582912" crc="d1906de4" md5="a4a2b825797e2059b5df60d733461f34" sha1="eae83c07e2e777d8e71a5be6120aed03d7e67782" />
 	</game>
 	<game name="Transformers - Beast Wars Transmetals (USA)">
 		<description>Transformers - Beast Wars Transmetals (USA)</description>
-		<release name="Transformers - Beast Wars Transmetals (USA)" region="USA"/>
-		<rom name="Transformers - Beast Wars Transmetals (USA).z64" size="16777216" crc="85138b5a" md5="6d38909faa2840fc409afa221489de49" sha1="8d074a0e74e69a45a57a48470383bd5268521cde"/>
+		<rom name="Transformers - Beast Wars Transmetals (USA).n64" />
+		<release name="Transformers - Beast Wars Transmetals (USA)" region="USA" />
+		<rom name="Transformers - Beast Wars Transmetals (USA).z64" size="16777216" crc="85138b5a" md5="6d38909faa2840fc409afa221489de49" sha1="8d074a0e74e69a45a57a48470383bd5268521cde" />
 	</game>
 	<game name="Transformers - Beast Wars Metals 64 (Japan)" cloneof="Transformers - Beast Wars Transmetals (USA)">
 		<description>Transformers - Beast Wars Metals 64 (Japan)</description>
-		<release name="Transformers - Beast Wars Metals 64 (Japan)" region="JPN"/>
-		<rom name="Transformers - Beast Wars Metals 64 (Japan).z64" size="12582912" crc="338f1d45" md5="3d22d5bd7997293612ecdd3046beba13" sha1="a292c7aab0092f39f1292434f3059782715863db"/>
+		<rom name="Transformers - Beast Wars Metals 64 (Japan).n64" />
+		<release name="Transformers - Beast Wars Metals 64 (Japan)" region="JPN" />
+		<rom name="Transformers - Beast Wars Metals 64 (Japan).z64" size="12582912" crc="338f1d45" md5="3d22d5bd7997293612ecdd3046beba13" sha1="a292c7aab0092f39f1292434f3059782715863db" />
 	</game>
 	<game name="Triple Play 2000 (USA)">
 		<description>Triple Play 2000 (USA)</description>
-		<release name="Triple Play 2000 (USA)" region="USA"/>
-		<rom name="Triple Play 2000 (USA).z64" size="16777216" crc="785dd0f8" md5="6f2c37a20e6eccb657fbfc4ba36a34bb" sha1="03619f14149d5a2716dffbe02e21c2a0f5ee24f5"/>
+		<rom name="Triple Play 2000 (USA).n64" />
+		<release name="Triple Play 2000 (USA)" region="USA" />
+		<rom name="Triple Play 2000 (USA).z64" size="16777216" crc="785dd0f8" md5="6f2c37a20e6eccb657fbfc4ba36a34bb" sha1="03619f14149d5a2716dffbe02e21c2a0f5ee24f5" />
 	</game>
 	<game name="Tsumi to Batsu - Hoshi no Keishousha (Japan)">
 		<description>Tsumi to Batsu - Hoshi no Keishousha (Japan)</description>
-		<release name="Tsumi to Batsu - Hoshi no Keishousha (Japan)" region="JPN"/>
-		<rom name="Tsumi to Batsu - Hoshi no Keishousha (Japan).z64" size="33554432" crc="ca2e5e49" md5="a0657bc99e169153fd46aeccfde748f3" sha1="581297b9d5c3a4c33169ae0aae218c742cd9cbcf" status="verified"/>
+		<rom name="Tsumi to Batsu - Hoshi no Keishousha (Japan).n64" />
+		<release name="Tsumi to Batsu - Hoshi no Keishousha (Japan)" region="JPN" />
+		<rom name="Tsumi to Batsu - Hoshi no Keishousha (Japan).z64" size="33554432" crc="ca2e5e49" md5="a0657bc99e169153fd46aeccfde748f3" sha1="581297b9d5c3a4c33169ae0aae218c742cd9cbcf" status="verified" />
 	</game>
 	<game name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue)" cloneof="Tsumi to Batsu - Hoshi no Keishousha (Japan)">
 		<description>Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue)</description>
-		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue).z64" size="33636352" crc="e00db418" md5="5ba3aa2953c47c8b2e615b21e60f2f17" sha1="5b9b53c4d93cf16a73903cfef7fbeb845f10c2e5"/>
+		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue).n64" />
+		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue).z64" size="33636352" crc="e00db418" md5="5ba3aa2953c47c8b2e615b21e60f2f17" sha1="5b9b53c4d93cf16a73903cfef7fbeb845f10c2e5" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (Europe) (Rev 2)</description>
-		<release name="Turok - Dinosaur Hunter (Europe) (Rev 2)" region="EUR"/>
-		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 2).z64" size="8388608" crc="312af877" md5="548fc0e6035b65bc2108255039859934" sha1="0b3cd4fcb03c704e1f8eb3bbd109c82f4be50075"/>
+		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 2).n64" />
+		<release name="Turok - Dinosaur Hunter (Europe) (Rev 2)" region="EUR" />
+		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 2).z64" size="8388608" crc="312af877" md5="548fc0e6035b65bc2108255039859934" sha1="0b3cd4fcb03c704e1f8eb3bbd109c82f4be50075" />
 	</game>
 	<game name="Jikuu Senshi Turok (Japan)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Jikuu Senshi Turok (Japan)</description>
-		<release name="Jikuu Senshi Turok (Japan)" region="JPN"/>
-		<rom name="Jikuu Senshi Turok (Japan).z64" size="8388608" crc="e6bd65d5" md5="7b261247150c431de55ab371e8b46ea8" sha1="726baefd703eb2ca72ec22b4aab8844662f32845"/>
+		<rom name="Jikuu Senshi Turok (Japan).n64" />
+		<release name="Jikuu Senshi Turok (Japan)" region="JPN" />
+		<rom name="Jikuu Senshi Turok (Japan).z64" size="8388608" crc="e6bd65d5" md5="7b261247150c431de55ab371e8b46ea8" sha1="726baefd703eb2ca72ec22b4aab8844662f32845" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (Europe)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (Europe)</description>
-		<rom name="Turok - Dinosaur Hunter (Europe).z64" size="8388608" crc="e8525687" md5="13faa58604597e4edc608070f8e0ae24" sha1="88916d5d2e2470f395ad8f4245d34138ef2d156a"/>
+		<rom name="Turok - Dinosaur Hunter (Europe).n64" />
+		<rom name="Turok - Dinosaur Hunter (Europe).z64" size="8388608" crc="e8525687" md5="13faa58604597e4edc608070f8e0ae24" sha1="88916d5d2e2470f395ad8f4245d34138ef2d156a" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (Europe) (Rev 1)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (Europe) (Rev 1)</description>
-		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 1).z64" size="8388608" crc="c2353283" md5="992ba72f4a1e9c51934ff345cdd0d90c" sha1="90809f3d30bf085f5eacbd12136672216aa7b88b"/>
+		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 1).n64" />
+		<rom name="Turok - Dinosaur Hunter (Europe) (Rev 1).z64" size="8388608" crc="c2353283" md5="992ba72f4a1e9c51934ff345cdd0d90c" sha1="90809f3d30bf085f5eacbd12136672216aa7b88b" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (Germany)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (Germany)</description>
-		<rom name="Turok - Dinosaur Hunter (Germany).z64" size="8388608" crc="64631ff9" md5="0c0bfd1038eda4f5c958dc362cdff2d6" sha1="698760178edfbb8293a536d4960aa9566f1a1871"/>
+		<rom name="Turok - Dinosaur Hunter (Germany).n64" />
+		<rom name="Turok - Dinosaur Hunter (Germany).z64" size="8388608" crc="64631ff9" md5="0c0bfd1038eda4f5c958dc362cdff2d6" sha1="698760178edfbb8293a536d4960aa9566f1a1871" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (USA)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (USA)</description>
-		<rom name="Turok - Dinosaur Hunter (USA).z64" size="8388608" crc="26c4f597" md5="ae5107efdd3c210e1edd4acd9b3cac31" sha1="40fb0250c095740031278fb1f82b9937a3895e01"/>
+		<rom name="Turok - Dinosaur Hunter (USA).n64" />
+		<rom name="Turok - Dinosaur Hunter (USA).z64" size="8388608" crc="26c4f597" md5="ae5107efdd3c210e1edd4acd9b3cac31" sha1="40fb0250c095740031278fb1f82b9937a3895e01" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (USA) (Rev 1)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (USA) (Rev 1)</description>
-		<rom name="Turok - Dinosaur Hunter (USA) (Rev 1).z64" size="8388608" crc="7f2476f4" md5="37260287d59fe4ec6049c1d22b5614e6" sha1="6e67dcb49f700f01b18b7b4fd9aeb6bd911f1850"/>
+		<rom name="Turok - Dinosaur Hunter (USA) (Rev 1).n64" />
+		<rom name="Turok - Dinosaur Hunter (USA) (Rev 1).z64" size="8388608" crc="7f2476f4" md5="37260287d59fe4ec6049c1d22b5614e6" sha1="6e67dcb49f700f01b18b7b4fd9aeb6bd911f1850" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (USA) (Rev 2)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (USA) (Rev 2)</description>
-		<release name="Turok - Dinosaur Hunter (USA) (Rev 2)" region="USA"/>
-		<rom name="Turok - Dinosaur Hunter (USA) (Rev 2).z64" size="8388608" crc="8c3bbc00" md5="039875b92c0e4fef9797ec1744877b17" sha1="c7ed00dee20f4235823bcf50d32fa5d6862d6fce"/>
+		<rom name="Turok - Dinosaur Hunter (USA) (Rev 2).n64" />
+		<release name="Turok - Dinosaur Hunter (USA) (Rev 2)" region="USA" />
+		<rom name="Turok - Dinosaur Hunter (USA) (Rev 2).z64" size="8388608" crc="8c3bbc00" md5="039875b92c0e4fef9797ec1744877b17" sha1="c7ed00dee20f4235823bcf50d32fa5d6862d6fce" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (Germany) (Rev 1)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (Germany) (Rev 1)</description>
-		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 1).z64" size="8388608" crc="2765dd8f" md5="388440013641887d85b791cf01729fa8" sha1="803bbc3cb2663aa24a88ec277d93c8ddd4ec34e3"/>
+		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 1).n64" />
+		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 1).z64" size="8388608" crc="2765dd8f" md5="388440013641887d85b791cf01729fa8" sha1="803bbc3cb2663aa24a88ec277d93c8ddd4ec34e3" />
 	</game>
 	<game name="Turok - Dinosaur Hunter (Germany) (Rev 2)" cloneof="Turok - Dinosaur Hunter (Europe) (Rev 2)">
 		<description>Turok - Dinosaur Hunter (Germany) (Rev 2)</description>
-		<release name="Turok - Dinosaur Hunter (Germany) (Rev 2)" region="GER"/>
-		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 2).z64" size="8388608" crc="72ca307a" md5="f0f687b449a9f4b0bff08104c35ea08c" sha1="0ad61791fb8fb1e0a3bd2a286f32e1967dc79309" status="verified"/>
+		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 2).n64" />
+		<release name="Turok - Dinosaur Hunter (Germany) (Rev 2)" region="GER" />
+		<rom name="Turok - Dinosaur Hunter (Germany) (Rev 2).z64" size="8388608" crc="72ca307a" md5="f0f687b449a9f4b0bff08104c35ea08c" sha1="0ad61791fb8fb1e0a3bd2a286f32e1967dc79309" status="verified" />
 	</game>
 	<game name="Turok - Rage Wars (Europe)">
 		<description>Turok - Rage Wars (Europe)</description>
-		<release name="Turok - Rage Wars (Europe)" region="EUR"/>
-		<rom name="Turok - Rage Wars (Europe).z64" size="8388608" crc="82b1e116" md5="dba166a42710f40dc78dc52eb37b0be6" sha1="46b474fac79a4b21535bb6c78ce3039a2c202359" status="verified"/>
+		<rom name="Turok - Rage Wars (Europe).n64" />
+		<release name="Turok - Rage Wars (Europe)" region="EUR" />
+		<rom name="Turok - Rage Wars (Europe).z64" size="8388608" crc="82b1e116" md5="dba166a42710f40dc78dc52eb37b0be6" sha1="46b474fac79a4b21535bb6c78ce3039a2c202359" status="verified" />
 	</game>
 	<game name="Turok - Legenden des Verlorenen Landes (Germany)" cloneof="Turok - Rage Wars (Europe)">
 		<description>Turok - Legenden des Verlorenen Landes (Germany)</description>
-		<release name="Turok - Legenden des Verlorenen Landes (Germany)" region="GER"/>
-		<rom name="Turok - Legenden des Verlorenen Landes (Germany).z64" size="8388608" crc="b937874f" md5="72a6aa28608ee93a1cb6feb0a5f4c28c" sha1="a6daacbd0e7f77c73208cf494aefc24703060b17" status="verified"/>
+		<rom name="Turok - Legenden des Verlorenen Landes (Germany).n64" />
+		<release name="Turok - Legenden des Verlorenen Landes (Germany)" region="GER" />
+		<rom name="Turok - Legenden des Verlorenen Landes (Germany).z64" size="8388608" crc="b937874f" md5="72a6aa28608ee93a1cb6feb0a5f4c28c" sha1="a6daacbd0e7f77c73208cf494aefc24703060b17" status="verified" />
 	</game>
 	<game name="Turok - Rage Wars (Europe) (En,Fr,It)" cloneof="Turok - Rage Wars (Europe)">
 		<description>Turok - Rage Wars (Europe) (En,Fr,It)</description>
-		<release name="Turok - Rage Wars (Europe) (En,Fr,It)" region="FRA"/>
-		<release name="Turok - Rage Wars (Europe) (En,Fr,It)" region="ITA"/>
-		<rom name="Turok - Rage Wars (Europe) (En,Fr,It).z64" size="8388608" crc="f4a2862b" md5="241cf94bed487fff62ffb7b846da46ab" sha1="0b54615930a55675955eef8d8a22f1dfc34d2b44"/>
+		<rom name="Turok - Rage Wars (Europe) (En,Fr,It).n64" />
+		<release name="Turok - Rage Wars (Europe) (En,Fr,It)" region="FRA" />
+		<release name="Turok - Rage Wars (Europe) (En,Fr,It)" region="ITA" />
+		<rom name="Turok - Rage Wars (Europe) (En,Fr,It).z64" size="8388608" crc="f4a2862b" md5="241cf94bed487fff62ffb7b846da46ab" sha1="0b54615930a55675955eef8d8a22f1dfc34d2b44" />
 	</game>
 	<game name="Turok - Rage Wars (USA)" cloneof="Turok - Rage Wars (Europe)">
 		<description>Turok - Rage Wars (USA)</description>
-		<rom name="Turok - Rage Wars (USA).z64" size="8388608" crc="422872a2" md5="cf5b28578fd62fa1ff8690079f5d68f5" sha1="9f8cb190831945f6f707aa8c2b20e04fa4276795"/>
+		<rom name="Turok - Rage Wars (USA).n64" />
+		<rom name="Turok - Rage Wars (USA).z64" size="8388608" crc="422872a2" md5="cf5b28578fd62fa1ff8690079f5d68f5" sha1="9f8cb190831945f6f707aa8c2b20e04fa4276795" />
 	</game>
 	<game name="Turok - Rage Wars (USA) (Rev 1)" cloneof="Turok - Rage Wars (Europe)">
 		<description>Turok - Rage Wars (USA) (Rev 1)</description>
-		<release name="Turok - Rage Wars (USA) (Rev 1)" region="USA"/>
-		<rom name="Turok - Rage Wars (USA) (Rev 1).z64" size="8388608" crc="e28756f4" md5="9b2ffe72080b03a5f92eb87ea849cac4" sha1="037fb397cee2669048ed6b762a64698de4a4d88a"/>
+		<rom name="Turok - Rage Wars (USA) (Rev 1).n64" />
+		<release name="Turok - Rage Wars (USA) (Rev 1)" region="USA" />
+		<rom name="Turok - Rage Wars (USA) (Rev 1).z64" size="8388608" crc="e28756f4" md5="9b2ffe72080b03a5f92eb87ea849cac4" sha1="037fb397cee2669048ed6b762a64698de4a4d88a" />
 	</game>
 	<game name="Turok 2 - Seeds of Evil (Europe)">
 		<description>Turok 2 - Seeds of Evil (Europe)</description>
-		<release name="Turok 2 - Seeds of Evil (Europe)" region="EUR"/>
-		<rom name="Turok 2 - Seeds of Evil (Europe).z64" size="33554432" crc="e2d34bfe" md5="e5a39521fa954eb97b96ac2154a5fd7a" sha1="1a0b36d9fd95db483c846d0d604d2549d6ce4cc3"/>
+		<rom name="Turok 2 - Seeds of Evil (Europe).n64" />
+		<release name="Turok 2 - Seeds of Evil (Europe)" region="EUR" />
+		<rom name="Turok 2 - Seeds of Evil (Europe).z64" size="33554432" crc="e2d34bfe" md5="e5a39521fa954eb97b96ac2154a5fd7a" sha1="1a0b36d9fd95db483c846d0d604d2549d6ce4cc3" />
 	</game>
 	<game name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" cloneof="Turok 2 - Seeds of Evil (Europe)">
 		<description>Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)</description>
-		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="FRA"/>
-		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="ITA"/>
-		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="SPA"/>
-		<rom name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It).z64" size="33554432" crc="1febde32" md5="144b10a484a22367fd2679529dbd2fed" sha1="fb20f8e540c01d321bf805922b05e7a448521e1e" status="verified"/>
+		<rom name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It).n64" />
+		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="FRA" />
+		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="ITA" />
+		<release name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It)" region="SPA" />
+		<rom name="Turok 2 - Seeds of Evil (Europe) (En,Fr,Es,It).z64" size="33554432" crc="1febde32" md5="144b10a484a22367fd2679529dbd2fed" sha1="fb20f8e540c01d321bf805922b05e7a448521e1e" status="verified" />
 	</game>
 	<game name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)" cloneof="Turok 2 - Seeds of Evil (Europe)">
 		<description>Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk)</description>
-		<rom name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk).z64" size="12582912" crc="4e29b234" md5="ce72237707f481cfe97fde330c2afcd6" sha1="bfc04b6c5c300d39bbabe0b42227aef45cc41d3f"/>
+		<rom name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk).n64" />
+		<rom name="Turok 2 - Seeds of Evil (Europe) (Demo) (Kiosk).z64" size="12582912" crc="4e29b234" md5="ce72237707f481cfe97fde330c2afcd6" sha1="bfc04b6c5c300d39bbabe0b42227aef45cc41d3f" />
 	</game>
 	<game name="Turok 2 - Seeds of Evil (Germany)" cloneof="Turok 2 - Seeds of Evil (Europe)">
 		<description>Turok 2 - Seeds of Evil (Germany)</description>
-		<release name="Turok 2 - Seeds of Evil (Germany)" region="GER"/>
-		<rom name="Turok 2 - Seeds of Evil (Germany).z64" size="33554432" crc="c07877b6" md5="b932116c967795076b5c112841ab4427" sha1="d09353c551f5309f29b6ff964b583a54e3d63c5f"/>
+		<rom name="Turok 2 - Seeds of Evil (Germany).n64" />
+		<release name="Turok 2 - Seeds of Evil (Germany)" region="GER" />
+		<rom name="Turok 2 - Seeds of Evil (Germany).z64" size="33554432" crc="c07877b6" md5="b932116c967795076b5c112841ab4427" sha1="d09353c551f5309f29b6ff964b583a54e3d63c5f" />
 	</game>
 	<game name="Turok 2 - Seeds of Evil (USA)" cloneof="Turok 2 - Seeds of Evil (Europe)">
 		<description>Turok 2 - Seeds of Evil (USA)</description>
-		<rom name="Turok 2 - Seeds of Evil (USA).z64" size="33554432" crc="ff5e7636" md5="fad4da8e17ce12f68cdf29180cdd4a90" sha1="fb0400f21e3f043939ab56500c7b12a3231006f1" status="verified"/>
+		<rom name="Turok 2 - Seeds of Evil (USA).n64" />
+		<rom name="Turok 2 - Seeds of Evil (USA).z64" size="33554432" crc="ff5e7636" md5="fad4da8e17ce12f68cdf29180cdd4a90" sha1="fb0400f21e3f043939ab56500c7b12a3231006f1" status="verified" />
 	</game>
 	<game name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)" cloneof="Turok 2 - Seeds of Evil (Europe)">
 		<description>Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk)</description>
-		<rom name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk).z64" size="12582912" crc="8d5b9bd0" md5="3bd42f6aec477c056e1afebb3515495c" sha1="68d1c5b79cc243804fce3c993d9c93a10a58cab8"/>
+		<rom name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk).n64" />
+		<rom name="Turok 2 - Seeds of Evil (USA) (Demo) (Kiosk).z64" size="12582912" crc="8d5b9bd0" md5="3bd42f6aec477c056e1afebb3515495c" sha1="68d1c5b79cc243804fce3c993d9c93a10a58cab8" />
 	</game>
 	<game name="Turok 2 - Seeds of Evil (USA) (Rev 1)" cloneof="Turok 2 - Seeds of Evil (Europe)">
 		<description>Turok 2 - Seeds of Evil (USA) (Rev 1)</description>
-		<release name="Turok 2 - Seeds of Evil (USA) (Rev 1)" region="USA"/>
-		<rom name="Turok 2 - Seeds of Evil (USA) (Rev 1).z64" size="33554432" crc="57f1fbf5" md5="166221365db70d446c4206083d422dd1" sha1="a86af6c2ac9f6d837181f07c0a27f7ee59e7df68"/>
+		<rom name="Turok 2 - Seeds of Evil (USA) (Rev 1).n64" />
+		<release name="Turok 2 - Seeds of Evil (USA) (Rev 1)" region="USA" />
+		<rom name="Turok 2 - Seeds of Evil (USA) (Rev 1).z64" size="33554432" crc="57f1fbf5" md5="166221365db70d446c4206083d422dd1" sha1="a86af6c2ac9f6d837181f07c0a27f7ee59e7df68" />
 	</game>
 	<game name="Violence Killer - Turok New Generation (Japan)" cloneof="Turok 2 - Seeds of Evil (Europe)">
 		<description>Violence Killer - Turok New Generation (Japan)</description>
-		<release name="Violence Killer - Turok New Generation (Japan)" region="JPN"/>
-		<rom name="Violence Killer - Turok New Generation (Japan).z64" size="33554432" crc="097f139f" md5="c3005d76af42e929e5c67421a19f8235" sha1="2dd9771030500a4e4512e76209267e358a4a0ae6"/>
+		<rom name="Violence Killer - Turok New Generation (Japan).n64" />
+		<release name="Violence Killer - Turok New Generation (Japan)" region="JPN" />
+		<rom name="Violence Killer - Turok New Generation (Japan).z64" size="33554432" crc="097f139f" md5="c3005d76af42e929e5c67421a19f8235" sha1="2dd9771030500a4e4512e76209267e358a4a0ae6" />
 	</game>
 	<game name="Turok 3 - Shadow of Oblivion (Europe)">
 		<description>Turok 3 - Shadow of Oblivion (Europe)</description>
-		<release name="Turok 3 - Shadow of Oblivion (Europe)" region="EUR"/>
-		<rom name="Turok 3 - Shadow of Oblivion (Europe).z64" size="33554432" crc="98d3114c" md5="279ec83bd60a3cce69a1db22b0a5c318" sha1="f3fdc0b58d0ae8111f033c5f61c364e6a9425f91" status="verified"/>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe).n64" />
+		<release name="Turok 3 - Shadow of Oblivion (Europe)" region="EUR" />
+		<rom name="Turok 3 - Shadow of Oblivion (Europe).z64" size="33554432" crc="98d3114c" md5="279ec83bd60a3cce69a1db22b0a5c318" sha1="f3fdc0b58d0ae8111f033c5f61c364e6a9425f91" status="verified" />
 	</game>
 	<game name="Turok 3 - Shadow of Oblivion (USA)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
 		<description>Turok 3 - Shadow of Oblivion (USA)</description>
-		<release name="Turok 3 - Shadow of Oblivion (USA)" region="USA"/>
-		<rom name="Turok 3 - Shadow of Oblivion (USA).z64" size="33554432" crc="cb297224" md5="1211c556d77b169d81a666a9661e1777" sha1="a2e0a28dc0d3a48c7c02cb9e4c4b38fe04b2d436"/>
+		<rom name="Turok 3 - Shadow of Oblivion (USA).n64" />
+		<release name="Turok 3 - Shadow of Oblivion (USA)" region="USA" />
+		<rom name="Turok 3 - Shadow of Oblivion (USA).z64" size="33554432" crc="cb297224" md5="1211c556d77b169d81a666a9661e1777" sha1="a2e0a28dc0d3a48c7c02cb9e4c4b38fe04b2d436" />
 	</game>
 	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
 		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10)</description>
-		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10).z64" size="33554432" crc="3cd1f9af" md5="c38acbae773cc3845ea354421e171998" sha1="22bd7985055c08da0d9885772fe65c2f78a5f9ac"/>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10).n64" />
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-07-10).z64" size="33554432" crc="3cd1f9af" md5="c38acbae773cc3845ea354421e171998" sha1="22bd7985055c08da0d9885772fe65c2f78a5f9ac" />
 	</game>
 	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
 		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31)</description>
-		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31).z64" size="33554432" crc="66e63bbc" md5="03d17aa3dc7663502017d3cc5a19aa8b" sha1="df10c5d421aeab2af438648588600839cd82b5e0"/>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31).n64" />
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-05-31).z64" size="33554432" crc="66e63bbc" md5="03d17aa3dc7663502017d3cc5a19aa8b" sha1="df10c5d421aeab2af438648588600839cd82b5e0" />
 	</game>
 	<game name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
 		<description>Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06)</description>
-		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06).z64" size="33554432" crc="7946b05a" md5="69ce88c46a7c829c6f54004de93efcef" sha1="08ec9170b67afe259104977def70fbcc706729f9"/>
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06).n64" />
+		<rom name="Turok 3 - Shadow of Oblivion (Europe) (Beta) (2000-06-06).z64" size="33554432" crc="7946b05a" md5="69ce88c46a7c829c6f54004de93efcef" sha1="08ec9170b67afe259104977def70fbcc706729f9" />
 	</game>
 	<game name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
 		<description>Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21)</description>
-		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21).z64" size="33554432" crc="667b553d" md5="9865a336b00e95601ed05a43a2422c23" sha1="0bac8aa24d636f1b8e5a65a7fd95b9c282c3e495"/>
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21).n64" />
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-07-21).z64" size="33554432" crc="667b553d" md5="9865a336b00e95601ed05a43a2422c23" sha1="0bac8aa24d636f1b8e5a65a7fd95b9c282c3e495" />
 	</game>
 	<game name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26)" cloneof="Turok 3 - Shadow of Oblivion (Europe)">
 		<description>Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26)</description>
-		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26).z64" size="33554432" crc="58c4c0ab" md5="f5738c4b804b0260b99ad39d49ddd43c" sha1="f3cddfc1bfce0348c41217f9f4e053f8ab3dd4ca"/>
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26).n64" />
+		<rom name="Turok 3 - Shadow of Oblivion (USA) (Beta) (2000-06-26).z64" size="33554432" crc="58c4c0ab" md5="f5738c4b804b0260b99ad39d49ddd43c" sha1="f3cddfc1bfce0348c41217f9f4e053f8ab3dd4ca" />
 	</game>
 	<game name="Twisted Edge - Snowboarding (Europe)">
 		<description>Twisted Edge - Snowboarding (Europe)</description>
-		<release name="Twisted Edge - Snowboarding (Europe)" region="EUR"/>
-		<rom name="Twisted Edge - Snowboarding (Europe).z64" size="12582912" crc="bf0c1291" md5="420c9fdbae15767c5e584070209ff253" sha1="de12629f2538f80e25901decafc7ccc18c7d481c"/>
+		<rom name="Twisted Edge - Snowboarding (Europe).n64" />
+		<release name="Twisted Edge - Snowboarding (Europe)" region="EUR" />
+		<rom name="Twisted Edge - Snowboarding (Europe).z64" size="12582912" crc="bf0c1291" md5="420c9fdbae15767c5e584070209ff253" sha1="de12629f2538f80e25901decafc7ccc18c7d481c" />
 	</game>
 	<game name="King Hill 64 - Extreme Snowboarding (Japan)" cloneof="Twisted Edge - Snowboarding (Europe)">
 		<description>King Hill 64 - Extreme Snowboarding (Japan)</description>
-		<release name="King Hill 64 - Extreme Snowboarding (Japan)" region="JPN"/>
-		<rom name="King Hill 64 - Extreme Snowboarding (Japan).z64" size="12582912" crc="f120cc52" md5="cca4e87ec206b5b65aeab9531c0f275b" sha1="10924ab3c8909b18dae64fede304af2a08d7ffe1"/>
+		<rom name="King Hill 64 - Extreme Snowboarding (Japan).n64" />
+		<release name="King Hill 64 - Extreme Snowboarding (Japan)" region="JPN" />
+		<rom name="King Hill 64 - Extreme Snowboarding (Japan).z64" size="12582912" crc="f120cc52" md5="cca4e87ec206b5b65aeab9531c0f275b" sha1="10924ab3c8909b18dae64fede304af2a08d7ffe1" />
 	</game>
 	<game name="Twisted Edge - Extreme Snowboarding (USA)" cloneof="Twisted Edge - Snowboarding (Europe)">
 		<description>Twisted Edge - Extreme Snowboarding (USA)</description>
-		<release name="Twisted Edge - Extreme Snowboarding (USA)" region="USA"/>
-		<rom name="Twisted Edge - Extreme Snowboarding (USA).z64" size="12582912" crc="bfbcc038" md5="9df6c2c97fa34a978ef3cb77631536fe" sha1="8888228ad423df143c2c820130fb0658df64c930"/>
+		<rom name="Twisted Edge - Extreme Snowboarding (USA).n64" />
+		<release name="Twisted Edge - Extreme Snowboarding (USA)" region="USA" />
+		<rom name="Twisted Edge - Extreme Snowboarding (USA).z64" size="12582912" crc="bfbcc038" md5="9df6c2c97fa34a978ef3cb77631536fe" sha1="8888228ad423df143c2c820130fb0658df64c930" />
 	</game>
 	<game name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)">
 		<description>Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)</description>
-		<release name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)" region="JPN"/>
-		<rom name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan).z64" size="8388608" crc="50cbe8a6" md5="ffeb5c1a85babbbe60f2feba2b35c893" sha1="557d2dadebea77fbc7342a881311fca5c5b35b39"/>
+		<rom name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan).n64" />
+		<release name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan)" region="JPN" />
+		<rom name="Utchan Nanchan no Hono no Challenger - Denryuu Ira Ira Bou (Japan).z64" size="8388608" crc="50cbe8a6" md5="ffeb5c1a85babbbe60f2feba2b35c893" sha1="557d2dadebea77fbc7342a881311fca5c5b35b39" />
 	</game>
 	<game name="V-Rally Edition 99 (Europe) (En,Fr,De)">
 		<description>V-Rally Edition 99 (Europe) (En,Fr,De)</description>
-		<release name="V-Rally Edition 99 (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="V-Rally Edition 99 (Europe) (En,Fr,De).z64" size="12582912" crc="0735d7a2" md5="dcac12eb5832d4a489188330eb9ec387" sha1="da3f262dfb86cff1376c9a1aa081212e5a7aad64" status="verified"/>
+		<rom name="V-Rally Edition 99 (Europe) (En,Fr,De).n64" />
+		<release name="V-Rally Edition 99 (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="V-Rally Edition 99 (Europe) (En,Fr,De).z64" size="12582912" crc="0735d7a2" md5="dcac12eb5832d4a489188330eb9ec387" sha1="da3f262dfb86cff1376c9a1aa081212e5a7aad64" status="verified" />
 	</game>
 	<game name="V-Rally Edition 99 (Japan)" cloneof="V-Rally Edition 99 (Europe) (En,Fr,De)">
 		<description>V-Rally Edition 99 (Japan)</description>
-		<release name="V-Rally Edition 99 (Japan)" region="JPN"/>
-		<rom name="V-Rally Edition 99 (Japan).z64" size="8388608" crc="02475a01" md5="8541d7a8737be09c52d4ec1274de2a91" sha1="b23adb839ac7bb51cc080ff531e42ab0bc86dd13"/>
+		<rom name="V-Rally Edition 99 (Japan).n64" />
+		<release name="V-Rally Edition 99 (Japan)" region="JPN" />
+		<rom name="V-Rally Edition 99 (Japan).z64" size="8388608" crc="02475a01" md5="8541d7a8737be09c52d4ec1274de2a91" sha1="b23adb839ac7bb51cc080ff531e42ab0bc86dd13" />
 	</game>
 	<game name="V-Rally Edition 99 (USA)" cloneof="V-Rally Edition 99 (Europe) (En,Fr,De)">
 		<description>V-Rally Edition 99 (USA)</description>
-		<release name="V-Rally Edition 99 (USA)" region="USA"/>
-		<rom name="V-Rally Edition 99 (USA).z64" size="8388608" crc="4803075e" md5="0c3448a9d85300acb9c5556f27a84b23" sha1="891c64c871993c043bf47745fcce16cd7e6aa76f"/>
+		<rom name="V-Rally Edition 99 (USA).n64" />
+		<release name="V-Rally Edition 99 (USA)" region="USA" />
+		<rom name="V-Rally Edition 99 (USA).z64" size="8388608" crc="4803075e" md5="0c3448a9d85300acb9c5556f27a84b23" sha1="891c64c871993c043bf47745fcce16cd7e6aa76f" />
 	</game>
 	<game name="Viewpoint 2064 (Japan) (Proto)">
 		<description>Viewpoint 2064 (Japan) (Proto)</description>
-		<release name="Viewpoint 2064 (Japan) (Proto)" region="JPN"/>
-		<rom name="Viewpoint 2064 (Japan) (Proto).z64" size="16777216" crc="93a630cb" md5="b7425d12935662e480268b48055f2e6c" sha1="defacaf6dbd22962ec0184849ed4a4c53a147454"/>
+		<rom name="Viewpoint 2064 (Japan) (Proto).n64" />
+		<release name="Viewpoint 2064 (Japan) (Proto)" region="JPN" />
+		<rom name="Viewpoint 2064 (Japan) (Proto).z64" size="16777216" crc="93a630cb" md5="b7425d12935662e480268b48055f2e6c" sha1="defacaf6dbd22962ec0184849ed4a4c53a147454" />
 	</game>
 	<game name="Vigilante 8 (Europe)">
 		<description>Vigilante 8 (Europe)</description>
-		<release name="Vigilante 8 (Europe)" region="EUR"/>
-		<rom name="Vigilante 8 (Europe).z64" size="8388608" crc="0e9bb6d6" md5="df011e19f41b1b19c21f1e77e13780b7" sha1="37603e7afba0d0ebebe64782efd135b096d4cadc" status="verified"/>
+		<rom name="Vigilante 8 (Europe).n64" />
+		<release name="Vigilante 8 (Europe)" region="EUR" />
+		<rom name="Vigilante 8 (Europe).z64" size="8388608" crc="0e9bb6d6" md5="df011e19f41b1b19c21f1e77e13780b7" sha1="37603e7afba0d0ebebe64782efd135b096d4cadc" status="verified" />
 	</game>
 	<game name="Vigilante 8 (France)" cloneof="Vigilante 8 (Europe)">
 		<description>Vigilante 8 (France)</description>
-		<release name="Vigilante 8 (France)" region="FRA"/>
-		<rom name="Vigilante 8 (France).z64" size="8388608" crc="11d23ab3" md5="ff9f85c50982dbdba9853a8915321d31" sha1="16688eac55153332d49a62696294f38d6c1afefa"/>
+		<rom name="Vigilante 8 (France).n64" />
+		<release name="Vigilante 8 (France)" region="FRA" />
+		<rom name="Vigilante 8 (France).z64" size="8388608" crc="11d23ab3" md5="ff9f85c50982dbdba9853a8915321d31" sha1="16688eac55153332d49a62696294f38d6c1afefa" />
 	</game>
 	<game name="Vigilante 8 (Germany)" cloneof="Vigilante 8 (Europe)">
 		<description>Vigilante 8 (Germany)</description>
-		<release name="Vigilante 8 (Germany)" region="GER"/>
-		<rom name="Vigilante 8 (Germany).z64" size="8388608" crc="17f63c3f" md5="37b430ee16167831c6c6292994f93277" sha1="39e4fc6d553d370efc0710de2e99d8bc8a020a7c"/>
+		<rom name="Vigilante 8 (Germany).n64" />
+		<release name="Vigilante 8 (Germany)" region="GER" />
+		<rom name="Vigilante 8 (Germany).z64" size="8388608" crc="17f63c3f" md5="37b430ee16167831c6c6292994f93277" sha1="39e4fc6d553d370efc0710de2e99d8bc8a020a7c" />
 	</game>
 	<game name="Vigilante 8 (USA)" cloneof="Vigilante 8 (Europe)">
 		<description>Vigilante 8 (USA)</description>
-		<release name="Vigilante 8 (USA)" region="USA"/>
-		<rom name="Vigilante 8 (USA).z64" size="8388608" crc="330b73e6" md5="d616adf6441acbbd0e6bef023a8f6031" sha1="22b7d7b4f1722efd52d3c8beba8cf5d07340569b"/>
+		<rom name="Vigilante 8 (USA).n64" />
+		<release name="Vigilante 8 (USA)" region="USA" />
+		<rom name="Vigilante 8 (USA).z64" size="8388608" crc="330b73e6" md5="d616adf6441acbbd0e6bef023a8f6031" sha1="22b7d7b4f1722efd52d3c8beba8cf5d07340569b" />
 	</game>
 	<game name="Vigilante 8 - 2nd Offense (Europe)">
 		<description>Vigilante 8 - 2nd Offense (Europe)</description>
-		<release name="Vigilante 8 - 2nd Offense (Europe)" region="EUR"/>
-		<rom name="Vigilante 8 - 2nd Offense (Europe).z64" size="12582912" crc="691aa971" md5="47661ef1964524b6319b759913f08b62" sha1="a2841a8b4c29481d05b52227442c0e419c574e2d"/>
+		<rom name="Vigilante 8 - 2nd Offense (Europe).n64" />
+		<release name="Vigilante 8 - 2nd Offense (Europe)" region="EUR" />
+		<rom name="Vigilante 8 - 2nd Offense (Europe).z64" size="12582912" crc="691aa971" md5="47661ef1964524b6319b759913f08b62" sha1="a2841a8b4c29481d05b52227442c0e419c574e2d" />
 	</game>
 	<game name="Vigilante 8 - 2nd Offense (USA)" cloneof="Vigilante 8 - 2nd Offense (Europe)">
 		<description>Vigilante 8 - 2nd Offense (USA)</description>
-		<release name="Vigilante 8 - 2nd Offense (USA)" region="USA"/>
-		<rom name="Vigilante 8 - 2nd Offense (USA).z64" size="12582912" crc="0293203f" md5="60cdf7445fad2aba05c958f46691501b" sha1="9634247ca456c82a65bb33f552db036ba6f33f79"/>
+		<rom name="Vigilante 8 - 2nd Offense (USA).n64" />
+		<release name="Vigilante 8 - 2nd Offense (USA)" region="USA" />
+		<rom name="Vigilante 8 - 2nd Offense (USA).z64" size="12582912" crc="0293203f" md5="60cdf7445fad2aba05c958f46691501b" sha1="9634247ca456c82a65bb33f552db036ba6f33f79" />
 	</game>
 	<game name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl).z64" size="4194304" crc="aae15243" md5="e790be1a5b883beba44bc0d2666c65f5" sha1="0899017b0a5231ecbb084abff2303d9c25342828"/>
+		<rom name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl).z64" size="4194304" crc="aae15243" md5="e790be1a5b883beba44bc0d2666c65f5" sha1="0899017b0a5231ecbb084abff2303d9c25342828" />
 	</game>
 	<game name="Virtual Chess 64 (USA) (En,Fr,Es)" cloneof="Virtual Chess 64 (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Virtual Chess 64 (USA) (En,Fr,Es)</description>
-		<release name="Virtual Chess 64 (USA) (En,Fr,Es)" region="USA"/>
-		<rom name="Virtual Chess 64 (USA) (En,Fr,Es).z64" size="4194304" crc="620de0b7" md5="f8a35270279b277586d7210fd15134ff" sha1="b3f84937813eb76f94dfcf1dbea69b11bdbf7e4f"/>
+		<rom name="Virtual Chess 64 (USA) (En,Fr,Es).n64" />
+		<release name="Virtual Chess 64 (USA) (En,Fr,Es)" region="USA" />
+		<rom name="Virtual Chess 64 (USA) (En,Fr,Es).z64" size="4194304" crc="620de0b7" md5="f8a35270279b277586d7210fd15134ff" sha1="b3f84937813eb76f94dfcf1dbea69b11bdbf7e4f" />
 	</game>
 	<game name="Virtual Pool 64 (Europe)">
 		<description>Virtual Pool 64 (Europe)</description>
-		<release name="Virtual Pool 64 (Europe)" region="EUR"/>
-		<rom name="Virtual Pool 64 (Europe).z64" size="4194304" crc="9a6fb0bc" md5="ab68fb43f012c1a45af1dbcc8e8c109c" sha1="70bd9ece445d6b66ef65afc19b5ea9df5a75dba4"/>
+		<rom name="Virtual Pool 64 (Europe).n64" />
+		<release name="Virtual Pool 64 (Europe)" region="EUR" />
+		<rom name="Virtual Pool 64 (Europe).z64" size="4194304" crc="9a6fb0bc" md5="ab68fb43f012c1a45af1dbcc8e8c109c" sha1="70bd9ece445d6b66ef65afc19b5ea9df5a75dba4" />
 	</game>
 	<game name="Virtual Pool 64 (USA)" cloneof="Virtual Pool 64 (Europe)">
 		<description>Virtual Pool 64 (USA)</description>
-		<release name="Virtual Pool 64 (USA)" region="USA"/>
-		<rom name="Virtual Pool 64 (USA).z64" size="4194304" crc="ad628ded" md5="6d3db67319da339df4b68ad0084904d5" sha1="4fed63f7ee35f4d3941f0d61175057481d91d2e0"/>
+		<rom name="Virtual Pool 64 (USA).n64" />
+		<release name="Virtual Pool 64 (USA)" region="USA" />
+		<rom name="Virtual Pool 64 (USA).z64" size="4194304" crc="ad628ded" md5="6d3db67319da339df4b68ad0084904d5" sha1="4fed63f7ee35f4d3941f0d61175057481d91d2e0" />
 	</game>
 	<game name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan)">
 		<description>Virtual Pro Wrestling 2 - Oudou Keishou (Japan)</description>
-		<release name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan)" region="JPN"/>
-		<rom name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan).z64" size="33554432" crc="f620835d" md5="90002501777e3237739f5ed9b0e349e2" sha1="82dd25a044689eab57ab362fe10c0da6388c217a"/>
+		<rom name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan).n64" />
+		<release name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan)" region="JPN" />
+		<rom name="Virtual Pro Wrestling 2 - Oudou Keishou (Japan).z64" size="33554432" crc="f620835d" md5="90002501777e3237739f5ed9b0e349e2" sha1="82dd25a044689eab57ab362fe10c0da6388c217a" />
 	</game>
 	<game name="Virtual Pro Wrestling 64 (Japan)">
 		<description>Virtual Pro Wrestling 64 (Japan)</description>
-		<release name="Virtual Pro Wrestling 64 (Japan)" region="JPN"/>
-		<rom name="Virtual Pro Wrestling 64 (Japan).z64" size="16777216" crc="e6651803" md5="5e6202200af40a8f026780edfe1e15d0" sha1="f9e9fa2ed819c3a39db5cb6afeca186f021db5ed"/>
+		<rom name="Virtual Pro Wrestling 64 (Japan).n64" />
+		<release name="Virtual Pro Wrestling 64 (Japan)" region="JPN" />
+		<rom name="Virtual Pro Wrestling 64 (Japan).z64" size="16777216" crc="e6651803" md5="5e6202200af40a8f026780edfe1e15d0" sha1="f9e9fa2ed819c3a39db5cb6afeca186f021db5ed" />
 	</game>
 	<game name="Waialae Country Club - True Golf Classics (Europe) (Rev 1)">
 		<description>Waialae Country Club - True Golf Classics (Europe) (Rev 1)</description>
-		<release name="Waialae Country Club - True Golf Classics (Europe) (Rev 1)" region="EUR"/>
-		<rom name="Waialae Country Club - True Golf Classics (Europe) (Rev 1).z64" size="16777216" crc="6cb097b3" md5="f7c1b1ee1ce37ce09aa48c7e0a115efa" sha1="074d13da1ac91167654a8047eb72d732fbcb5121"/>
+		<rom name="Waialae Country Club - True Golf Classics (Europe) (Rev 1).n64" />
+		<release name="Waialae Country Club - True Golf Classics (Europe) (Rev 1)" region="EUR" />
+		<rom name="Waialae Country Club - True Golf Classics (Europe) (Rev 1).z64" size="16777216" crc="6cb097b3" md5="f7c1b1ee1ce37ce09aa48c7e0a115efa" sha1="074d13da1ac91167654a8047eb72d732fbcb5121" />
 	</game>
 	<game name="Waialae Country Club - True Golf Classics (Europe)" cloneof="Waialae Country Club - True Golf Classics (Europe) (Rev 1)">
 		<description>Waialae Country Club - True Golf Classics (Europe)</description>
-		<rom name="Waialae Country Club - True Golf Classics (Europe).z64" size="16777216" crc="6858759a" md5="5f1906df4eb30537c2ac2fcbd005907d" sha1="a06f905f4466637012adb5eb56ccdcbee2e7ac72"/>
+		<rom name="Waialae Country Club - True Golf Classics (Europe).n64" />
+		<rom name="Waialae Country Club - True Golf Classics (Europe).z64" size="16777216" crc="6858759a" md5="5f1906df4eb30537c2ac2fcbd005907d" sha1="a06f905f4466637012adb5eb56ccdcbee2e7ac72" />
 	</game>
 	<game name="Waialae Country Club - True Golf Classics (USA)" cloneof="Waialae Country Club - True Golf Classics (Europe) (Rev 1)">
 		<description>Waialae Country Club - True Golf Classics (USA)</description>
-		<rom name="Waialae Country Club - True Golf Classics (USA).z64" size="16777216" crc="ccab08d7" md5="dd8154d507c88694afd69c7af16a8cd6" sha1="f8609f518d60c87cb6a4e257633e8a1be957311c"/>
+		<rom name="Waialae Country Club - True Golf Classics (USA).n64" />
+		<rom name="Waialae Country Club - True Golf Classics (USA).z64" size="16777216" crc="ccab08d7" md5="dd8154d507c88694afd69c7af16a8cd6" sha1="f8609f518d60c87cb6a4e257633e8a1be957311c" />
 	</game>
 	<game name="Waialae Country Club - True Golf Classics (USA) (Rev 1)" cloneof="Waialae Country Club - True Golf Classics (Europe) (Rev 1)">
 		<description>Waialae Country Club - True Golf Classics (USA) (Rev 1)</description>
-		<release name="Waialae Country Club - True Golf Classics (USA) (Rev 1)" region="USA"/>
-		<rom name="Waialae Country Club - True Golf Classics (USA) (Rev 1).z64" size="16777216" crc="c65ee122" md5="67f75c4dd30922a001c8c32aeb9333ac" sha1="45c9e0ca0d41b47bb59d36cebb1d2a9db7c8278b"/>
+		<rom name="Waialae Country Club - True Golf Classics (USA) (Rev 1).n64" />
+		<release name="Waialae Country Club - True Golf Classics (USA) (Rev 1)" region="USA" />
+		<rom name="Waialae Country Club - True Golf Classics (USA) (Rev 1).z64" size="16777216" crc="c65ee122" md5="67f75c4dd30922a001c8c32aeb9333ac" sha1="45c9e0ca0d41b47bb59d36cebb1d2a9db7c8278b" />
 	</game>
 	<game name="War Gods (Europe)">
 		<description>War Gods (Europe)</description>
-		<release name="War Gods (Europe)" region="EUR"/>
-		<rom name="War Gods (Europe).z64" size="12582912" crc="c73010c8" md5="d25dd15903bdcb7724a2e8a02561987f" sha1="c9bdd7e5af853135fc4cbd72e461fc227f7498e3"/>
+		<rom name="War Gods (Europe).n64" />
+		<release name="War Gods (Europe)" region="EUR" />
+		<rom name="War Gods (Europe).z64" size="12582912" crc="c73010c8" md5="d25dd15903bdcb7724a2e8a02561987f" sha1="c9bdd7e5af853135fc4cbd72e461fc227f7498e3" />
 	</game>
 	<game name="War Gods (USA)" cloneof="War Gods (Europe)">
 		<description>War Gods (USA)</description>
-		<release name="War Gods (USA)" region="USA"/>
-		<rom name="War Gods (USA).z64" size="12582912" crc="ffacf993" md5="9ff2ba3c8408de9f0edb6d764a97c197" sha1="829c4f0f1caa72a2fbabaee5651e2acc695d3921"/>
+		<rom name="War Gods (USA).n64" />
+		<release name="War Gods (USA)" region="USA" />
+		<rom name="War Gods (USA).z64" size="12582912" crc="ffacf993" md5="9ff2ba3c8408de9f0edb6d764a97c197" sha1="829c4f0f1caa72a2fbabaee5651e2acc695d3921" />
 	</game>
 	<game name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
 		<description>Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)</description>
-		<release name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)" region="EUR"/>
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De).z64" size="8388608" crc="fb289893" md5="310659115e9939f219a783abdd456ce9" sha1="c20aa97dc25aec7a9b9c6889286bbd216fc7caa4" status="verified"/>
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De).n64" />
+		<release name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)" region="EUR" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De).z64" size="8388608" crc="fb289893" md5="310659115e9939f219a783abdd456ce9" sha1="c20aa97dc25aec7a9b9c6889286bbd216fc7caa4" status="verified" />
 	</game>
 	<game name="Shuishang Motuo (China) (iQue)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
 		<description>Shuishang Motuo (China) (iQue)</description>
-		<rom name="Shuishang Motuo (China) (iQue).z64" size="8159232" crc="30f45e87" md5="1f83663b2c84512fc3706a6cacc1a9f3" sha1="19c2e84440ebec5b6a349ec96cdc629e03491a19"/>
+		<rom name="Shuishang Motuo (China) (iQue).n64" />
+		<rom name="Shuishang Motuo (China) (iQue).z64" size="8159232" crc="30f45e87" md5="1f83663b2c84512fc3706a6cacc1a9f3" sha1="19c2e84440ebec5b6a349ec96cdc629e03491a19" />
 	</game>
 	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
 		<description>Wave Race 64 - Kawasaki Jet Ski (Japan)</description>
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan).z64" size="8388608" crc="6c93ff83" md5="b32e555bc1a375256e8a4021a25339be" sha1="05d40e57c9cb29a8992595afdde6653936e16729" status="verified"/>
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan).n64" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan).z64" size="8388608" crc="6c93ff83" md5="b32e555bc1a375256e8a4021a25339be" sha1="05d40e57c9cb29a8992595afdde6653936e16729" status="verified" />
 	</game>
 	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
 		<description>Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition)</description>
-		<release name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition)" region="JPN"/>
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition).z64" size="8388608" crc="90044c4b" md5="ff67df97476c210d158779ae6142f239" sha1="445ecb4904cc0ab6b81fb415a35072e99f18b545" status="verified"/>
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition).n64" />
+		<release name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition)" region="JPN" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 2) (Shindou Edition).z64" size="8388608" crc="90044c4b" md5="ff67df97476c210d158779ae6142f239" sha1="445ecb4904cc0ab6b81fb415a35072e99f18b545" status="verified" />
 	</game>
 	<game name="Wave Race 64 - Kawasaki Jet Ski (USA)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
 		<description>Wave Race 64 - Kawasaki Jet Ski (USA)</description>
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA).z64" size="8388608" crc="74a7b725" md5="ae480013f39d4aec86eea1b4995600d1" sha1="887ab588c2ecc64c52fb2065f06b0a1ee4af13dc"/>
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA).n64" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA).z64" size="8388608" crc="74a7b725" md5="ae480013f39d4aec86eea1b4995600d1" sha1="887ab588c2ecc64c52fb2065f06b0a1ee4af13dc" />
 	</game>
 	<game name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
 		<description>Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1)</description>
-		<release name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1)" region="USA"/>
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1).z64" size="8388608" crc="394948c4" md5="2048a640c12d1cf2052ba1629937d2ff" sha1="508dfc2d4caa42b6f6de5263d0aed5e44ac7966a" status="verified"/>
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1).n64" />
+		<release name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1)" region="USA" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (USA) (Rev 1).z64" size="8388608" crc="394948c4" md5="2048a640c12d1cf2052ba1629937d2ff" sha1="508dfc2d4caa42b6f6de5263d0aed5e44ac7966a" status="verified" />
 	</game>
 	<game name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1)" cloneof="Wave Race 64 - Kawasaki Jet Ski (Europe) (En,De)">
 		<description>Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1)</description>
-		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1).z64" size="8388608" crc="54d190a8" md5="d05c6f3caf9059b306cc13535e2a8ba6" sha1="4b6cd84b40dd2f4fbe55c6e10f298f33f9184a9a" status="verified"/>
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1).n64" />
+		<rom name="Wave Race 64 - Kawasaki Jet Ski (Japan) (Rev 1).z64" size="8388608" crc="54d190a8" md5="d05c6f3caf9059b306cc13535e2a8ba6" sha1="4b6cd84b40dd2f4fbe55c6e10f298f33f9184a9a" status="verified" />
 	</game>
 	<game name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)">
 		<description>Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)</description>
-		<release name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es).z64" size="8388608" crc="442a4f5f" md5="319816aaa30e512827be7b7f81f80d86" sha1="d9a6ba9a6e75a198e995af3c4c81f4cfb3830c64" status="verified"/>
+		<rom name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es).n64" />
+		<release name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es).z64" size="8388608" crc="442a4f5f" md5="319816aaa30e512827be7b7f81f80d86" sha1="d9a6ba9a6e75a198e995af3c4c81f4cfb3830c64" status="verified" />
 	</game>
 	<game name="Wayne Gretzky's 3D Hockey (Japan)" cloneof="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)">
 		<description>Wayne Gretzky's 3D Hockey (Japan)</description>
-		<release name="Wayne Gretzky's 3D Hockey (Japan)" region="JPN"/>
-		<rom name="Wayne Gretzky's 3D Hockey (Japan).z64" size="8388608" crc="485275ed" md5="61e637b542d5df178040454075c28e19" sha1="d8edc3b462bf80b48c98fb36032b8aca95164055"/>
+		<rom name="Wayne Gretzky's 3D Hockey (Japan).n64" />
+		<release name="Wayne Gretzky's 3D Hockey (Japan)" region="JPN" />
+		<rom name="Wayne Gretzky's 3D Hockey (Japan).z64" size="8388608" crc="485275ed" md5="61e637b542d5df178040454075c28e19" sha1="d8edc3b462bf80b48c98fb36032b8aca95164055" />
 	</game>
 	<game name="Wayne Gretzky's 3D Hockey (USA)" cloneof="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)">
 		<description>Wayne Gretzky's 3D Hockey (USA)</description>
-		<rom name="Wayne Gretzky's 3D Hockey (USA).z64" size="8388608" crc="9781f88d" md5="6df0d6259261d0096c90bbc6aa037d8e" sha1="400aa84811f1f2f6c62c756b43b54d534d5a5ec8"/>
+		<rom name="Wayne Gretzky's 3D Hockey (USA).n64" />
+		<rom name="Wayne Gretzky's 3D Hockey (USA).z64" size="8388608" crc="9781f88d" md5="6df0d6259261d0096c90bbc6aa037d8e" sha1="400aa84811f1f2f6c62c756b43b54d534d5a5ec8" />
 	</game>
 	<game name="Wayne Gretzky's 3D Hockey (USA) (Rev 1)" cloneof="Wayne Gretzky's 3D Hockey (Europe) (En,Fr,De,Es)">
 		<description>Wayne Gretzky's 3D Hockey (USA) (Rev 1)</description>
-		<release name="Wayne Gretzky's 3D Hockey (USA) (Rev 1)" region="USA"/>
-		<rom name="Wayne Gretzky's 3D Hockey (USA) (Rev 1).z64" size="8388608" crc="c2678971" md5="04e650b7742a69dae98f125d1b492d78" sha1="91f33097c5da2c3480e0a9f04f7463cea16b176b"/>
+		<rom name="Wayne Gretzky's 3D Hockey (USA) (Rev 1).n64" />
+		<release name="Wayne Gretzky's 3D Hockey (USA) (Rev 1)" region="USA" />
+		<rom name="Wayne Gretzky's 3D Hockey (USA) (Rev 1).z64" size="8388608" crc="c2678971" md5="04e650b7742a69dae98f125d1b492d78" sha1="91f33097c5da2c3480e0a9f04f7463cea16b176b" />
 	</game>
 	<game name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)">
 		<description>Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)</description>
-		<release name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)" region="EUR"/>
-		<rom name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es).z64" size="8388608" crc="6f6dc53d" md5="24a0d8c8cabc22116e469476ff6c691d" sha1="3eb1a78c0480af0cc6f2180f87260790c37367d0"/>
+		<rom name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es).n64" />
+		<release name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)" region="EUR" />
+		<rom name="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es).z64" size="8388608" crc="6f6dc53d" md5="24a0d8c8cabc22116e469476ff6c691d" sha1="3eb1a78c0480af0cc6f2180f87260790c37367d0" />
 	</game>
 	<game name="Wayne Gretzky's 3D Hockey '98 (USA)" cloneof="Wayne Gretzky's 3D Hockey '98 (Europe) (En,Fr,De,Es)">
 		<description>Wayne Gretzky's 3D Hockey '98 (USA)</description>
-		<release name="Wayne Gretzky's 3D Hockey '98 (USA)" region="USA"/>
-		<rom name="Wayne Gretzky's 3D Hockey '98 (USA).z64" size="8388608" crc="355fb089" md5="810f8bc2c8c66bda3b206c7dd4b6d42f" sha1="1af0be9568f8ace865d5cf76fd241da741154b0f"/>
+		<rom name="Wayne Gretzky's 3D Hockey '98 (USA).n64" />
+		<release name="Wayne Gretzky's 3D Hockey '98 (USA)" region="USA" />
+		<rom name="Wayne Gretzky's 3D Hockey '98 (USA).z64" size="8388608" crc="355fb089" md5="810f8bc2c8c66bda3b206c7dd4b6d42f" sha1="1af0be9568f8ace865d5cf76fd241da741154b0f" />
 	</game>
 	<game name="WCW Backstage Assault (USA)">
 		<description>WCW Backstage Assault (USA)</description>
-		<release name="WCW Backstage Assault (USA)" region="USA"/>
-		<rom name="WCW Backstage Assault (USA).z64" size="33554432" crc="5dcc2e4e" md5="02aed169eb579494ace75d22e10d789b" sha1="34f793d55770d5eb112cff0e28cb0a35e0ec7385"/>
+		<rom name="WCW Backstage Assault (USA).n64" />
+		<release name="WCW Backstage Assault (USA)" region="USA" />
+		<rom name="WCW Backstage Assault (USA).z64" size="33554432" crc="5dcc2e4e" md5="02aed169eb579494ace75d22e10d789b" sha1="34f793d55770d5eb112cff0e28cb0a35e0ec7385" />
 	</game>
 	<game name="WCW Mayhem (Europe)">
 		<description>WCW Mayhem (Europe)</description>
-		<release name="WCW Mayhem (Europe)" region="EUR"/>
-		<rom name="WCW Mayhem (Europe).z64" size="16777216" crc="864e066e" md5="9e943752bcf4fba9ca3028e596f4eb4a" sha1="594b273ee9d6e174cfd9b33d4fd6aa86cd3e2442"/>
+		<rom name="WCW Mayhem (Europe).n64" />
+		<release name="WCW Mayhem (Europe)" region="EUR" />
+		<rom name="WCW Mayhem (Europe).z64" size="16777216" crc="864e066e" md5="9e943752bcf4fba9ca3028e596f4eb4a" sha1="594b273ee9d6e174cfd9b33d4fd6aa86cd3e2442" />
 	</game>
 	<game name="WCW Mayhem (USA)" cloneof="WCW Mayhem (Europe)">
 		<description>WCW Mayhem (USA)</description>
-		<release name="WCW Mayhem (USA)" region="USA"/>
-		<rom name="WCW Mayhem (USA).z64" size="16777216" crc="f1f9b6eb" md5="87bf3784709cd09693cd7bcc08460c63" sha1="83382ee31db3dccd598d8af55607e70db1bcbbb6"/>
+		<rom name="WCW Mayhem (USA).n64" />
+		<release name="WCW Mayhem (USA)" region="USA" />
+		<rom name="WCW Mayhem (USA).z64" size="16777216" crc="f1f9b6eb" md5="87bf3784709cd09693cd7bcc08460c63" sha1="83382ee31db3dccd598d8af55607e70db1bcbbb6" />
 	</game>
 	<game name="WCW Nitro (USA)">
 		<description>WCW Nitro (USA)</description>
-		<release name="WCW Nitro (USA)" region="USA"/>
-		<rom name="WCW Nitro (USA).z64" size="12582912" crc="455b0830" md5="1e9fead701fe5aaaa248d4713891775d" sha1="1f3b1a9e348506ae3d2a79216b0bc6e69d04a4f9"/>
+		<rom name="WCW Nitro (USA).n64" />
+		<release name="WCW Nitro (USA)" region="USA" />
+		<rom name="WCW Nitro (USA).z64" size="12582912" crc="455b0830" md5="1e9fead701fe5aaaa248d4713891775d" sha1="1f3b1a9e348506ae3d2a79216b0bc6e69d04a4f9" />
 	</game>
 	<game name="WCW vs. nWo - World Tour (Europe)">
 		<description>WCW vs. nWo - World Tour (Europe)</description>
-		<release name="WCW vs. nWo - World Tour (Europe)" region="EUR"/>
-		<rom name="WCW vs. nWo - World Tour (Europe).z64" size="12582912" crc="37f358eb" md5="553d8d5347969c66e5d91c3fe35208b9" sha1="840b8b6303acaceb49619eb1533cb4221cdec474"/>
+		<rom name="WCW vs. nWo - World Tour (Europe).n64" />
+		<release name="WCW vs. nWo - World Tour (Europe)" region="EUR" />
+		<rom name="WCW vs. nWo - World Tour (Europe).z64" size="12582912" crc="37f358eb" md5="553d8d5347969c66e5d91c3fe35208b9" sha1="840b8b6303acaceb49619eb1533cb4221cdec474" />
 	</game>
 	<game name="WCW vs. nWo - World Tour (USA)" cloneof="WCW vs. nWo - World Tour (Europe)">
 		<description>WCW vs. nWo - World Tour (USA)</description>
-		<rom name="WCW vs. nWo - World Tour (USA).z64" size="12582912" crc="dfbfc61f" md5="203c3bbfdd10c5a0b7c5d0cdb085d853" sha1="5ad2d8359058c8bb71f08e3d3433b7a50d3bb645"/>
+		<rom name="WCW vs. nWo - World Tour (USA).n64" />
+		<rom name="WCW vs. nWo - World Tour (USA).z64" size="12582912" crc="dfbfc61f" md5="203c3bbfdd10c5a0b7c5d0cdb085d853" sha1="5ad2d8359058c8bb71f08e3d3433b7a50d3bb645" />
 	</game>
 	<game name="WCW vs. nWo - World Tour (USA) (Rev 1)" cloneof="WCW vs. nWo - World Tour (Europe)">
 		<description>WCW vs. nWo - World Tour (USA) (Rev 1)</description>
-		<release name="WCW vs. nWo - World Tour (USA) (Rev 1)" region="USA"/>
-		<rom name="WCW vs. nWo - World Tour (USA) (Rev 1).z64" size="12582912" crc="a74da07a" md5="b7a220b59303d47f3beae233ca868cfd" sha1="60814fb3ad2dd206badbeee47c07636357dd0d7e"/>
+		<rom name="WCW vs. nWo - World Tour (USA) (Rev 1).n64" />
+		<release name="WCW vs. nWo - World Tour (USA) (Rev 1)" region="USA" />
+		<rom name="WCW vs. nWo - World Tour (USA) (Rev 1).z64" size="12582912" crc="a74da07a" md5="b7a220b59303d47f3beae233ca868cfd" sha1="60814fb3ad2dd206badbeee47c07636357dd0d7e" />
 	</game>
 	<game name="WCW-nWo Revenge (Europe)">
 		<description>WCW-nWo Revenge (Europe)</description>
-		<release name="WCW-nWo Revenge (Europe)" region="EUR"/>
-		<rom name="WCW-nWo Revenge (Europe).z64" size="16777216" crc="8af0f964" md5="30c6676ec1d62122f4e7607ef3abbd41" sha1="c59315a3e7a6e8124495477656a77e4619dac104"/>
+		<rom name="WCW-nWo Revenge (Europe).n64" />
+		<release name="WCW-nWo Revenge (Europe)" region="EUR" />
+		<rom name="WCW-nWo Revenge (Europe).z64" size="16777216" crc="8af0f964" md5="30c6676ec1d62122f4e7607ef3abbd41" sha1="c59315a3e7a6e8124495477656a77e4619dac104" />
 	</game>
 	<game name="WCW-nWo Revenge (USA)" cloneof="WCW-nWo Revenge (Europe)">
 		<description>WCW-nWo Revenge (USA)</description>
-		<release name="WCW-nWo Revenge (USA)" region="USA"/>
-		<rom name="WCW-nWo Revenge (USA).z64" size="16777216" crc="54cbaaa8" md5="c1384f3637d7a381b29341fed3ef3ceb" sha1="e1711a2511394b9357b5f1ac8ca5cc17bd674836"/>
+		<rom name="WCW-nWo Revenge (USA).n64" />
+		<release name="WCW-nWo Revenge (USA)" region="USA" />
+		<rom name="WCW-nWo Revenge (USA).z64" size="16777216" crc="54cbaaa8" md5="c1384f3637d7a381b29341fed3ef3ceb" sha1="e1711a2511394b9357b5f1ac8ca5cc17bd674836" />
 	</game>
 	<game name="Wetrix (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Wetrix (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Wetrix (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Wetrix (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="eddc5b06" md5="a99e2cb6acef7a004961de5f6dfeeff0" sha1="4cc1b6e3aa150cd79093f21e3fbe91a72fb86ad6"/>
+		<rom name="Wetrix (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Wetrix (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Wetrix (Europe) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="eddc5b06" md5="a99e2cb6acef7a004961de5f6dfeeff0" sha1="4cc1b6e3aa150cd79093f21e3fbe91a72fb86ad6" />
 	</game>
 	<game name="Wetrix (Japan)" cloneof="Wetrix (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Wetrix (Japan)</description>
-		<release name="Wetrix (Japan)" region="JPN"/>
-		<rom name="Wetrix (Japan).z64" size="4194304" crc="bad08218" md5="e8997bf5662540b184fbf8277d260984" sha1="1b1635546cb973ebaa0a4a0940a363ec2c074053"/>
+		<rom name="Wetrix (Japan).n64" />
+		<release name="Wetrix (Japan)" region="JPN" />
+		<rom name="Wetrix (Japan).z64" size="4194304" crc="bad08218" md5="e8997bf5662540b184fbf8277d260984" sha1="1b1635546cb973ebaa0a4a0940a363ec2c074053" />
 	</game>
 	<game name="Wetrix (USA) (En,Fr,De,Es,It,Nl)" cloneof="Wetrix (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Wetrix (USA) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Wetrix (USA) (En,Fr,De,Es,It,Nl)" region="USA"/>
-		<rom name="Wetrix (USA) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="50cd1f71" md5="6e81d3056e409208e4af2d39a2ff0f03" sha1="6e40312cf88a9182e93b396b9d82457b1aba7cd6"/>
+		<rom name="Wetrix (USA) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Wetrix (USA) (En,Fr,De,Es,It,Nl)" region="USA" />
+		<rom name="Wetrix (USA) (En,Fr,De,Es,It,Nl).z64" size="8388608" crc="50cd1f71" md5="6e81d3056e409208e4af2d39a2ff0f03" sha1="6e40312cf88a9182e93b396b9d82457b1aba7cd6" />
 	</game>
 	<game name="Wheel of Fortune (USA)">
 		<description>Wheel of Fortune (USA)</description>
-		<release name="Wheel of Fortune (USA)" region="USA"/>
-		<rom name="Wheel of Fortune (USA).z64" size="4194304" crc="8d3efa8d" md5="2abe36754e866b9b6c4bdcffc1d11abf" sha1="b51b28660699bf029f862f51c319a5962fe9de9b"/>
+		<rom name="Wheel of Fortune (USA).n64" />
+		<release name="Wheel of Fortune (USA)" region="USA" />
+		<rom name="Wheel of Fortune (USA).z64" size="4194304" crc="8d3efa8d" md5="2abe36754e866b9b6c4bdcffc1d11abf" sha1="b51b28660699bf029f862f51c319a5962fe9de9b" />
 	</game>
 	<game name="Wildwaters (USA) (Proto) (1999-06-15)">
 		<description>Wildwaters (USA) (Proto) (1999-06-15)</description>
-		<release name="Wildwaters (USA) (Proto) (1999-06-15)" region="USA"/>
-		<rom name="Wildwaters (USA) (Proto) (1999-06-15).z64" size="16777216" crc="40443c67" md5="b867880c96c9e8d3130dde5526c95439" sha1="3ff76b30a9179f1ac116cc04d560ce333db443af"/>
+		<rom name="Wildwaters (USA) (Proto) (1999-06-15).n64" />
+		<release name="Wildwaters (USA) (Proto) (1999-06-15)" region="USA" />
+		<rom name="Wildwaters (USA) (Proto) (1999-06-15).z64" size="16777216" crc="40443c67" md5="b867880c96c9e8d3130dde5526c95439" sha1="3ff76b30a9179f1ac116cc04d560ce333db443af" />
 	</game>
 	<game name="Wipeout 64 (Europe)">
 		<description>Wipeout 64 (Europe)</description>
-		<release name="Wipeout 64 (Europe)" region="EUR"/>
-		<rom name="Wipeout 64 (Europe).z64" size="8388608" crc="38111048" md5="5783373634b11f81c86908c3d81ca988" sha1="3eef8ec7d0009ee67d604aaca2bb61b7397ba862" status="verified"/>
+		<rom name="Wipeout 64 (Europe).n64" />
+		<release name="Wipeout 64 (Europe)" region="EUR" />
+		<rom name="Wipeout 64 (Europe).z64" size="8388608" crc="38111048" md5="5783373634b11f81c86908c3d81ca988" sha1="3eef8ec7d0009ee67d604aaca2bb61b7397ba862" status="verified" />
 	</game>
 	<game name="Wipeout 64 (USA)" cloneof="Wipeout 64 (Europe)">
 		<description>Wipeout 64 (USA)</description>
-		<release name="Wipeout 64 (USA)" region="USA"/>
-		<rom name="Wipeout 64 (USA).z64" size="8388608" crc="4888d0fe" md5="73c6d87dbe50f73f3b44e0f237a546d7" sha1="54e4795aba4fc326f79d0703ffdb51a212dd4b5c"/>
+		<rom name="Wipeout 64 (USA).n64" />
+		<release name="Wipeout 64 (USA)" region="USA" />
+		<rom name="Wipeout 64 (USA).z64" size="8388608" crc="4888d0fe" md5="73c6d87dbe50f73f3b44e0f237a546d7" sha1="54e4795aba4fc326f79d0703ffdb51a212dd4b5c" />
 	</game>
 	<game name="Wipeout 64 (Europe) (Beta)" cloneof="Wipeout 64 (Europe)">
 		<description>Wipeout 64 (Europe) (Beta)</description>
-		<rom name="Wipeout 64 (Europe) (Beta).z64" size="16777216" crc="944b258f" md5="7260da1cecd0d8844c5e29aa63476def" sha1="a05a1f4c9f4ee67159db0cd15c37e05f255d35d0"/>
+		<rom name="Wipeout 64 (Europe) (Beta).n64" />
+		<rom name="Wipeout 64 (Europe) (Beta).z64" size="16777216" crc="944b258f" md5="7260da1cecd0d8844c5e29aa63476def" sha1="a05a1f4c9f4ee67159db0cd15c37e05f255d35d0" />
 	</game>
 	<game name="Wonder Project J2 - Koruro no Mori no Jozet (Japan)">
 		<description>Wonder Project J2 - Koruro no Mori no Jozet (Japan)</description>
-		<release name="Wonder Project J2 - Koruro no Mori no Jozet (Japan)" region="JPN"/>
-		<rom name="Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size="8388608" crc="5e8fc436" md5="0ff1f8628d8fe69582db54572d2bea79" sha1="3a311ec0d77d4e0fc425a99cb6b9416f072e268e" status="verified"/>
+		<rom name="Wonder Project J2 - Koruro no Mori no Jozet (Japan).n64" />
+		<release name="Wonder Project J2 - Koruro no Mori no Jozet (Japan)" region="JPN" />
+		<rom name="Wonder Project J2 - Koruro no Mori no Jozet (Japan).z64" size="8388608" crc="5e8fc436" md5="0ff1f8628d8fe69582db54572d2bea79" sha1="3a311ec0d77d4e0fc425a99cb6b9416f072e268e" status="verified" />
 	</game>
 	<game name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)">
 		<description>World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)</description>
-		<release name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)" region="EUR"/>
-		<rom name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).z64" size="12582912" crc="79f483f7" md5="3aa263aca66f3a07bb081b575d66deeb" sha1="cd92b2cbb253411fc66544649567d9b1c44bb210"/>
+		<rom name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).n64" />
+		<release name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)" region="EUR" />
+		<rom name="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da).z64" size="12582912" crc="79f483f7" md5="3aa263aca66f3a07bb081b575d66deeb" sha1="cd92b2cbb253411fc66544649567d9b1c44bb210" />
 	</game>
 	<game name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)" cloneof="World Cup 98 (Europe) (En,Fr,De,Es,It,Nl,Sv,Da)">
 		<description>World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)</description>
-		<release name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)" region="USA"/>
-		<rom name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da).z64" size="12582912" crc="13930c26" md5="4bef5e9aa9e71205dac1a7060e778235" sha1="b496edee84e5e84ead8da6f57a765936b2af2f9f"/>
+		<rom name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da).n64" />
+		<release name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da)" region="USA" />
+		<rom name="World Cup 98 (USA) (En,Fr,De,Es,It,Nl,Sv,Da).z64" size="12582912" crc="13930c26" md5="4bef5e9aa9e71205dac1a7060e778235" sha1="b496edee84e5e84ead8da6f57a765936b2af2f9f" />
 	</game>
 	<game name="World Driver Championship (Europe) (En,Fr,De,Es,It)">
 		<description>World Driver Championship (Europe) (En,Fr,De,Es,It)</description>
-		<release name="World Driver Championship (Europe) (En,Fr,De,Es,It)" region="EUR"/>
-		<rom name="World Driver Championship (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="76151df6" md5="431de8f6611a8131b536f0ede1f330d9" sha1="7b054d1580cc263429eb6961ad6ed6e0140e1df0"/>
+		<rom name="World Driver Championship (Europe) (En,Fr,De,Es,It).n64" />
+		<release name="World Driver Championship (Europe) (En,Fr,De,Es,It)" region="EUR" />
+		<rom name="World Driver Championship (Europe) (En,Fr,De,Es,It).z64" size="16777216" crc="76151df6" md5="431de8f6611a8131b536f0ede1f330d9" sha1="7b054d1580cc263429eb6961ad6ed6e0140e1df0" />
 	</game>
 	<game name="World Driver Championship (USA)" cloneof="World Driver Championship (Europe) (En,Fr,De,Es,It)">
 		<description>World Driver Championship (USA)</description>
-		<release name="World Driver Championship (USA)" region="USA"/>
-		<rom name="World Driver Championship (USA).z64" size="16777216" crc="5e4acbfa" md5="7c567a5bb1ad4cbe414fb6bbff66e336" sha1="93227776f59b42e9fb1c942eba9d5b465eeb3979"/>
+		<rom name="World Driver Championship (USA).n64" />
+		<release name="World Driver Championship (USA)" region="USA" />
+		<rom name="World Driver Championship (USA).z64" size="16777216" crc="5e4acbfa" md5="7c567a5bb1ad4cbe414fb6bbff66e336" sha1="93227776f59b42e9fb1c942eba9d5b465eeb3979" />
 	</game>
 	<game name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)</description>
-		<release name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)" region="EUR"/>
-		<rom name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="6bfff27b" md5="44fc2a7f028f0b6f71b255f672c8b495" sha1="34042046e3cfa44723c32f6d366052483edb80d7"/>
+		<rom name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl).n64" />
+		<release name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)" region="EUR" />
+		<rom name="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl).z64" size="12582912" crc="6bfff27b" md5="44fc2a7f028f0b6f71b255f672c8b495" sha1="34042046e3cfa44723c32f6d366052483edb80d7" />
 	</game>
 	<game name="Worms Armageddon (USA) (En,Fr,Es)" cloneof="Worms Armageddon (Europe) (En,Fr,De,Es,It,Nl)">
 		<description>Worms Armageddon (USA) (En,Fr,Es)</description>
-		<release name="Worms Armageddon (USA) (En,Fr,Es)" region="USA"/>
-		<rom name="Worms Armageddon (USA) (En,Fr,Es).z64" size="12582912" crc="5471ae3b" md5="491d4db6718302489bf05fb962c73651" sha1="3b17b36ba91737b86aa56ecb1b48a89444b53572"/>
+		<rom name="Worms Armageddon (USA) (En,Fr,Es).n64" />
+		<release name="Worms Armageddon (USA) (En,Fr,Es)" region="USA" />
+		<rom name="Worms Armageddon (USA) (En,Fr,Es).z64" size="12582912" crc="5471ae3b" md5="491d4db6718302489bf05fb962c73651" sha1="3b17b36ba91737b86aa56ecb1b48a89444b53572" />
 	</game>
 	<game name="WWF Attitude (Europe)">
 		<description>WWF Attitude (Europe)</description>
-		<release name="WWF Attitude (Europe)" region="EUR"/>
-		<rom name="WWF Attitude (Europe).z64" size="33554432" crc="804fe494" md5="3fdb2e5f9982fda2c2344a883b8ab6ef" sha1="880d3aacae0b3792235404decd294afdad51a0a6"/>
+		<rom name="WWF Attitude (Europe).n64" />
+		<release name="WWF Attitude (Europe)" region="EUR" />
+		<rom name="WWF Attitude (Europe).z64" size="33554432" crc="804fe494" md5="3fdb2e5f9982fda2c2344a883b8ab6ef" sha1="880d3aacae0b3792235404decd294afdad51a0a6" />
 	</game>
 	<game name="WWF Attitude (Germany)" cloneof="WWF Attitude (Europe)">
 		<description>WWF Attitude (Germany)</description>
-		<release name="WWF Attitude (Germany)" region="GER"/>
-		<rom name="WWF Attitude (Germany).z64" size="33554432" crc="ea5d8359" md5="b86ec8d19d7d1a50ea900ea10355a735" sha1="40c2c6309589755c4cfdbf3e4e39b3788820b199"/>
+		<rom name="WWF Attitude (Germany).n64" />
+		<release name="WWF Attitude (Germany)" region="GER" />
+		<rom name="WWF Attitude (Germany).z64" size="33554432" crc="ea5d8359" md5="b86ec8d19d7d1a50ea900ea10355a735" sha1="40c2c6309589755c4cfdbf3e4e39b3788820b199" />
 	</game>
 	<game name="WWF Attitude (USA)" cloneof="WWF Attitude (Europe)">
 		<description>WWF Attitude (USA)</description>
-		<release name="WWF Attitude (USA)" region="USA"/>
-		<rom name="WWF Attitude (USA).z64" size="33554432" crc="7a4b3686" md5="9faf514cb3dbb742c129deb395dca342" sha1="259973eb0ba1d01f1a5fbf3039ed511e6b705f26"/>
+		<rom name="WWF Attitude (USA).n64" />
+		<release name="WWF Attitude (USA)" region="USA" />
+		<rom name="WWF Attitude (USA).z64" size="33554432" crc="7a4b3686" md5="9faf514cb3dbb742c129deb395dca342" sha1="259973eb0ba1d01f1a5fbf3039ed511e6b705f26" />
 	</game>
 	<game name="WWF No Mercy (Europe) (Rev 1)">
 		<description>WWF No Mercy (Europe) (Rev 1)</description>
-		<release name="WWF No Mercy (Europe) (Rev 1)" region="EUR"/>
-		<rom name="WWF No Mercy (Europe) (Rev 1).z64" size="33554432" crc="43ba9e7e" md5="400a14f132d993f5544f8b008ec136fa" sha1="cc8b9863c0e96d1b6a611d6ac2238e38b247ea5d"/>
+		<rom name="WWF No Mercy (Europe) (Rev 1).n64" />
+		<release name="WWF No Mercy (Europe) (Rev 1)" region="EUR" />
+		<rom name="WWF No Mercy (Europe) (Rev 1).z64" size="33554432" crc="43ba9e7e" md5="400a14f132d993f5544f8b008ec136fa" sha1="cc8b9863c0e96d1b6a611d6ac2238e38b247ea5d" />
 	</game>
 	<game name="WWF No Mercy (Europe)" cloneof="WWF No Mercy (Europe) (Rev 1)">
 		<description>WWF No Mercy (Europe)</description>
-		<rom name="WWF No Mercy (Europe).z64" size="33554432" crc="e88d7e16" md5="d94a8f78178473d4ba4bed62fa8e2e66" sha1="15ad0a48dbb2da32b39601e6bfb5d7b381853529"/>
+		<rom name="WWF No Mercy (Europe).n64" />
+		<rom name="WWF No Mercy (Europe).z64" size="33554432" crc="e88d7e16" md5="d94a8f78178473d4ba4bed62fa8e2e66" sha1="15ad0a48dbb2da32b39601e6bfb5d7b381853529" />
 	</game>
 	<game name="WWF No Mercy (USA)" cloneof="WWF No Mercy (Europe) (Rev 1)">
 		<description>WWF No Mercy (USA)</description>
-		<rom name="WWF No Mercy (USA).z64" size="33554432" crc="b33f44f0" md5="04c492be7f89fc6f425238bd67629544" sha1="3566d9b5723291937582453ad0453ce517cfc358"/>
+		<rom name="WWF No Mercy (USA).n64" />
+		<rom name="WWF No Mercy (USA).z64" size="33554432" crc="b33f44f0" md5="04c492be7f89fc6f425238bd67629544" sha1="3566d9b5723291937582453ad0453ce517cfc358" />
 	</game>
 	<game name="WWF No Mercy (USA) (Rev 1)" cloneof="WWF No Mercy (Europe) (Rev 1)">
 		<description>WWF No Mercy (USA) (Rev 1)</description>
-		<release name="WWF No Mercy (USA) (Rev 1)" region="USA"/>
-		<rom name="WWF No Mercy (USA) (Rev 1).z64" size="33554432" crc="baceea13" md5="66b8ec24557a50514a814f15429bd559" sha1="91cee3d096f4a76644d8b35b9aead6448909abd1"/>
+		<rom name="WWF No Mercy (USA) (Rev 1).n64" />
+		<release name="WWF No Mercy (USA) (Rev 1)" region="USA" />
+		<rom name="WWF No Mercy (USA) (Rev 1).z64" size="33554432" crc="baceea13" md5="66b8ec24557a50514a814f15429bd559" sha1="91cee3d096f4a76644d8b35b9aead6448909abd1" />
 	</game>
 	<game name="WWF War Zone (Europe)">
 		<description>WWF War Zone (Europe)</description>
-		<release name="WWF War Zone (Europe)" region="EUR"/>
-		<rom name="WWF War Zone (Europe).z64" size="12582912" crc="90a0b609" md5="ebc0cf55fc58845c6ee86cf8b2d87303" sha1="808a8997aa8d717aac2a9a0c476b901338ac626e"/>
+		<rom name="WWF War Zone (Europe).n64" />
+		<release name="WWF War Zone (Europe)" region="EUR" />
+		<rom name="WWF War Zone (Europe).z64" size="12582912" crc="90a0b609" md5="ebc0cf55fc58845c6ee86cf8b2d87303" sha1="808a8997aa8d717aac2a9a0c476b901338ac626e" />
 	</game>
 	<game name="WWF War Zone (USA)" cloneof="WWF War Zone (Europe)">
 		<description>WWF War Zone (USA)</description>
-		<release name="WWF War Zone (USA)" region="USA"/>
-		<rom name="WWF War Zone (USA).z64" size="12582912" crc="2fbb5507" md5="2322da2b9e7dc74678cd683b7a246b49" sha1="8700f89cd7cfa873452117f6b2a648d32796111c"/>
+		<rom name="WWF War Zone (USA).n64" />
+		<release name="WWF War Zone (USA)" region="USA" />
+		<rom name="WWF War Zone (USA).z64" size="12582912" crc="2fbb5507" md5="2322da2b9e7dc74678cd683b7a246b49" sha1="8700f89cd7cfa873452117f6b2a648d32796111c" />
 	</game>
 	<game name="WWF WrestleMania 2000 (Europe)">
 		<description>WWF WrestleMania 2000 (Europe)</description>
-		<release name="WWF WrestleMania 2000 (Europe)" region="EUR"/>
-		<rom name="WWF WrestleMania 2000 (Europe).z64" size="33554432" crc="09d710c7" md5="b75149f87cc5f3a508643ac377f2fcc9" sha1="d37c4100d967cb8b71852993b947619467ffcaf7"/>
+		<rom name="WWF WrestleMania 2000 (Europe).n64" />
+		<release name="WWF WrestleMania 2000 (Europe)" region="EUR" />
+		<rom name="WWF WrestleMania 2000 (Europe).z64" size="33554432" crc="09d710c7" md5="b75149f87cc5f3a508643ac377f2fcc9" sha1="d37c4100d967cb8b71852993b947619467ffcaf7" />
 	</game>
 	<game name="WWF WrestleMania 2000 (Japan)" cloneof="WWF WrestleMania 2000 (Europe)">
 		<description>WWF WrestleMania 2000 (Japan)</description>
-		<release name="WWF WrestleMania 2000 (Japan)" region="JPN"/>
-		<rom name="WWF WrestleMania 2000 (Japan).z64" size="33554432" crc="c2034d24" md5="11eee2f34bf8da05a1b8f4fb9fe9f74c" sha1="e020c26dede0c349181cf08a3541816dc47f63a8"/>
+		<rom name="WWF WrestleMania 2000 (Japan).n64" />
+		<release name="WWF WrestleMania 2000 (Japan)" region="JPN" />
+		<rom name="WWF WrestleMania 2000 (Japan).z64" size="33554432" crc="c2034d24" md5="11eee2f34bf8da05a1b8f4fb9fe9f74c" sha1="e020c26dede0c349181cf08a3541816dc47f63a8" />
 	</game>
 	<game name="WWF WrestleMania 2000 (USA)" cloneof="WWF WrestleMania 2000 (Europe)">
 		<description>WWF WrestleMania 2000 (USA)</description>
-		<release name="WWF WrestleMania 2000 (USA)" region="USA"/>
-		<rom name="WWF WrestleMania 2000 (USA).z64" size="33554432" crc="0b50b4c6" md5="d9030ca30e4d1af805acce1bfed988cc" sha1="442d417a52ed672ca1a47e7261a5414debb1e27a"/>
+		<rom name="WWF WrestleMania 2000 (USA).n64" />
+		<release name="WWF WrestleMania 2000 (USA)" region="USA" />
+		<rom name="WWF WrestleMania 2000 (USA).z64" size="33554432" crc="0b50b4c6" md5="d9030ca30e4d1af805acce1bfed988cc" sha1="442d417a52ed672ca1a47e7261a5414debb1e27a" />
 	</game>
 	<game name="Xena - Warrior Princess - The Talisman of Fate (Europe)">
 		<description>Xena - Warrior Princess - The Talisman of Fate (Europe)</description>
-		<release name="Xena - Warrior Princess - The Talisman of Fate (Europe)" region="EUR"/>
-		<rom name="Xena - Warrior Princess - The Talisman of Fate (Europe).z64" size="12582912" crc="d3932f88" md5="ec2bcb1b7fc7d068be1f39e79e49a842" sha1="2fa884f36bd370d844ed1e57c4357510584fe3e2"/>
+		<rom name="Xena - Warrior Princess - The Talisman of Fate (Europe).n64" />
+		<release name="Xena - Warrior Princess - The Talisman of Fate (Europe)" region="EUR" />
+		<rom name="Xena - Warrior Princess - The Talisman of Fate (Europe).z64" size="12582912" crc="d3932f88" md5="ec2bcb1b7fc7d068be1f39e79e49a842" sha1="2fa884f36bd370d844ed1e57c4357510584fe3e2" />
 	</game>
 	<game name="Xena - Warrior Princess - The Talisman of Fate (USA)" cloneof="Xena - Warrior Princess - The Talisman of Fate (Europe)">
 		<description>Xena - Warrior Princess - The Talisman of Fate (USA)</description>
-		<release name="Xena - Warrior Princess - The Talisman of Fate (USA)" region="USA"/>
-		<rom name="Xena - Warrior Princess - The Talisman of Fate (USA).z64" size="12582912" crc="7da93999" md5="1ac234649d28f09e82c0d11abb17f03b" sha1="e3316269b8466fe1fb968ac9338e6acdc0379970"/>
+		<rom name="Xena - Warrior Princess - The Talisman of Fate (USA).n64" />
+		<release name="Xena - Warrior Princess - The Talisman of Fate (USA)" region="USA" />
+		<rom name="Xena - Warrior Princess - The Talisman of Fate (USA).z64" size="12582912" crc="7da93999" md5="1ac234649d28f09e82c0d11abb17f03b" sha1="e3316269b8466fe1fb968ac9338e6acdc0379970" />
 	</game>
 	<game name="Xingji Huohu (China) (v4) (iQue) (Manual)">
 		<description>Xingji Huohu (China) (v4) (iQue) (Manual)</description>
-		<release name="Xingji Huohu (China) (v4) (iQue) (Manual)" region="CHN"/>
-		<rom name="Xingji Huohu (China) (v4) (iQue) (Manual).z64" size="229376" crc="28cda0eb" md5="3dcd5e15aa35a73c68db4f56e2670fa2" sha1="12811f1b0f69cad88022bcf36f158865c8f89f32"/>
+		<rom name="Xingji Huohu (China) (v4) (iQue) (Manual).n64" />
+		<release name="Xingji Huohu (China) (v4) (iQue) (Manual)" region="CHN" />
+		<rom name="Xingji Huohu (China) (v4) (iQue) (Manual).z64" size="229376" crc="28cda0eb" md5="3dcd5e15aa35a73c68db4f56e2670fa2" sha1="12811f1b0f69cad88022bcf36f158865c8f89f32" />
 	</game>
 	<game name="Xplorer 64 (Germany) (v1.067) (Unl)">
 		<description>Xplorer 64 (Germany) (v1.067) (Unl)</description>
-		<release name="Xplorer 64 (Germany) (v1.067) (Unl)" region="GER"/>
-		<rom name="Xplorer 64 (Germany) (v1.067) (Unl).bin" size="262144" crc="656acdf5" md5="9137129a586e1bcab6ae81bac6b01275" sha1="3a13b42074c2b6948f55f22d3e4fe44fbf2cde6a"/>
+		<rom name="Xplorer 64 (Germany) (v1.067) (Unl).z64" />
+		<rom name="Xplorer 64 (Germany) (v1.067) (Unl).n64" />
+		<release name="Xplorer 64 (Germany) (v1.067) (Unl)" region="GER" />
+		<rom name="Xplorer 64 (Germany) (v1.067) (Unl).bin" size="262144" crc="656acdf5" md5="9137129a586e1bcab6ae81bac6b01275" sha1="3a13b42074c2b6948f55f22d3e4fe44fbf2cde6a" />
 	</game>
 	<game name="Yakouchuu II - Satsujin Kouro (Japan)">
 		<description>Yakouchuu II - Satsujin Kouro (Japan)</description>
-		<release name="Yakouchuu II - Satsujin Kouro (Japan)" region="JPN"/>
-		<rom name="Yakouchuu II - Satsujin Kouro (Japan).z64" size="33554432" crc="4538c41a" md5="e24942948f7140ee4260268db763d0fd" sha1="09929ca361d47fb9fc0eb4077cf1fb77cb843cef"/>
+		<rom name="Yakouchuu II - Satsujin Kouro (Japan).n64" />
+		<release name="Yakouchuu II - Satsujin Kouro (Japan)" region="JPN" />
+		<rom name="Yakouchuu II - Satsujin Kouro (Japan).z64" size="33554432" crc="4538c41a" md5="e24942948f7140ee4260268db763d0fd" sha1="09929ca361d47fb9fc0eb4077cf1fb77cb843cef" />
 	</game>
 	<game name="Yaoxi Gushi (China) (v6) (iQue) (Manual)">
 		<description>Yaoxi Gushi (China) (v6) (iQue) (Manual)</description>
-		<release name="Yaoxi Gushi (China) (v6) (iQue) (Manual)" region="CHN"/>
-		<rom name="Yaoxi Gushi (China) (v6) (iQue) (Manual).z64" size="425984" crc="5cef9b96" md5="85a90c61b65b56334e00950210c6cfc4" sha1="3f2d73aab7732d5448881df99d6f131c7354b6b8"/>
+		<rom name="Yaoxi Gushi (China) (v6) (iQue) (Manual).n64" />
+		<release name="Yaoxi Gushi (China) (v6) (iQue) (Manual)" region="CHN" />
+		<rom name="Yaoxi Gushi (China) (v6) (iQue) (Manual).z64" size="425984" crc="5cef9b96" md5="85a90c61b65b56334e00950210c6cfc4" sha1="3f2d73aab7732d5448881df99d6f131c7354b6b8" />
 	</game>
 	<game name="Yaoxi Gushi (China) (v2) (iQue) (Manual)" cloneof="Yaoxi Gushi (China) (v6) (iQue) (Manual)">
 		<description>Yaoxi Gushi (China) (v2) (iQue) (Manual)</description>
-		<rom name="Yaoxi Gushi (China) (v2) (iQue) (Manual).z64" size="196608" crc="4b5ae477" md5="df8164da753c9ef0b7c2611f584e81a9" sha1="9c9635ba9f35f01a55a92153987d831113d454d3"/>
+		<rom name="Yaoxi Gushi (China) (v2) (iQue) (Manual).n64" />
+		<rom name="Yaoxi Gushi (China) (v2) (iQue) (Manual).z64" size="196608" crc="4b5ae477" md5="df8164da753c9ef0b7c2611f584e81a9" sha1="9c9635ba9f35f01a55a92153987d831113d454d3" />
 	</game>
 	<game name="Yaoxi Gushi (China) (v4) (iQue) (Manual)" cloneof="Yaoxi Gushi (China) (v6) (iQue) (Manual)">
 		<description>Yaoxi Gushi (China) (v4) (iQue) (Manual)</description>
-		<rom name="Yaoxi Gushi (China) (v4) (iQue) (Manual).z64" size="245760" crc="5d76a1c1" md5="d6778d9d560dec35d8c05af4738e27aa" sha1="7eca70394a089f4058b67b1678e3f33c75fae738"/>
+		<rom name="Yaoxi Gushi (China) (v4) (iQue) (Manual).n64" />
+		<rom name="Yaoxi Gushi (China) (v4) (iQue) (Manual).z64" size="245760" crc="5d76a1c1" md5="d6778d9d560dec35d8c05af4738e27aa" sha1="7eca70394a089f4058b67b1678e3f33c75fae738" />
 	</game>
 	<game name="Yoshi's Story (Europe) (En,Fr,De)">
 		<description>Yoshi's Story (Europe) (En,Fr,De)</description>
-		<release name="Yoshi's Story (Europe) (En,Fr,De)" region="EUR"/>
-		<rom name="Yoshi's Story (Europe) (En,Fr,De).z64" size="16777216" crc="f9ffc760" md5="2524e5fb8ed4bb8c831c5ac057e8f344" sha1="5b56ec1da78456f968129baddc1f233e1fb4f4f3" status="verified"/>
+		<rom name="Yoshi's Story (Europe) (En,Fr,De).n64" />
+		<release name="Yoshi's Story (Europe) (En,Fr,De)" region="EUR" />
+		<rom name="Yoshi's Story (Europe) (En,Fr,De).z64" size="16777216" crc="f9ffc760" md5="2524e5fb8ed4bb8c831c5ac057e8f344" sha1="5b56ec1da78456f968129baddc1f233e1fb4f4f3" status="verified" />
 	</game>
 	<game name="Yaoxi Gushi (China) (iQue)" cloneof="Yoshi's Story (Europe) (En,Fr,De)">
 		<description>Yaoxi Gushi (China) (iQue)</description>
-		<rom name="Yaoxi Gushi (China) (iQue).z64" size="16023552" crc="9a579a29" md5="f7aa4f819f41cb4236792a8145684627" sha1="f04aabaca4d107f3ce35ed234698d30a79394431"/>
+		<rom name="Yaoxi Gushi (China) (iQue).n64" />
+		<rom name="Yaoxi Gushi (China) (iQue).z64" size="16023552" crc="9a579a29" md5="f7aa4f819f41cb4236792a8145684627" sha1="f04aabaca4d107f3ce35ed234698d30a79394431" />
 	</game>
 	<game name="Yoshi Story (Japan)" cloneof="Yoshi's Story (Europe) (En,Fr,De)">
 		<description>Yoshi Story (Japan)</description>
-		<release name="Yoshi Story (Japan)" region="JPN"/>
-		<rom name="Yoshi Story (Japan).z64" size="16777216" crc="4f44a9ef" md5="dd8a0e5472f13ea87b176f0155fa0c66" sha1="ff320b4122894c773f465a8996e82a00f3116e83" status="verified"/>
+		<rom name="Yoshi Story (Japan).n64" />
+		<release name="Yoshi Story (Japan)" region="JPN" />
+		<rom name="Yoshi Story (Japan).z64" size="16777216" crc="4f44a9ef" md5="dd8a0e5472f13ea87b176f0155fa0c66" sha1="ff320b4122894c773f465a8996e82a00f3116e83" status="verified" />
 	</game>
 	<game name="Yoshi's Story (USA) (En,Ja)" cloneof="Yoshi's Story (Europe) (En,Fr,De)">
 		<description>Yoshi's Story (USA) (En,Ja)</description>
-		<release name="Yoshi's Story (USA) (En,Ja)" region="USA"/>
-		<rom name="Yoshi's Story (USA) (En,Ja).z64" size="16777216" crc="a1453e0d" md5="586a092e22604840973b82dfaceac77a" sha1="b13072fef6c6df48c07d8822c01e5bc59036f6da" status="verified"/>
+		<rom name="Yoshi's Story (USA) (En,Ja).n64" />
+		<release name="Yoshi's Story (USA) (En,Ja)" region="USA" />
+		<rom name="Yoshi's Story (USA) (En,Ja).z64" size="16777216" crc="a1453e0d" md5="586a092e22604840973b82dfaceac77a" sha1="b13072fef6c6df48c07d8822c01e5bc59036f6da" status="verified" />
 	</game>
 	<game name="Yueye Motuo (China) (iQue) (Manual)">
 		<description>Yueye Motuo (China) (iQue) (Manual)</description>
-		<release name="Yueye Motuo (China) (iQue) (Manual)" region="CHN"/>
-		<rom name="Yueye Motuo (China) (iQue) (Manual).z64" size="262144" crc="3863dfe0" md5="876f87c91a4b6339daa8fc1f41eb7acd" sha1="312ee2f121983f148644d49a1f742dad3920f5d7"/>
+		<rom name="Yueye Motuo (China) (iQue) (Manual).n64" />
+		<release name="Yueye Motuo (China) (iQue) (Manual)" region="CHN" />
+		<rom name="Yueye Motuo (China) (iQue) (Manual).z64" size="262144" crc="3863dfe0" md5="876f87c91a4b6339daa8fc1f41eb7acd" sha1="312ee2f121983f148644d49a1f742dad3920f5d7" />
 	</game>
 	<game name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)">
 		<description>Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)</description>
-		<release name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)" region="CHN"/>
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual).z64" size="425984" crc="07e6c6e6" md5="912628118e67fea670ed2c63f7a7b003" sha1="5d50125c3f7c916f49e95806c651afb3ed4f74ad"/>
+		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual).n64" />
+		<release name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)" region="CHN" />
+		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual).z64" size="425984" crc="07e6c6e6" md5="912628118e67fea670ed2c63f7a7b003" sha1="5d50125c3f7c916f49e95806c651afb3ed4f74ad" />
 	</game>
 	<game name="Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual)" cloneof="Zelda Chuanshuo Shiguang Zhi Di (China) (v4) (iQue) (Manual)">
 		<description>Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual)</description>
-		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual).z64" size="278528" crc="f8d9250d" md5="9729a68f40f197d4d040fa641ff099e7" sha1="b5ed1ed47e0876bbc0eeb10f5ccc28cd31bed0fa"/>
+		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual).n64" />
+		<rom name="Zelda Chuanshuo Shiguang Zhi Di (China) (v2) (iQue) (Manual).z64" size="278528" crc="f8d9250d" md5="9729a68f40f197d4d040fa641ff099e7" sha1="b5ed1ed47e0876bbc0eeb10f5ccc28cd31bed0fa" />
 	</game>
 	<game name="Zhi Pian Mario (China) (v4) (iQue) (Manual)">
 		<description>Zhi Pian Mario (China) (v4) (iQue) (Manual)</description>
-		<release name="Zhi Pian Mario (China) (v4) (iQue) (Manual)" region="CHN"/>
-		<rom name="Zhi Pian Mario (China) (v4) (iQue) (Manual).z64" size="376832" crc="b370284f" md5="d9597922207298a87fa46878c017e6da" sha1="02a3eb14d2646ea7651f5ad9af58bf374f7bb023"/>
+		<rom name="Zhi Pian Mario (China) (v4) (iQue) (Manual).n64" />
+		<release name="Zhi Pian Mario (China) (v4) (iQue) (Manual)" region="CHN" />
+		<rom name="Zhi Pian Mario (China) (v4) (iQue) (Manual).z64" size="376832" crc="b370284f" md5="d9597922207298a87fa46878c017e6da" sha1="02a3eb14d2646ea7651f5ad9af58bf374f7bb023" />
 	</game>
 	<game name="Zhi Pian Mario (China) (v2) (iQue) (Manual)" cloneof="Zhi Pian Mario (China) (v4) (iQue) (Manual)">
 		<description>Zhi Pian Mario (China) (v2) (iQue) (Manual)</description>
-		<rom name="Zhi Pian Mario (China) (v2) (iQue) (Manual).z64" size="376832" crc="977e9a2f" md5="c4d652425aa4f2fc1d12564df01f8a04" sha1="5dc7d52a4545eeb9daddcae110a60e7e488d755a"/>
+		<rom name="Zhi Pian Mario (China) (v2) (iQue) (Manual).n64" />
+		<rom name="Zhi Pian Mario (China) (v2) (iQue) (Manual).z64" size="376832" crc="977e9a2f" md5="c4d652425aa4f2fc1d12564df01f8a04" sha1="5dc7d52a4545eeb9daddcae110a60e7e488d755a" />
 	</game>
 	<game name="Zool - Majuu Tsukai Densetsu (Japan)">
 		<description>Zool - Majuu Tsukai Densetsu (Japan)</description>
-		<release name="Zool - Majuu Tsukai Densetsu (Japan)" region="JPN"/>
-		<rom name="Zool - Majuu Tsukai Densetsu (Japan).z64" size="12582912" crc="756ba26d" md5="692a33b0d7456fc733a81ab83c20382b" sha1="2d6efdb155f6726478ad255e76220a95b559be40"/>
+		<rom name="Zool - Majuu Tsukai Densetsu (Japan).n64" />
+		<release name="Zool - Majuu Tsukai Densetsu (Japan)" region="JPN" />
+		<rom name="Zool - Majuu Tsukai Densetsu (Japan).z64" size="12582912" crc="756ba26d" md5="692a33b0d7456fc733a81ab83c20382b" sha1="2d6efdb155f6726478ad255e76220a95b559be40" />
 	</game>
 	<game name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual)">
 		<description>Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual)</description>
-		<release name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual)" region="CHN"/>
-		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual).z64" size="245760" crc="f336cc75" md5="9abb0f6f79e01fc9a942d6027719c3e4" sha1="0ac28c05e402820d6b65722a813f8bdb25db890c"/>
+		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual).n64" />
+		<release name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual)" region="CHN" />
+		<rom name="Zui Yu Fa Diqiu De Jicheng Zhe (China) (iQue) (Manual).z64" size="245760" crc="f336cc75" md5="9abb0f6f79e01fc9a942d6027719c3e4" sha1="0ac28c05e402820d6b65722a813f8bdb25db890c" />
 	</game>
 </datafile>

--- a/Sony - PlayStation pbp tool.py
+++ b/Sony - PlayStation pbp tool.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""
+Module Docstring
+"""
+
+__author__ = "Stephen Ancona"
+__version__ = "0.1.0"
+__license__ = "MIT"
+
+
+import xml.etree.ElementTree as ET
+
+header = '<?xml version="1.0"?>\n<!DOCTYPE datafile PUBLIC "-//Logiqx//DTD ROM Management Datafile//EN" "http://www.logiqx.com/Dats/datafile.dtd">\n'
+
+
+def main():
+    """ Main entry point of the app """
+    try:
+        tree = ET.parse("Sony - PlayStation.dat")
+    except:
+        print("Error opening Sony - PlayStation.dat")
+        exit(1)
+    root = tree.getroot()
+    for child in root:
+        if child.tag == "header":
+            for sub in child:
+                if sub.tag == "version":
+                    sub.text = sub.text + " Ludo Custom"
+                if sub.tag == "author":
+                    sub.text = "Ludo PlayStation Customizer"
+        if child.tag == "game":
+            if "(Disc" in child.attrib["name"]:
+                if "(Disc 1)" in child.attrib["name"]:
+                    updated_name = child.attrib["name"].replace(" (Disc 1)", "")
+                    new_element = ET.SubElement(root, "game")
+                    new_element.set("name", updated_name)
+                    ET.SubElement(new_element, "category")
+                    new_element[0].text = "Games"
+                    ET.SubElement(new_element, "description")
+                    new_element[1].text = updated_name
+                    ET.SubElement(new_element, "rom")
+                    new_element[2].set("name", updated_name + ".pbp")
+                    # I'll add these two lines back when I figure out how to get ludo detecting m3u files.
+                    ET.SubElement(new_element, "rom")
+                    new_element[3].set("name", updated_name + ".m3u")
+                else:
+                    pass
+            else:
+                if ".pbp" not in child[2].attrib["name"]:
+                    original_name = child[2].attrib["name"]
+                    updated_name = original_name.split(".")
+                    updated_name.pop()
+                    updated_name.append("pbp")
+                    updated_name = ".".join(updated_name)
+                    new_element = ET.Element("rom")
+                    new_element.set("name", updated_name)
+                    child.insert(2,new_element)
+    ET.indent(tree, "\t")
+    tree.write("Sony - PlayStation.dat")
+    with open("Sony - PlayStation.dat") as file_raw:
+        file_dat = file_raw.read()
+    file_dat = header + file_dat
+    with open("Sony - PlayStation.dat", "w") as file_raw:
+        file_raw.write(file_dat)
+
+
+if __name__ == "__main__":
+    """ This is executed when run from the command line """
+    main()


### PR DESCRIPTION
This pull request does two things.

1. It adds `.pbp` rom tags to all single disc games in the `Sony - PlayStation.dat` file
2. It adds new single item game tag for all multi disc games in the `Sony - PlayStation.dat` file

For example, a single disc game would be updated as follows:

```xml
	<game name="Ace Combat 3 - Electrosphere (Europe) (En,Fr,De,Es,It)">
		<category>Games</category>
		<description>Ace Combat 3 - Electrosphere (Europe) (En,Fr,De,Es,It)</description>
		<rom name="Ace Combat 3 - Electrosphere (Europe) (En,Fr,De,Es,It).pbp" />
		<rom name="Ace Combat 3 - Electrosphere (Europe) (En,Fr,De,Es,It).cue" size="120" crc="92b3ff37" md5="56125070a7f679f547133512543a3585" sha1="5cc0e2d25792ae13ec7dab7b2ee8974c700c3337" />
		<rom name="Ace Combat 3 - Electrosphere (Europe) (En,Fr,De,Es,It).bin" size="470999760" crc="91cad2df" md5="24c2f5a5e43e4bc4c41081f5ef4dc818" sha1="8c215d983ad7d7f5f8aa122981cbd79d846532ec" />
	</game>
```

While a two disc game would have a new game entry added to the list as follows:

```xml
	<game name="Chrono Cross (USA)">
		<category>Games</category>
		<description>Chrono Cross (USA)</description>
		<rom name="Chrono Cross (USA).pbp" />
	</game>
```

These new entries do not contain any fields other than `name` for a few reasons.

* There is no equivalent to redump for `.pbp` files
* Collectors tools for generating `.pbp` files allow you to specify level of compression or store art assets, both of which will change the checksum values

I do have a version of this that add includes `.m3u` files in multi disc entries, but I have yet to get that working with the scanner in ludo.